### PR TITLE
fix(traveler): published-at alignment under destination

### DIFF
--- a/src/features/traveler/components/requests/traveler-request-detail-screen.tsx
+++ b/src/features/traveler/components/requests/traveler-request-detail-screen.tsx
@@ -94,9 +94,12 @@ export function TravelerRequestDetailScreen({ record }: Props) {
 
       <div className="space-y-3 rounded-lg border bg-card p-4">
         <div className="flex items-start justify-between gap-3">
-          <h1 className="text-3xl font-semibold text-foreground">
-            {request.destination}
-          </h1>
+          <div>
+            <h1 className="text-3xl font-semibold text-foreground">
+              {request.destination}
+            </h1>
+            <p className="text-xs text-muted-foreground mt-1">{publishedAt}</p>
+          </div>
           <CancelRequestButton requestId={record.id} status={record.status} />
         </div>
 
@@ -142,8 +145,6 @@ export function TravelerRequestDetailScreen({ record }: Props) {
             </Badge>
           )}
         </div>
-
-        <p className="text-xs text-muted-foreground">{publishedAt}</p>
 
         {interests.length > 0 ? (
           <div className="flex flex-wrap gap-2">


### PR DESCRIPTION
## Summary
- Moves 'Опубликован...' text directly under the destination heading (Тбилиси), above the badges
- Removes orphaned placement below badge row

## Test plan
- [x] typecheck ✓
- [x] 688/688 tests passing
- [x] lint ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)