### PR TITLE
fix(rls): Q&A thread creation + fixed-cred QA seeding

### DIFF
--- a/scripts/seed-test-users.mjs
+++ b/scripts/seed-test-users.mjs
@@ -12,9 +12,14 @@ const env = Object.fromEntries(
     .map(l => { const i = l.indexOf('='); return [l.slice(0, i).trim(), l.slice(i + 1).replace(/^"|"$/g, '').trim()]; })
 );
 
-const url = env.PROVODNIK_SUPABASE_URL;
-const key = env.PROVODNIK_SUPABASE_SECRET_KEY;
-if (!url || !key) { console.error('missing PROVODNIK_SUPABASE_URL / PROVODNIK_SUPABASE_SECRET_KEY'); process.exit(2); }
+const url = env.PROVODNIK_SUPABASE_URL ?? env.NEXT_PUBLIC_SUPABASE_URL;
+const key = env.PROVODNIK_SUPABASE_SECRET_KEY ?? env.SUPABASE_SECRET_KEY;
+if (!url || !key) { console.error('missing PROVODNIK_SUPABASE_URL / PROVODNIK_SUPABASE_SECRET_KEY (or NEXT_PUBLIC_SUPABASE_URL / SUPABASE_SECRET_KEY)'); process.exit(2); }
+
+// Fixed-credential mode for e2e: QA_SEED_PASSWORD (process env or env-file) pins all QA
+// account passwords so playwright fixtures can log in across runs. Without it each run
+// generated a random password — which is what kept the e2e suite permanently skipped.
+const fixedPassword = process.env.QA_SEED_PASSWORD ?? env.QA_SEED_PASSWORD ?? null;
 
 const supa = createClient(url, key, { auth: { autoRefreshToken: false, persistSession: false } });
 
@@ -32,7 +37,7 @@ async function findUserByEmail(email) {
 
 const results = [];
 for (const acct of accounts) {
-  const password = randomBytes(18).toString('base64url');
+  const password = fixedPassword ?? randomBytes(18).toString('base64url');
   const existing = await findUserByEmail(acct.email);
   let userId;
   if (existing) {

--- a/supabase/migrations/20260612000001_conversation_threads_select_creator.sql
+++ b/supabase/migrations/20260612000001_conversation_threads_select_creator.sql
@@ -1,0 +1,14 @@
+-- Q&A threads could never be created: INSERT ... RETURNING (postgrest .insert().select())
+-- applies the SELECT policy to the just-inserted row, and can_access_conversation_thread()
+-- queries conversation_threads ITSELF — the new row is not visible in the function's
+-- snapshot yet, so the policy evaluated false and every thread creation failed with 42501.
+-- Fix: give the creator a direct column-predicate leg that evaluates against the NEW row
+-- without a self-referencing subquery. (Creator visibility was already the function's
+-- intent — ct.created_by = uid — it just couldn't see the row during RETURNING.)
+drop policy if exists conversation_threads_select on public.conversation_threads;
+create policy conversation_threads_select on public.conversation_threads
+  for select
+  using (
+    (created_by = (select auth.uid()))
+    or public.can_access_conversation_thread(id, (select auth.uid()))
+  );


### PR DESCRIPTION
Root cause: INSERT...RETURNING applies the SELECT policy to the new row; can_access_conversation_thread() queries conversation_threads itself, so the just-inserted row was invisible in the function snapshot — every thread creation failed with 42501 (zero threads ever created in prod). Fix: direct created_by predicate leg. Migration already applied to live DB via mgmt API + ledger repaired; verified live: traveler creates thread + sends, guide replies, traveler reads. Also: seed-test-users.mjs supports QA_SEED_PASSWORD (env) for stable e2e creds.