### PR TITLE
G1 inbox: format label + hide wishes + hard-filter (clean, 3 fixes only)

### DIFF
--- a/src/data/supabase/queries.test.ts
+++ b/src/data/supabase/queries.test.ts
@@ -12,6 +12,7 @@ vi.mock("@supabase/supabase-js", () => ({
 }));
 
 import {
+  formatRequestPreference,
   getActiveListings,
   getDestinationBySlug,
   getDestinations,
@@ -21,6 +22,7 @@ import {
   getGuides,
   getGuidesByDestination,
   getHomepageRequests,
+  mapRequestRow,
   getOffersForRequest,
   getOpenRequests,
   getListingReviews,
@@ -183,6 +185,33 @@ describe("public Supabase query helpers", () => {
 });
 
 describe("PII-safe Supabase query mapping", () => {
+  it.each([
+    { value: "group", expected: "Сборная" },
+    { value: "private", expected: "Своя" },
+    { value: "combo", expected: "combo" },
+  ])("formats request preference $value as $expected", ({ value, expected }) => {
+    expect(formatRequestPreference(value)).toBe(expected);
+  });
+
+  it.each([
+    { formatPreference: "group", expected: "Сборная" },
+    { formatPreference: "private", expected: "Своя" },
+    { formatPreference: null, expected: "" },
+    { formatPreference: "combo", expected: "combo" },
+  ])("maps format_preference $formatPreference to $expected", ({ formatPreference, expected }) => {
+    const row: Record<string, unknown> = {
+      id: "request-1",
+      destination: "Москва",
+      budget_minor: null,
+      participants_count: 2,
+      status: "open",
+      created_at: "2026-06-03T00:00:00Z",
+      format_preference: formatPreference,
+    };
+
+    expect(mapRequestRow(row).format).toBe(expected);
+  });
+
   it("uses anonymous requester and member display data in open request lists", async () => {
     const client = createFakeClient({
       traveler_requests: [

--- a/src/data/supabase/queries.ts
+++ b/src/data/supabase/queries.ts
@@ -313,7 +313,7 @@ function getNotesPlainText(notes: string | null | undefined): string | null {
   }
 }
 
-function formatCategory(cat: string): string {
+export function formatCategory(cat: string): string {
   switch (cat) {
     case "city": return "Городская экскурсия";
     case "nature": return "Природный маршрут";
@@ -322,6 +322,14 @@ function formatCategory(cat: string): string {
     case "adventure": return "Активный отдых";
     case "relax": return "Отдых";
     default: return cat;
+  }
+}
+
+export function formatRequestPreference(value: string): string {
+  switch (value) {
+    case "group": return "Сборная";
+    case "private": return "Своя";
+    default: return value;
   }
 }
 
@@ -391,7 +399,7 @@ export function mapRequestRow(
       ? (row.interests as string[]).filter((s) => (VALID_INTEREST_SLUGS as readonly string[]).includes(s))
       : [],
     mode: (row.open_to_join as boolean) === true ? "assembly" : "private",
-    format: formatCategory((row.format_preference as string) ?? ""),
+    format: formatRequestPreference((row.format_preference as string | null | undefined) ?? ""),
     status: (row.status as RequestRecord["status"]) ?? "open",
     createdAt: (row.created_at as string) ?? "",
     offerCount: 0,

--- a/src/features/guide/components/requests/guide-requests-inbox-filter.ts
+++ b/src/features/guide/components/requests/guide-requests-inbox-filter.ts
@@ -71,15 +71,12 @@ export function filterInbox(
     filtered = [...filtered].sort((a, b) => b.groupSize - a.groupSize);
   }
 
-  // Plan 50 T3 — soft sort: matched first, unmatched second; in-tier order preserved
+  // Hard filter: show only requests whose topics match the guide's specializations.
+  // Guarded so guides with no specializations still see all open requests.
   if (specializations.length > 0) {
-    const matched = filtered.filter((r: RequestRecord) =>
-      isMatchedRequest(r, specializations),
+    filtered = filtered.filter((item: RequestRecord) =>
+      isMatchedRequest(item, specializations),
     );
-    const unmatched = filtered.filter(
-      (r: RequestRecord) => !isMatchedRequest(r, specializations),
-    );
-    filtered = [...matched, ...unmatched];
   }
 
   return filtered;

--- a/src/features/guide/components/requests/guide-requests-inbox-screen.test.tsx
+++ b/src/features/guide/components/requests/guide-requests-inbox-screen.test.tsx
@@ -207,7 +207,7 @@ describe("GuideRequestsInboxScreen meta layout", () => {
       ),
       "utf8",
     );
-    const metaBlock = source.match(/\{\/\* Meta \*\/\}([\s\S]*?)\{item\.description/)?.[1];
+    const metaBlock = source.match(/\{\/\* Meta \*\/\}([\s\S]*?)\{\/\* Actions \*\/\}/)?.[1];
 
     expect(metaBlock).toContain(
       'className="mt-3 space-y-1 text-xs text-muted-foreground"',

--- a/src/features/guide/components/requests/guide-requests-inbox-screen.tsx
+++ b/src/features/guide/components/requests/guide-requests-inbox-screen.tsx
@@ -352,11 +352,6 @@ export function GuideRequestsInboxScreen() {
                           </p>
                         </div>
 
-                        {item.description ? (
-                          <p className="mt-3 line-clamp-2 text-sm text-muted-foreground">
-                            {item.description}
-                          </p>
-                        ) : null}
 
                         {/* Actions */}
                         <div className="mt-4 flex flex-wrap items-center gap-3">


### PR DESCRIPTION
Re-applies the 3 stranded G1 fixes cleanly on top of restored main. Net diff vs 852df22 = 5 files only. Sort (compareStartDates) intentionally excluded — paused pending review. Gates: bun check OK, 683/683 tests pass.