### PR TITLE
test(e2e): tripster suite alive — hydration-safe login, env-aware config

### DIFF
--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -5,8 +5,9 @@ const baseURL = process.env.E2E_BASE_URL ?? "http://localhost:3000";
 
 export default defineConfig({
   testDir: "./tests/e2e",
-  timeout: 30000,
-  retries: 0,
+  // Remote dev target compiles routes on demand — first hits can take >30s.
+  timeout: process.env.E2E_BASE_URL ? 90_000 : 30_000,
+  retries: process.env.E2E_BASE_URL ? 1 : 0,
   workers: 1,
   reporter: "list",
   use: {

--- a/tests/e2e/helpers.ts
+++ b/tests/e2e/helpers.ts
@@ -1,13 +1,21 @@
-import type { Page } from "@playwright/test";
+import { expect, type Page } from "@playwright/test";
 
 export async function loginAs(page: Page, email: string, password: string) {
   await page.goto("/auth");
-  await page.fill("#email", email);
-  await page.fill("#password", password);
-  await page.click('[type="submit"]');
+  // Hydration replaces the server-rendered form with empty React state — values typed
+  // too early are wiped and the submit button stays disabled. The reliable signal is the
+  // button itself: refill until React state catches up and enables it. (networkidle is
+  // useless here — the dev server's HMR websocket keeps the network permanently busy.)
+  const submit = page.locator('button[type="submit"]');
+  await expect(async () => {
+    await page.fill("#email", email);
+    await page.fill("#password", password);
+    await expect(submit).toBeEnabled({ timeout: 2_000 });
+  }).toPass({ timeout: 45_000 });
+  await submit.click();
   // Wait for redirect away from /auth
   await page.waitForFunction(
     () => !window.location.pathname.startsWith("/auth"),
-    { timeout: 10000 }
+    { timeout: 30_000 },
   );
 }

--- a/tests/e2e/tripster-v1/01-create-listing.spec.ts
+++ b/tests/e2e/tripster-v1/01-create-listing.spec.ts
@@ -1,5 +1,6 @@
 import { test } from "@playwright/test";
 import { E2E_READY, SEED_USERS } from "../fixtures";
+import { loginAs } from "../helpers";
 
 // SKIPPED — see ERR-059 in .claude/sot/ERRORS.md and docs/qa/2026-05-10-e2e-spec-rot-fix.md.
 // Spec hard-codes guide1@provodnik.test / testpass123 but seed creates guide@provodnik.test
@@ -8,11 +9,9 @@ import { E2E_READY, SEED_USERS } from "../fixtures";
 test("guide creates an excursion listing", async ({ page }) => {
   test.skip(!E2E_READY, "QA_SEED_PASSWORD not set");
 
-  await page.goto("/auth");
-  await page.fill("#email", SEED_USERS.guide.email);
-  await page.fill("#password", SEED_USERS.guide.password);
-  await page.click('[type="submit"]');
-  await page.waitForURL("/guide/dashboard");
+  // Login via the shared helper — the app redirects guides to /guide (the old
+  // /guide/dashboard wait predates the route-group refactor and never resolves).
+  await loginAs(page, SEED_USERS.guide.email, SEED_USERS.guide.password);
 
   await page.goto("/guide/listings/new");
   // If FEATURE_TRIPSTER_V1 is on, should show type picker


### PR DESCRIPTION
Suite green against dev.provodnik.app (exit 0): full booking-confirm and dispute flows executed; remaining skips are legitimate E2E_READY/state guards. Login helper retries fills until React hydration enables the submit button; 01 stale /guide/dashboard wait replaced with shared helper; remote runs get 90s budget + 1 retry (dev compile latency).