### PR TITLE
feat(offer-card): guide response timestamp + reject offer button

### DIFF
--- a/src/app/(protected)/traveler/requests/[requestId]/actions.ts
+++ b/src/app/(protected)/traveler/requests/[requestId]/actions.ts
@@ -2,6 +2,7 @@
 
 import { z } from "zod";
 import { redirect } from "next/navigation";
+import { revalidatePath } from "next/cache";
 
 import { notifyBookingCreated } from "@/lib/notifications/triggers";
 import { getOrCreateThread } from "@/lib/supabase/conversations";
@@ -149,6 +150,79 @@ export async function acceptOfferAction(
   redirect(
     `/traveler/requests/${requestId}/accepted?booking_id=${booking.id}&guide_id=${guideId}`,
   );
+}
+
+export type RejectOfferActionState = { error: string | null };
+
+export async function rejectOfferAction(
+  _prev: RejectOfferActionState,
+  formData: FormData,
+): Promise<RejectOfferActionState> {
+  const offerId = formData.get("offer_id") as string | null;
+  const requestId = formData.get("request_id") as string | null;
+
+  if (!offerId || !requestId) {
+    return { error: "Недостаточно данных для отклонения предложения." };
+  }
+
+  const supabase = await createSupabaseServerClient();
+
+  const {
+    data: { user },
+    error: authError,
+  } = await supabase.auth.getUser();
+
+  if (authError || !user) {
+    return { error: "Необходима авторизация." };
+  }
+
+  const { data: requestRow, error: reqError } = await supabase
+    .from("traveler_requests")
+    .select("id, traveler_id, status")
+    .eq("id", requestId)
+    .maybeSingle();
+
+  if (reqError || !requestRow) {
+    return { error: "Запрос не найден." };
+  }
+
+  if (requestRow.traveler_id !== user.id) {
+    return { error: "Вы не являетесь владельцем этого запроса." };
+  }
+
+  if (requestRow.status !== "open") {
+    return { error: "Запрос уже не открыт." };
+  }
+
+  const { data: offerRow, error: offerError } = await supabase
+    .from("guide_offers")
+    .select("id, request_id, status")
+    .eq("id", offerId)
+    .maybeSingle();
+
+  if (offerError || !offerRow) {
+    return { error: "Предложение не найдено." };
+  }
+
+  if (offerRow.request_id !== requestId) {
+    return { error: "Предложение не относится к этому запросу." };
+  }
+
+  if (offerRow.status !== "pending") {
+    return { error: "Предложение уже не активно." };
+  }
+
+  const { error: updateError } = await supabase
+    .from("guide_offers")
+    .update({ status: "declined" })
+    .eq("id", offerId);
+
+  if (updateError) {
+    return { error: "Не удалось отклонить предложение." };
+  }
+
+  revalidatePath(`/traveler/requests/${requestId}`);
+  return { error: null };
 }
 
 export async function openOfferThreadAction(formData: FormData) {

--- a/src/features/traveler/components/requests/offer-card.tsx
+++ b/src/features/traveler/components/requests/offer-card.tsx
@@ -14,6 +14,7 @@ import type { GuideOfferRow } from "@/lib/supabase/types";
 import type { QaThread } from "@/lib/supabase/qa-threads";
 
 import { AcceptOfferButton } from "./accept-offer-button";
+import { RejectOfferButton } from "./reject-offer-button";
 import { OfferQaSheet } from "./offer-qa-sheet";
 
 interface GuideInfo {
@@ -296,12 +297,15 @@ export function OfferCard({
       {/* Actions */}
       <div className="flex flex-wrap gap-2">
         {canAccept ? (
-          <AcceptOfferButton
-            offerId={offer.id}
-            requestId={requestId}
-            guideId={offer.guide_id}
-            priceMinor={offer.price_minor}
-          />
+          <>
+            <AcceptOfferButton
+              offerId={offer.id}
+              requestId={requestId}
+              guideId={offer.guide_id}
+              priceMinor={offer.price_minor}
+            />
+            <RejectOfferButton offerId={offer.id} requestId={requestId} />
+          </>
         ) : null}
 
         <OfferQaSheet

--- a/src/features/traveler/components/requests/offer-card.tsx
+++ b/src/features/traveler/components/requests/offer-card.tsx
@@ -65,6 +65,14 @@ function formatDateRu(iso: string | null | undefined): string {
   return d.toLocaleDateString("ru-RU", { day: "numeric", month: "long" });
 }
 
+function formatOfferDate(iso: string): string {
+  const d = new Date(iso);
+  if (Number.isNaN(d.getTime())) return "";
+  const date = d.toLocaleDateString("ru-RU", { day: "numeric", month: "long" });
+  const time = d.toLocaleTimeString("ru-RU", { hour: "2-digit", minute: "2-digit" });
+  return `Ответил ${date}, ${time}`;
+}
+
 function formatTime(iso: string | null | undefined): string {
   if (!iso) return "—";
   const d = new Date(iso);
@@ -177,10 +185,11 @@ export function OfferCard({
         </Avatar>
         <div className="min-w-0 flex-1">
           <p className="truncate font-medium">{guideName}</p>
+          <p className="text-xs text-muted-foreground">{formatOfferDate(offer.created_at)}</p>
         </div>
-        <Badge variant={offer.status === "accepted" ? "default" : "outline"}>
-          {offer.status === "accepted" ? "Принято" : "Ожидает"}
-        </Badge>
+        {offer.status === "accepted" ? (
+          <Badge variant="default">Принято</Badge>
+        ) : null}
       </div>
 
       {isCounterOffer ? (

--- a/src/features/traveler/components/requests/reject-offer-button.tsx
+++ b/src/features/traveler/components/requests/reject-offer-button.tsx
@@ -1,0 +1,33 @@
+"use client";
+
+import { useActionState } from "react";
+
+import {
+  rejectOfferAction,
+  type RejectOfferActionState,
+} from "@/app/(protected)/traveler/requests/[requestId]/actions";
+import { Button } from "@/components/ui/button";
+
+const initialState: RejectOfferActionState = { error: null };
+
+interface RejectOfferButtonProps {
+  offerId: string;
+  requestId: string;
+}
+
+export function RejectOfferButton({ offerId, requestId }: RejectOfferButtonProps) {
+  const [state, formAction, isPending] = useActionState(rejectOfferAction, initialState);
+
+  return (
+    <form action={formAction}>
+      <input type="hidden" name="offer_id" value={offerId} />
+      <input type="hidden" name="request_id" value={requestId} />
+      {state.error ? (
+        <p className="mb-2 font-sans text-[0.8125rem] text-destructive">{state.error}</p>
+      ) : null}
+      <Button type="submit" variant="outline" disabled={isPending}>
+        {isPending ? "Обработка…" : "Отклонить"}
+      </Button>
+    </form>
+  );
+}


### PR DESCRIPTION
Two reviewed commits from the dev tree: e7a1dc9 (guide response timestamp, remove redundant pending badge), d8f5361 (reject offer button for traveler with ownership+status validation). Gates green: typecheck, lint, 722+ tests.