### PR TITLE
revert(request-form): undo E-19 #5 (assembly-default + column swap) — premature/unapproved to prod

### DIFF
--- a/src/features/homepage-classic/components/homepage-request-form-classic.tsx
+++ b/src/features/homepage-classic/components/homepage-request-form-classic.tsx
@@ -139,9 +139,21 @@ export function HomepageRequestFormClassic({ destinations }: Props) {
         </div>
       </div>
 
-      {/* 4. Сборная группа + Сколько вас */}
+      {/* 4. Сколько вас + Сборная группа */}
       <div className="grid gap-3">
         <div className="grid grid-cols-2 items-start gap-2">
+          <div className="grid gap-2">
+            <FieldLabel htmlFor="groupSize">Сколько вас</FieldLabel>
+            <Input
+              id="groupSize"
+              type="text"
+              inputMode="numeric"
+              placeholder="2"
+              aria-invalid={Boolean(errors.groupSize)}
+              {...register("groupSize", { valueAsNumber: true })}
+            />
+            <FieldError id="groupSize-error" message={errors.groupSize?.message} />
+          </div>
           <div className="grid gap-2">
             <FieldLabel>Сборная группа</FieldLabel>
             <button
@@ -162,18 +174,6 @@ export function HomepageRequestFormClassic({ destinations }: Props) {
             >
               {isAssembly ? "Сборная" : "Своя"}
             </button>
-          </div>
-          <div className="grid gap-2">
-            <FieldLabel htmlFor="groupSize">Сколько вас</FieldLabel>
-            <Input
-              id="groupSize"
-              type="text"
-              inputMode="numeric"
-              placeholder="2"
-              aria-invalid={Boolean(errors.groupSize)}
-              {...register("groupSize", { valueAsNumber: true })}
-            />
-            <FieldError id="groupSize-error" message={errors.groupSize?.message} />
           </div>
         </div>
 

--- a/src/features/homepage-classic/components/homepage-request-form.test.tsx
+++ b/src/features/homepage-classic/components/homepage-request-form.test.tsx
@@ -277,9 +277,9 @@ describe("HomepageRequestForm UI affordances", () => {
     const assemblyButton = getAssemblyButton();
     expect(assemblyButton).toHaveClass("cursor-pointer");
     expect(assemblyButton).not.toHaveAttribute("title");
-    expect(assemblyButton).toHaveClass("border-sky-200", "bg-sky-100");
+    expect(assemblyButton).toHaveClass("border-purple-200", "bg-purple-100");
     fireEvent.click(assemblyButton);
-    expect(assemblyButton).toHaveClass("border-purple-200", "text-purple-700");
+    expect(assemblyButton).toHaveClass("border-sky-200", "text-sky-700");
   });
 
   it("renders topic chips as horizontal icon and label rows", () => {

--- a/src/features/homepage-classic/components/homepage-request-form.tsx
+++ b/src/features/homepage-classic/components/homepage-request-form.tsx
@@ -139,10 +139,24 @@ export function HomepageRequestForm({ destinations }: Props) {
         </div>
       </div>
 
-      {/* 4. Сборная группа + Сколько вас */}
+      {/* 4. Сколько вас + Сборная группа */}
       <div className="grid gap-3">
         <div className="grid grid-cols-2 items-start gap-2">
-          {/* Left: Сборная группа labeled toggle */}
+          {/* Left: groupSize */}
+          <div className="grid gap-2">
+            <FieldLabel htmlFor="groupSize">Сколько вас</FieldLabel>
+            <Input
+              id="groupSize"
+              type="text"
+              inputMode="numeric"
+              placeholder="2"
+              aria-invalid={Boolean(errors.groupSize)}
+              {...register("groupSize", { valueAsNumber: true })}
+            />
+            <FieldError id="groupSize-error" message={errors.groupSize?.message} />
+          </div>
+
+          {/* Right: Сборная группа labeled toggle */}
           <div className="grid gap-2">
             <FieldLabel>Сборная группа</FieldLabel>
             <button
@@ -163,20 +177,6 @@ export function HomepageRequestForm({ destinations }: Props) {
             >
               {isAssembly ? "Сборная" : "Своя"}
             </button>
-          </div>
-
-          {/* Right: groupSize */}
-          <div className="grid gap-2">
-            <FieldLabel htmlFor="groupSize">Сколько вас</FieldLabel>
-            <Input
-              id="groupSize"
-              type="text"
-              inputMode="numeric"
-              placeholder="2"
-              aria-invalid={Boolean(errors.groupSize)}
-              {...register("groupSize", { valueAsNumber: true })}
-            />
-            <FieldError id="groupSize-error" message={errors.groupSize?.message} />
           </div>
         </div>
 

--- a/src/features/homepage-classic/components/use-request-form.ts
+++ b/src/features/homepage-classic/components/use-request-form.ts
@@ -25,7 +25,7 @@ export function useRequestForm() {
   const form = useForm<FormInput, unknown, FormValues>({
     resolver: zodResolver(travelerRequestSchema),
     defaultValues: {
-      mode: "assembly",
+      mode: "private",
       interests: [] as TravelerRequest["interests"],
       requestedLanguages: ["Русский"],
       destination: process.env.NEXT_PUBLIC_PHASE_A_CITY ?? "Москва",


### PR DESCRIPTION
Reverts 1adab58c. E-19 #5 was a queued, not-yet-fired task that an autonomous run executed out-of-band and rode into prod. Restores form to private default + Сколько вас left. Isolated to 4 form files; no overlap with badge/join-button/mapper fixes. Gates green: tsc, 28 tests, next build.