### PR TITLE
feat(assembly-open-ignore-capacity): Для сборной группы `openToMoreMembers` всегда true, независи

### DIFF
--- a/src/app/(site)/requests/[requestId]/page.tsx
+++ b/src/app/(site)/requests/[requestId]/page.tsx
@@ -43,9 +43,7 @@ function mapToOpenRequestRecord(request: RequestRecord): OpenRequestRecord {
     group: {
       sizeTarget: request.capacity ?? request.groupSize,
       sizeCurrent: request.groupSize,
-      openToMoreMembers: request.capacity != null
-        ? request.groupSize < request.capacity
-        : request.mode === "assembly",
+      openToMoreMembers: request.mode === "assembly",
     },
     destinationLabel: request.destination,
     imageUrl: request.imageUrl,


### PR DESCRIPTION
Automated single-merger integration.