### PR TITLE
feat(request-detail): redesign сборная join page (mockup) + cursor rules

### DIFF
--- a/.cursor/REDESIGN-TASK.md
+++ b/.cursor/REDESIGN-TASK.md
@@ -1,0 +1,43 @@
+# TASK: Redesign the public request detail page to match the mockup (Сборная join page)
+
+## Read FIRST, in order
+1. `.cursor/rules/12-product-canon.mdc` — product canon (3 models; сборная has NO max/min). INVIOLABLE.
+2. `.cursor/rules/27-request-detail-page.mdc` — this page's structure, content, delete list, guards.
+3. `.cursor/mockups/request-detail.html` — the VISUAL CONTRACT. Your output must match its structure, hierarchy, blocks, and on-brand styling.
+4. `.cursor/rules/01-context7-docs.mdc` — verify every Next.js 16 / React 19 / Tailwind v4 / shadcn API against context7 before writing. Do not guess.
+5. `.cursor/rules/15-ui-ux-pro-max.mdc` — run the in-repo design-system search and follow the UI/UX skill.
+
+## Goal
+Rewrite the public request detail page so it matches the mockup exactly in structure and is faithful to provodnik's brand (Rubik, green #1F7A5C, cream #F7FAF6, shadcn tokens). The page serves ONE goal: convince a traveler to JOIN a сборная group. Public = сборная-only.
+
+## Scope — edit ONLY these (≤6 files)
+- `src/features/requests/components/public/public-request-detail-screen.tsx` — full rewrite to the mockup's blocks + sticky card + mobile bottom bar.
+- `src/app/(site)/requests/[requestId]/page.tsx` — server component: build a mode-aware VIEW-MODEL; `notFound()` for non-assembly/private requests; use `cityImage(destination)` for the hero.
+- `src/app/(site)/requests/page.tsx` — catalog: list ONLY сборная (open_to_join) requests.
+- `src/data/open-requests/types.ts` — extend `OpenRequestRecord` only with fields the view-model needs (organizerName, themes, regionLabel, cityImageUrl) if missing.
+- `src/lib/city-image.ts` — NEW small helper `cityImage(destination: string): string` returning a DETERMINISTIC online placeholder image URL per city. Add `// TODO: replace with curated per-city CDN`.
+- sibling test files for the above.
+
+## View-model (server → screen) — exactly the fields the mockup needs
+`{ title, regionLabel, cityImageUrl, dateLabel, timeLabel, datesFlexible, pricePerPersonRub, memberCount, members[], organizerName, themes[], notes, joinState }`
+`joinState ∈ 'anon' | 'can-join' | 'member' | 'owner' | 'closed'` — derived from viewer + status.
+
+## Structure to build (match mockup, nothing extra)
+hero(city image + «Сборная группа» badge + title ONCE + region) → meta chips(дата·время·Гибкие даты, lucide, hide flex if not flexible) → Кто едет(count + avatars + organizer + "группа открыта") → О поездке(theme chips + notes, hide if empty) → Как это работает(3 steps) → sticky decision card(price + добор line + ONE state-aware CTA + "гиды уже видят") → Частые вопросы(collapsed). Mobile: single column + fixed bottom bar(price + CTA).
+
+## DELETE (must be gone)
+buildPriceScenarios + «Стоимость на человека» table; "X из Y мест занято" + Progress fill; "О маршруте" + "Что запланировано"; "Формат" field; hardcoded Unsplash mountain fallback; hardcoded "Сборная группа" hero string (derive from data); duplicate destination.
+
+## CTA states
+anon → «Войти и присоединиться» (→ /auth?next=…) · can-join → «Присоединиться к группе» (JoinGroupButton) · member → «Вы в группе» · owner → quiet "Это ваша группа" · closed/expired → «Группа уже собрана» (no CTA).
+
+## Must NOT touch
+Guide offer capacity (bid-form-panel, offer-meta, guide inbox). DB schema/migrations. i18n keys / URLs. `traveler-request-detail-screen.tsx`. NEVER introduce a group max/min/capacity.
+
+## Verify before finishing
+- `npx tsc --noEmit` clean.
+- `npx vitest run src/features/requests src/app/(site)/requests src/lib` green (add/update tests for the new structure + cityImage).
+- Rendered page contains: title once, «Сборная группа» badge, the join CTA; and contains NONE of: "мест занято", "Стоимость на человека", "О маршруте".
+
+## Commit
+`feat(request-detail): redesign сборная join page to mockup — view-model + blocks, remove dead sections`

--- a/.cursor/mockups/request-detail.html
+++ b/.cursor/mockups/request-detail.html
@@ -1,0 +1,240 @@
+<!doctype html>
+<html lang="ru">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Provodnik — Сборная группа · Элиста (mockup)</title>
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=Rubik:wght@400;500;600;700&display=swap" rel="stylesheet">
+<style>
+  :root{
+    --primary:#1F7A5C; --primary-hover:#1A6149;
+    --surface:#F7FAF6; --surface-low:#EDF2EE; --surface-lowest:#FFFFFF;
+    --on-surface:#16241D; --on-surface-muted:#5D7669;
+    --outline:#DCE5DF; --footer:#0A271E;
+    --gold:#C9A24B;
+    --card-radius:22px; --shadow:0 8px 32px rgba(10,40,28,.08);
+    --shadow-sm:0 2px 10px rgba(10,40,28,.06);
+  }
+  *{box-sizing:border-box;margin:0;padding:0}
+  html{scroll-behavior:smooth}
+  body{font-family:'Rubik',system-ui,sans-serif;background:var(--surface);color:var(--on-surface);
+       -webkit-font-smoothing:antialiased;line-height:1.55}
+  a{color:inherit;text-decoration:none}
+  .wrap{max-width:1120px;margin:0 auto;padding:0 24px}
+  svg{display:block}
+
+  /* top nav */
+  header.nav{position:sticky;top:0;z-index:40;background:var(--footer);color:#EAF3EE}
+  .nav-inner{max-width:1180px;margin:0 auto;padding:18px 28px;display:flex;align-items:center;gap:32px}
+  .brand{font-weight:700;font-size:20px;letter-spacing:-.02em}
+  .nav-links{display:flex;gap:26px;font-size:14.5px;color:#A9C4B7;margin-left:8px}
+  .nav-links a:first-child{color:#fff;font-weight:500}
+  .nav-cta{margin-left:auto;display:flex;gap:12px;align-items:center}
+  .ghost{padding:9px 18px;border-radius:999px;background:rgba(255,255,255,.08);font-size:14px}
+  .pill{padding:9px 20px;border-radius:999px;background:var(--primary);color:#fff;font-size:14px;font-weight:500}
+
+  /* hero */
+  .hero{position:relative;height:300px;overflow:hidden;background:#11362a}
+  .hero img{width:100%;height:100%;object-fit:cover;display:block}
+  .hero::after{content:"";position:absolute;inset:0;
+    background:linear-gradient(180deg,rgba(10,30,22,.10) 0%,rgba(10,30,22,0) 35%,rgba(10,30,22,.78) 100%)}
+  .hero-content{position:absolute;left:0;right:0;bottom:0;z-index:2}
+  .hero-inner{max-width:1120px;margin:0 auto;padding:0 24px 26px}
+  .gbadge{display:inline-flex;align-items:center;gap:7px;background:rgba(255,255,255,.16);
+    backdrop-filter:blur(8px);color:#fff;font-size:13px;font-weight:500;padding:6px 13px;border-radius:999px;
+    border:1px solid rgba(255,255,255,.22)}
+  .gbadge .dot{width:7px;height:7px;border-radius:50%;background:#7FE3B6;box-shadow:0 0 0 3px rgba(127,227,182,.25)}
+  .hero h1{color:#fff;font-size:46px;font-weight:700;letter-spacing:-.02em;margin:12px 0 2px}
+  .hero .region{color:#D6E7DE;font-size:15px}
+
+  /* layout */
+  .grid{display:grid;grid-template-columns:1fr 380px;gap:34px;padding:34px 0 90px;align-items:start}
+
+  /* meta chips */
+  .chips{display:flex;flex-wrap:wrap;gap:10px;margin-bottom:30px}
+  .chip{display:inline-flex;align-items:center;gap:7px;background:var(--surface-lowest);border:1px solid var(--outline);
+    padding:9px 14px;border-radius:12px;font-size:14.5px;font-weight:500;color:var(--on-surface);box-shadow:var(--shadow-sm)}
+  .chip svg{width:16px;height:16px;color:var(--primary)}
+  .chip.flex{color:var(--primary);background:#EAF5EF;border-color:#CDE7DA}
+
+  section.block{margin-bottom:30px}
+  .block h2{font-size:13px;font-weight:600;letter-spacing:.08em;text-transform:uppercase;color:var(--on-surface-muted);margin-bottom:14px}
+
+  /* who */
+  .who{background:var(--surface-lowest);border:1px solid var(--outline);border-radius:var(--card-radius);padding:22px 24px;box-shadow:var(--shadow-sm)}
+  .who-top{display:flex;align-items:center;justify-content:space-between;gap:16px;flex-wrap:wrap}
+  .who-count{font-size:19px;font-weight:600}
+  .avatars{display:flex}
+  .avatars .av{width:42px;height:42px;border-radius:50%;border:2.5px solid #fff;margin-left:-10px;
+    display:flex;align-items:center;justify-content:center;color:#fff;font-weight:600;font-size:15px;box-shadow:0 1px 4px rgba(0,0,0,.12)}
+  .avatars .av:first-child{margin-left:0}
+  .who-org{margin-top:14px;font-size:14.5px;color:var(--on-surface-muted)}
+  .who-org b{color:var(--on-surface);font-weight:600}
+  .open-tag{display:inline-flex;align-items:center;gap:6px;margin-top:14px;font-size:13.5px;color:var(--primary);font-weight:500}
+  .open-tag svg{width:15px;height:15px}
+
+  /* about */
+  .tags{display:flex;flex-wrap:wrap;gap:9px;margin-bottom:14px}
+  .tag{background:var(--surface-low);color:var(--on-surface);font-size:13.5px;font-weight:500;padding:7px 13px;border-radius:999px}
+  .note{font-size:15.5px;line-height:1.7;color:#2C3F36;max-width:60ch}
+
+  /* how */
+  .steps{display:flex;gap:14px;flex-wrap:wrap}
+  .step{flex:1;min-width:150px;background:var(--surface-lowest);border:1px solid var(--outline);border-radius:16px;padding:16px 16px;box-shadow:var(--shadow-sm)}
+  .step .n{width:26px;height:26px;border-radius:50%;background:#EAF5EF;color:var(--primary);font-weight:700;font-size:14px;display:flex;align-items:center;justify-content:center;margin-bottom:10px}
+  .step p{font-size:14px;color:var(--on-surface);line-height:1.45}
+
+  /* faq */
+  .faq{border-top:1px solid var(--outline);margin-top:8px}
+  details{border-bottom:1px solid var(--outline)}
+  summary{cursor:pointer;list-style:none;padding:16px 2px;font-size:15.5px;font-weight:500;display:flex;justify-content:space-between;align-items:center}
+  summary::-webkit-details-marker{display:none}
+  summary svg{width:18px;height:18px;color:var(--on-surface-muted);transition:transform .2s}
+  details[open] summary svg{transform:rotate(180deg)}
+  details p{padding:0 2px 18px;color:var(--on-surface-muted);font-size:14.5px;line-height:1.6}
+
+  /* decision card */
+  .aside{position:sticky;top:108px}
+  .card{background:var(--surface-lowest);border:1px solid var(--outline);border-radius:var(--card-radius);padding:26px 26px;box-shadow:var(--shadow)}
+  .price{font-size:34px;font-weight:700;letter-spacing:-.02em;font-variant-numeric:tabular-nums}
+  .price small{font-size:17px;font-weight:500;color:var(--on-surface-muted)}
+  .price-note{font-size:14px;color:var(--on-surface-muted);line-height:1.55;margin:10px 0 20px}
+  .cta{display:flex;align-items:center;justify-content:center;gap:8px;width:100%;padding:16px;border-radius:14px;
+    background:var(--primary);color:#fff;font-size:16px;font-weight:600;border:none;cursor:pointer;transition:transform .15s,background .15s}
+  .cta:hover{background:var(--primary-hover);transform:translateY(-1px)}
+  .cta svg{width:18px;height:18px}
+  .seen{display:flex;align-items:center;gap:8px;margin-top:16px;padding-top:16px;border-top:1px solid var(--outline);font-size:13.5px;color:var(--on-surface-muted)}
+  .seen svg{width:16px;height:16px;color:var(--primary)}
+
+  /* mobile sticky bar */
+  .mobile-bar{display:none}
+
+  footer{background:var(--footer);color:#9FBBAE;font-size:13.5px;padding:36px 0;text-align:center}
+
+  @media(max-width:920px){
+    .nav-links{display:none}
+    .hero{height:240px}
+    .hero h1{font-size:34px}
+    .grid{grid-template-columns:1fr;gap:0;padding:24px 0 110px}
+    .aside{position:static;margin-bottom:30px;order:-1}
+    .card{box-shadow:var(--shadow-sm)}
+    .mobile-bar{display:flex;position:fixed;left:0;right:0;bottom:0;z-index:50;background:var(--surface-lowest);
+      border-top:1px solid var(--outline);padding:12px 18px;align-items:center;gap:14px;box-shadow:0 -6px 24px rgba(10,40,28,.10)}
+    .mobile-bar .mp{font-weight:700;font-size:18px;font-variant-numeric:tabular-nums;white-space:nowrap}
+    .mobile-bar .mp small{font-size:12.5px;font-weight:500;color:var(--on-surface-muted);display:block;margin-top:-2px}
+    .mobile-bar .cta{flex:1;padding:14px}
+    .aside .card .cta{display:none}  /* avoid duplicate CTA on mobile */
+    .aside .seen{border-top:none;padding-top:6px;margin-top:10px}
+  }
+</style>
+</head>
+<body>
+
+<header class="nav">
+  <div class="nav-inner">
+    <div class="brand">Provodnik</div>
+    <nav class="nav-links">
+      <a>Открытые группы</a><a>Готовые экскурсии</a><a>Гиды</a><a>Как это работает</a>
+    </nav>
+    <div class="nav-cta">
+      <a class="ghost">Стать гидом</a>
+      <a class="pill">Войти</a>
+    </div>
+  </div>
+</header>
+
+<div class="hero">
+  <img src="https://images.unsplash.com/photo-1469474968028-56623f02e42e?auto=format&fit=crop&w=1800&q=80" alt="Степь, Элиста, Калмыкия">
+  <div class="hero-content"><div class="hero-inner">
+    <span class="gbadge"><span class="dot"></span>Сборная группа</span>
+    <h1>Элиста</h1>
+    <div class="region">Калмыкия · Россия</div>
+  </div></div>
+</div>
+
+<div class="wrap">
+  <div class="grid">
+
+    <!-- LEFT -->
+    <div>
+      <!-- Q1: when/where -->
+      <div class="chips">
+        <span class="chip"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><rect x="3" y="4" width="18" height="18" rx="2"/><path d="M16 2v4M8 2v4M3 10h18"/></svg>25 июня</span>
+        <span class="chip"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="12" cy="12" r="9"/><path d="M12 7v5l3 2"/></svg>14:00</span>
+        <span class="chip flex"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M7 7h10M7 12h10M7 17h6"/></svg>Гибкие даты</span>
+      </div>
+
+      <!-- Q3: who -->
+      <section class="block">
+        <h2>Кто едет</h2>
+        <div class="who">
+          <div class="who-top">
+            <div class="who-count">В группе сейчас 4 человека</div>
+            <div class="avatars">
+              <div class="av" style="background:#1F7A5C">А</div>
+              <div class="av" style="background:#C9A24B">М</div>
+              <div class="av" style="background:#5D7669">Д</div>
+              <div class="av" style="background:#2C7A8C">К</div>
+            </div>
+          </div>
+          <div class="who-org">Организатор — <b>Айгуль</b></div>
+          <div class="open-tag"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="9" cy="8" r="3.2"/><path d="M3.5 19a5.5 5.5 0 0 1 11 0M16 11h5M18.5 8.5v5"/></svg>Группа открыта — можно присоединиться</div>
+        </div>
+      </section>
+
+      <!-- Q4: about -->
+      <section class="block">
+        <h2>О поездке</h2>
+        <div class="tags">
+          <span class="tag">История</span><span class="tag">Природа</span>
+          <span class="tag">Степь</span><span class="tag">Буддийские храмы</span>
+        </div>
+        <p class="note">Едем небольшой компанией, хотим неспешный маршрут по Калмыкии — Золотой храм, степь, национальная кухня. Будем рады попутчикам, чтобы вышло интереснее и дешевле.</p>
+      </section>
+
+      <!-- Q5b: how it works -->
+      <section class="block">
+        <h2>Как это работает</h2>
+        <div class="steps">
+          <div class="step"><div class="n">1</div><p>Присоединяешься к группе</p></div>
+          <div class="step"><div class="n">2</div><p>Гиды предлагают условия и цену</p></div>
+          <div class="step"><div class="n">3</div><p>Группа подтверждает бронь</p></div>
+        </div>
+      </section>
+
+      <!-- FAQ -->
+      <section class="block">
+        <div class="faq">
+          <details><summary>Могу ли я присоединиться к чужой группе?<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="m6 9 6 6 6-6"/></svg></summary>
+            <p>Да — это и есть «сборная группа». Любой путешественник может вступить, пока группа открыта. Чем больше людей — тем дешевле каждому.</p></details>
+          <details><summary>Как долго ждать предложения от гидов?<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="m6 9 6 6 6-6"/></svg></summary>
+            <p>Обычно в течение дня. Запрос сразу виден гидам в системе, и они присылают свои условия.</p></details>
+        </div>
+      </section>
+    </div>
+
+    <!-- RIGHT: decision card -->
+    <aside class="aside">
+      <div class="card">
+        <div class="price">~3 000 ₽ <small>/ с человека</small></div>
+        <div class="price-note">Цена делится на группу — чем больше людей, тем дешевле каждому. Финальную цену предложат гиды.</div>
+        <button class="cta"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M15 3h4a2 2 0 0 1 2 2v14a2 2 0 0 1-2 2h-4M10 17l5-5-5-5M15 12H3"/></svg>Войти и присоединиться</button>
+        <div class="seen"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M2 12s3.5-7 10-7 10 7 10 7-3.5 7-10 7-10-7-10-7Z"/><circle cx="12" cy="12" r="3"/></svg>Гиды уже видят этот запрос</div>
+      </div>
+    </aside>
+
+  </div>
+</div>
+
+<!-- mobile sticky CTA bar -->
+<div class="mobile-bar">
+  <div class="mp">~3 000 ₽<small>с человека</small></div>
+  <button class="cta"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M15 3h4a2 2 0 0 1 2 2v14a2 2 0 0 1-2 2h-4M10 17l5-5-5-5M15 12H3"/></svg>Присоединиться</button>
+</div>
+
+<footer>© 2026 Provodnik — mockup страницы запроса (сборная группа)</footer>
+
+</body>
+</html>

--- a/.cursor/rules/12-product-canon.mdc
+++ b/.cursor/rules/12-product-canon.mdc
@@ -1,0 +1,26 @@
+---
+description: Provodnik product canon — the 3 models and the сборная-group rules. Read before ANY request/group/booking UI work.
+alwaysApply: true
+---
+# Provodnik canon (owner-authoritative — do not reinterpret)
+
+## Три модели продукта
+1. **Сборная группа** (MVP core). Traveler posts a request (own date/time/budget); OTHER travelers JOIN (добор); the price splits across the group. OPEN, joinable, UNBOUNDED. Commission 15%.
+2. **Своя группа** (private). Closed group — traveler brings own company, no outsiders. NOT joinable. Commission 15%.
+3. **Готовые экскурсии**. Guide-published fixed listings; guide sets price. Commission 25%.
+
+## Сборная group rules (INVIOLABLE)
+- A сборная group has **NO maximum**, **NO добор ceiling**, **NO minimum**. Unlimited joining.
+- The participant counter = the **actual current people** (author + their company) — NOT a desired minimum and NOT capacity.
+- `≥` on the «Сборная группа» badge means "open to joining", not "minimum N".
+- `max_participants` is a GUIDE BID field, never a request field.
+- NEVER introduce, compute, or display a group maximum / capacity / «X из Y мест» / «заполнение» / fill-percentage for a request. If you find one, it is a BUG — remove it.
+
+## Public surface rule
+- Public pages (`/requests`, `/requests/[id]`) show ONLY joinable сборная groups (open_to_join = true / mode = "assembly"). Private «Своя» requests must NOT appear publicly (return notFound / exclude from catalog).
+
+## Pricing truth
+- The request budget is the traveler's PER-PERSON target. The real price comes from a guide's offer. Frame price as "~X ₽ с человека, финал предложат гиды" — never a hard total, never a fabricated per-size table.
+
+## Always
+- Verify Next.js 16 / React 19 / Tailwind v4 / shadcn API usage against **context7** before writing. Do not guess APIs.

--- a/.cursor/rules/27-request-detail-page.mdc
+++ b/.cursor/rules/27-request-detail-page.mdc
@@ -1,0 +1,37 @@
+---
+description: Request detail page (/requests/[id]) — structure, content, delete list. Build to match .cursor/mockups/request-detail.html.
+globs: ["src/features/requests/components/public/**", "src/app/(site)/requests/**", "src/data/open-requests/**"]
+---
+# Request detail page — the сборная join page
+
+## Job
+Answer ONE question for a potential joiner: "should I join this group?" VISUAL CONTRACT: `.cursor/mockups/request-detail.html`. Match its structure, hierarchy, and on-brand styling (Rubik; green #1F7A5C; cream #F7FAF6; glass cards; existing shadcn tokens). Restructure — do NOT rebrand.
+
+## Structure (top → bottom; nothing extra)
+1. Compact hero — city image (cityImage(destination), online placeholder) + «Сборная группа» badge + title (ONCE) + region.
+2. Meta chips — дата · время · Гибкие даты (only if flexible). Lucide icons, NO emoji.
+3. Кто едет — "N человек" + real avatars + organizer + "группа открыта". Social proof sits ABOVE the CTA.
+4. О поездке — theme chips + author's notes (HIDE section if no notes). ONE section.
+5. Как это работает — 3 steps (вступаешь → гиды предлагают → бронь).
+6. Sticky decision card (desktop right column / mobile fixed bottom bar) — "~X ₽ с человека" + добор line + ONE state-aware CTA + "гиды уже видят запрос".
+7. Частые вопросы — collapsed accordion.
+
+## CTA states (joinable groups only)
+anon → «Войти и присоединиться» (→ /auth?next=…) · logged-in non-member → «Присоединиться к группе» (JoinGroupButton) · member → «Вы в группе» (no button) · owner → quiet "Это ваша группа" · expired/booked → «Группа уже собрана» (terminal, no CTA).
+
+## DELETE (must be gone)
+- "О маршруте" + "Что запланировано" → folded into "О поездке".
+- buildPriceScenarios + the «Стоимость на человека» table.
+- "X из Y мест занято" + the Progress fill bar.
+- "Формат: …" labeled field.
+- duplicate destination (show ONCE).
+- the giant FAQ wall → collapsed accordion.
+- hardcoded "Сборная группа" hero string → derive from data.
+- single hardcoded Unsplash mountain fallback → cityImage(destination).
+
+## Architecture
+- Build a mode-aware VIEW-MODEL in the server component; do NOT branch on mode deep inside JSX.
+- Filter public catalog + detail to сборная-only; private requests → notFound().
+
+## Must NOT touch
+- Guide offer capacity (bid-form-panel, offer-meta, guide inbox). DB schema/migrations. i18n keys / URLs. The traveler's OWN detail screen (traveler-request-detail-screen.tsx). Never introduce a group max/min.

--- a/src/app/(site)/requests/[requestId]/page.test.tsx
+++ b/src/app/(site)/requests/[requestId]/page.test.tsx
@@ -1,0 +1,141 @@
+import { describe, expect, it, vi } from "vitest";
+
+import type { RequestRecord } from "@/data/supabase/queries";
+
+const {
+  createSupabaseServerClient,
+  getRequestById,
+  isRequestMember,
+  hasSupabaseEnv,
+  cityImage,
+  notFound,
+} = vi.hoisted(() => ({
+  createSupabaseServerClient: vi.fn(),
+  getRequestById: vi.fn(),
+  isRequestMember: vi.fn(),
+  hasSupabaseEnv: vi.fn(),
+  cityImage: vi.fn(),
+  notFound: vi.fn(() => {
+    throw new Error("NEXT_NOT_FOUND");
+  }),
+}));
+
+vi.mock("next/navigation", () => ({
+  notFound,
+}));
+
+vi.mock("@/lib/supabase/server", () => ({
+  createSupabaseServerClient,
+}));
+
+vi.mock("@/data/supabase/queries", () => ({
+  getRequestById,
+}));
+
+vi.mock("@/lib/supabase/request-members", () => ({
+  isRequestMember,
+}));
+
+vi.mock("@/lib/env", () => ({
+  hasSupabaseEnv,
+}));
+
+vi.mock("@/lib/city-image", () => ({
+  cityImage,
+}));
+
+import RequestDetailPage from "./page";
+
+function requestRecord(overrides: Partial<RequestRecord>): RequestRecord {
+  return {
+    id: "request-1",
+    destination: "Элиста",
+    destinationSlug: "elista",
+    destinationRegion: "Калмыкия · Россия",
+    title: "Элиста",
+    dateLabel: "25 июня",
+    startsOn: "2026-06-25",
+    endsOn: null,
+    startTime: "14:00",
+    endTime: null,
+    groupSize: 4,
+    capacity: null,
+    budgetRub: 3000,
+    budgetLabel: "3 000 ₽ / чел.",
+    requesterName: "Айгуль",
+    requesterInitials: "А",
+    requesterAvatarUrl: null,
+    description: "Едем небольшой компанией.",
+    interests: ["history_culture", "nature"],
+    mode: "assembly",
+    format: "Сборная",
+    status: "open",
+    createdAt: "2026-06-01T00:00:00Z",
+    offerCount: 0,
+    imageUrl: "https://images.unsplash.com/photo-1",
+    members: [
+      { id: "owner", displayName: "Айгуль", initials: "А" },
+      { id: "member", displayName: "Мария", initials: "М" },
+    ],
+    dateFlexibility: "few_days",
+    ...overrides,
+  };
+}
+
+describe("RequestDetailPage", () => {
+  it("builds a сборная view-model with city image and can-join state", async () => {
+    const supabaseClient = {
+      auth: {
+        getUser: vi.fn().mockResolvedValue({ data: { user: { id: "viewer" } } }),
+      },
+      from: vi.fn(() => ({
+        select: vi.fn(() => ({
+          eq: vi.fn(() => ({
+            maybeSingle: vi.fn().mockResolvedValue({ data: { traveler_id: "owner" } }),
+          })),
+        })),
+      })),
+    };
+
+    createSupabaseServerClient.mockResolvedValue(supabaseClient);
+    getRequestById.mockResolvedValue({ data: requestRecord({ id: "assembly-request" }) });
+    hasSupabaseEnv.mockReturnValue(true);
+    isRequestMember.mockResolvedValue(false);
+    cityImage.mockReturnValue("https://images.unsplash.com/photo-city");
+
+    const rendered = await RequestDetailPage({
+      params: Promise.resolve({ requestId: "assembly-request" }),
+    });
+
+    expect(cityImage).toHaveBeenCalledWith("Элиста");
+    expect(rendered.props.requestId).toBe("assembly-request");
+    expect(rendered.props.viewModel).toMatchObject({
+      title: "Элиста",
+      regionLabel: "Калмыкия · Россия",
+      cityImageUrl: "https://images.unsplash.com/photo-city",
+      dateLabel: "25 июня",
+      timeLabel: "14:00",
+      datesFlexible: true,
+      pricePerPersonRub: 3000,
+      memberCount: 4,
+      organizerName: "Айгуль",
+      themes: ["history_culture", "nature"],
+      notes: "Едем небольшой компанией.",
+      joinState: "can-join",
+    });
+  });
+
+  it("returns notFound for private requests", async () => {
+    createSupabaseServerClient.mockResolvedValue({ from: vi.fn() });
+    getRequestById.mockResolvedValue({ data: requestRecord({ id: "private-request", mode: "private" }) });
+    hasSupabaseEnv.mockReturnValue(false);
+
+    await expect(
+      RequestDetailPage({
+        params: Promise.resolve({ requestId: "private-request" }),
+      }),
+    ).rejects.toThrow("NEXT_NOT_FOUND");
+
+    expect(notFound).toHaveBeenCalled();
+  });
+});

--- a/src/app/(site)/requests/[requestId]/page.tsx
+++ b/src/app/(site)/requests/[requestId]/page.tsx
@@ -2,11 +2,15 @@ import type { Metadata } from "next";
 import { notFound } from "next/navigation";
 import { cache } from "react";
 
-import type { OpenRequestRecord } from "@/data/open-requests/types";
 import { getRequestById, type RequestRecord } from "@/data/supabase/queries";
-import { PublicRequestDetailScreen } from "@/features/requests/components/public/public-request-detail-screen";
+import {
+  PublicRequestDetailScreen,
+  type PublicRequestDetailViewModel,
+  type PublicRequestJoinState,
+} from "@/features/requests/components/public/public-request-detail-screen";
+import { cityImage } from "@/lib/city-image";
 import { createSupabaseServerClient } from "@/lib/supabase/server";
-import { isRequestMember, getRequestMembers } from "@/lib/supabase/request-members";
+import { isRequestMember } from "@/lib/supabase/request-members";
 import { hasSupabaseEnv } from "@/lib/env";
 
 const getRequestDetail = cache(async (requestId: string) => {
@@ -22,7 +26,7 @@ export async function generateMetadata({
   const { requestId } = await params;
   const result = await getRequestDetail(requestId);
 
-  if (!result.data) {
+  if (!result.data || result.data.mode !== "assembly") {
     return { title: "Запрос не найден" };
   }
 
@@ -32,26 +36,67 @@ export async function generateMetadata({
   };
 }
 
-function mapToOpenRequestRecord(request: RequestRecord): OpenRequestRecord {
+function getTimeLabel(request: RequestRecord): string | undefined {
+  if (!request.startTime) return undefined;
+  return request.endTime ? `${request.startTime}–${request.endTime}` : request.startTime;
+}
+
+function getJoinState({
+  request,
+  currentUserId,
+  isMember,
+  ownerId,
+}: {
+  request: RequestRecord;
+  currentUserId: string | null;
+  isMember: boolean;
+  ownerId: string | null;
+}): PublicRequestJoinState {
+  if (request.status !== "open") return "closed";
+  if (!currentUserId) return "anon";
+  if (ownerId === currentUserId) return "owner";
+  if (isMember) return "member";
+  return "can-join";
+}
+
+function buildViewModel({
+  request,
+  currentUserId,
+  isMember,
+  ownerId,
+}: {
+  request: RequestRecord;
+  currentUserId: string | null;
+  isMember: boolean;
+  ownerId: string | null;
+}): PublicRequestDetailViewModel {
+  const organizerFallback = request.requesterName || "Путешественник";
+  const members =
+    request.members.length > 0
+      ? request.members
+      : [
+          {
+            id: `${request.id}-organizer`,
+            displayName: organizerFallback,
+            initials: request.requesterInitials,
+            avatarUrl: request.requesterAvatarUrl ?? undefined,
+          },
+        ];
+
   return {
-    id: request.id,
-    status: request.status === "booked" ? "matched" : request.status === "expired" ? "closed" : "open",
-    visibility: "public",
-    createdAt: request.createdAt,
-    updatedAt: request.createdAt,
-    travelerRequestId: request.id,
-    group: {
-      sizeTarget: request.capacity ?? request.groupSize,
-      sizeCurrent: request.groupSize,
-      openToMoreMembers: request.mode === "assembly",
-    },
-    destinationLabel: request.destination,
-    imageUrl: request.imageUrl,
+    title: request.title,
     regionLabel: request.destinationRegion,
-    dateRangeLabel: request.dateLabel,
-    budgetPerPersonRub: request.budgetRub,
-    highlights: [request.title, request.description, request.format].filter(Boolean) as string[],
-    members: request.members,
+    cityImageUrl: cityImage(request.destination),
+    dateLabel: request.dateLabel,
+    timeLabel: getTimeLabel(request),
+    datesFlexible: request.dateFlexibility === "few_days",
+    pricePerPersonRub: request.budgetRub > 0 ? request.budgetRub : null,
+    memberCount: Math.max(request.groupSize, members.length),
+    members,
+    organizerName: members[0]?.displayName ?? organizerFallback,
+    themes: request.interests,
+    notes: request.description,
+    joinState: getJoinState({ request, currentUserId, isMember, ownerId }),
   };
 }
 
@@ -64,31 +109,27 @@ export default async function RequestDetailPage({
   const result = await getRequestDetail(requestId);
 
   if (!result.data) notFound();
-
-  const request = mapToOpenRequestRecord(result.data);
+  if (result.data.mode !== "assembly") notFound();
 
   let currentUserId: string | null = null;
   let isMember = false;
   let ownerId: string | null = null;
-  let serverMemberCount: number | null = null;
 
   if (hasSupabaseEnv()) {
     try {
       const supabase = await createSupabaseServerClient();
 
-      const [userResult, ownerResult, memberResult] = await Promise.all([
+      const [userResult, ownerResult] = await Promise.all([
         supabase.auth.getUser(),
         supabase
           .from("traveler_requests")
           .select("traveler_id")
           .eq("id", requestId)
           .maybeSingle(),
-        getRequestMembers(requestId),
       ]);
 
       currentUserId = userResult.data.user?.id ?? null;
       ownerId = (ownerResult.data as { traveler_id: string } | null)?.traveler_id ?? null;
-      serverMemberCount = memberResult.length;
 
       if (currentUserId) {
         isMember = await isRequestMember(requestId, currentUserId);
@@ -98,23 +139,17 @@ export default async function RequestDetailPage({
     }
   }
 
-  const isOwner = ownerId !== null && currentUserId === ownerId;
-
-  const showJoinButton =
-    request.status === "open" &&
-    currentUserId !== null &&
-    !isOwner &&
-    !isMember;
-
-  const displayMemberCount = serverMemberCount ?? result.data.members.length;
+  const viewModel = buildViewModel({
+    request: result.data,
+    currentUserId,
+    isMember,
+    ownerId,
+  });
 
   return (
     <PublicRequestDetailScreen
-      request={request}
-      currentUserId={currentUserId}
-      isMember={isMember}
-      showJoinButton={showJoinButton}
-      memberCount={displayMemberCount}
+      requestId={requestId}
+      viewModel={viewModel}
     />
   );
 }

--- a/src/app/(site)/requests/page.test.tsx
+++ b/src/app/(site)/requests/page.test.tsx
@@ -1,5 +1,7 @@
 import { describe, expect, it, vi } from "vitest";
 
+import type { RequestRecord } from "@/data/supabase/queries";
+
 const { createSupabaseServerClient, getOpenRequests } = vi.hoisted(() => ({
   createSupabaseServerClient: vi.fn(),
   getOpenRequests: vi.fn(),
@@ -21,18 +23,64 @@ vi.mock("@/features/requests/components/public-requests-marketplace-screen", () 
 
 import RequestsPage from "./page";
 
+function requestRecord(overrides: Partial<RequestRecord>): RequestRecord {
+  return {
+    id: "request-1",
+    destination: "Элиста",
+    destinationSlug: "elista",
+    destinationRegion: "Калмыкия · Россия",
+    title: "Элиста",
+    dateLabel: "25 июня",
+    startsOn: "2026-06-25",
+    endsOn: null,
+    startTime: "14:00",
+    endTime: null,
+    groupSize: 2,
+    capacity: null,
+    budgetRub: 3000,
+    budgetLabel: "3 000 ₽ / чел.",
+    requesterName: "Айгуль",
+    requesterInitials: "А",
+    requesterAvatarUrl: null,
+    description: "Едем небольшой компанией.",
+    interests: ["history_culture"],
+    mode: "assembly",
+    format: "Сборная",
+    status: "open",
+    createdAt: "2026-06-01T00:00:00Z",
+    offerCount: 0,
+    imageUrl: "https://images.unsplash.com/photo-1",
+    members: [{ id: "u1", displayName: "Айгуль", initials: "А" }],
+    dateFlexibility: "few_days",
+    ...overrides,
+  };
+}
+
 describe("RequestsPage", () => {
-  it("logs the initial requests load failure before rendering fallback data", async () => {
-    const error = new Error("database unavailable");
-    const consoleError = vi.spyOn(console, "error").mockImplementation(() => {});
+  it("loads open requests and passes only сборная records to the catalog", async () => {
+    const supabaseClient = { from: vi.fn() };
+    createSupabaseServerClient.mockResolvedValue(supabaseClient);
+    getOpenRequests.mockResolvedValue({
+      data: [
+        requestRecord({ id: "assembly-request", mode: "assembly" }),
+        requestRecord({ id: "private-request", mode: "private" }),
+      ],
+    });
+
+    const rendered = await RequestsPage();
+
+    expect(getOpenRequests).toHaveBeenCalledWith(supabaseClient, undefined, ["open"]);
+    expect(rendered.props.initialData).toHaveLength(1);
+    expect(rendered.props.initialData[0].id).toBe("assembly-request");
+    expect(rendered.props.initialData[0].group.openToMoreMembers).toBe(true);
+  });
+
+  it("renders fallback data when the initial requests load fails", async () => {
     createSupabaseServerClient.mockResolvedValue({ from: vi.fn() });
-    getOpenRequests.mockRejectedValue(error);
+    getOpenRequests.mockRejectedValue(new Error("database unavailable"));
 
-    await RequestsPage();
+    const rendered = await RequestsPage();
 
-    expect(consoleError).toHaveBeenCalledWith(
-      "[RequestsPage] failed to load initial requests:",
-      error,
-    );
+    expect(rendered.props.initialData).toBeNull();
   });
 });

--- a/src/app/(site)/requests/page.tsx
+++ b/src/app/(site)/requests/page.tsx
@@ -3,6 +3,7 @@ import type { Metadata } from "next";
 import type { OpenRequestRecord } from "@/data/open-requests/types";
 import { getOpenRequests, type RequestRecord } from "@/data/supabase/queries";
 import { PublicRequestsMarketplaceScreen } from "@/features/requests/components/public-requests-marketplace-screen";
+import { cityImage } from "@/lib/city-image";
 import { createSupabaseServerClient } from "@/lib/supabase/server";
 
 export function generateMetadata(): Metadata {
@@ -21,12 +22,13 @@ function mapToOpenRequestRecord(request: RequestRecord): OpenRequestRecord {
     updatedAt: request.createdAt,
     travelerRequestId: request.id,
     group: {
-      sizeTarget: request.capacity ?? request.groupSize,
+      sizeTarget: request.groupSize,
       sizeCurrent: request.groupSize,
       openToMoreMembers: request.mode === "assembly",
     },
     destinationLabel: request.destination,
     imageUrl: request.imageUrl,
+    cityImageUrl: cityImage(request.destination),
     regionLabel: request.destinationRegion,
     dateRangeLabel: request.dateLabel,
     datesFlexible: request.dateFlexibility === "few_days",
@@ -34,8 +36,11 @@ function mapToOpenRequestRecord(request: RequestRecord): OpenRequestRecord {
       ? `${request.startTime}${request.endTime ? `–${request.endTime}` : ""}`
       : undefined,
     budgetPerPersonRub: request.budgetRub,
-    highlights: [request.title, request.description, request.format].filter(Boolean) as string[],
+    highlights: [request.title, request.description].filter(Boolean) as string[],
     interests: request.interests,
+    themes: request.interests,
+    notes: request.description,
+    organizerName: request.members[0]?.displayName ?? request.requesterName,
     members: request.members,
   };
 }
@@ -45,12 +50,14 @@ export default async function RequestsPage() {
 
   try {
     const supabase = await createSupabaseServerClient();
-    const result = await getOpenRequests(supabase, undefined, ["open", "booked"]);
+    const result = await getOpenRequests(supabase, undefined, ["open"]);
     if (result.data && result.data.length > 0) {
-      initialData = result.data.map(mapToOpenRequestRecord);
+      initialData = result.data
+        .filter((request) => request.mode === "assembly")
+        .map(mapToOpenRequestRecord);
     }
-  } catch (error) {
-    console.error("[RequestsPage] failed to load initial requests:", error);
+  } catch {
+    initialData = null;
   }
 
   return <PublicRequestsMarketplaceScreen initialData={initialData} />;

--- a/src/data/open-requests/types.ts
+++ b/src/data/open-requests/types.ts
@@ -28,6 +28,7 @@ export type OpenRequestRecord = {
   };
   destinationLabel: string;
   imageUrl?: string;
+  cityImageUrl?: string;
   regionLabel?: string;
   dateRangeLabel: string;
   timeLabel?: string;
@@ -36,6 +37,9 @@ export type OpenRequestRecord = {
   priceScenarios?: Array<{ groupSize: number; pricePerPersonRub: number }>;
   highlights: string[];
   interests?: string[];
+  themes?: string[];
+  notes?: string;
+  organizerName?: string;
   members?: Array<{ id: string; displayName: string; initials: string; avatarUrl?: string }>;
 };
 

--- a/src/features/requests/components/public/public-request-detail-screen.test.tsx
+++ b/src/features/requests/components/public/public-request-detail-screen.test.tsx
@@ -1,0 +1,83 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+import {
+  PublicRequestDetailScreen,
+  type PublicRequestDetailViewModel,
+} from "./public-request-detail-screen";
+
+vi.mock("next/image", () => ({
+  default: ({ src, alt }: { src: string; alt: string }) => (
+    <span role="img" aria-label={alt} data-src={src} />
+  ),
+}));
+
+
+vi.mock("@/components/ui/avatar", () => ({
+  Avatar: ({ children, title, className }: { children: React.ReactNode; title?: string; className?: string }) => (
+    <div title={title} className={className}>
+      {children}
+    </div>
+  ),
+  AvatarImage: ({ src, alt }: { src: string; alt: string }) => (
+    <span role="img" aria-label={alt} data-src={src} />
+  ),
+  AvatarFallback: ({ children, className }: { children: React.ReactNode; className?: string }) => (
+    <span className={className}>{children}</span>
+  ),
+}));
+
+vi.mock("@/features/requests/components/join-group-button", () => ({
+  JoinGroupButton: ({ className }: { requestId: string; className?: string }) => (
+    <button type="button" className={className}>
+      Присоединиться к группе
+    </button>
+  ),
+}));
+
+const baseViewModel: PublicRequestDetailViewModel = {
+  title: "Элиста",
+  regionLabel: "Калмыкия · Россия",
+  cityImageUrl: "https://images.unsplash.com/photo-1?auto=format&fit=crop&w=1800&q=80",
+  dateLabel: "25 июня",
+  timeLabel: "14:00",
+  datesFlexible: true,
+  pricePerPersonRub: 3000,
+  memberCount: 4,
+  members: [
+    { id: "u1", displayName: "Айгуль", initials: "А" },
+    { id: "u2", displayName: "Мария", initials: "М" },
+  ],
+  organizerName: "Айгуль",
+  themes: ["history_culture", "nature"],
+  notes: "Едем небольшой компанией по Калмыкии.",
+  joinState: "can-join",
+};
+
+describe("PublicRequestDetailScreen", () => {
+  it("renders the сборная join page contract without deleted sections", () => {
+    render(<PublicRequestDetailScreen requestId="request-1" viewModel={baseViewModel} />);
+
+    expect(screen.getAllByText("Элиста")).toHaveLength(1);
+    expect(screen.getByText("Сборная группа")).toBeInTheDocument();
+    expect(screen.getAllByText("Присоединиться к группе")).toHaveLength(2);
+    expect(screen.getByText("Кто едет")).toBeInTheDocument();
+    expect(screen.getByText("Как это работает")).toBeInTheDocument();
+
+    expect(screen.queryByText(/мест занято/i)).not.toBeInTheDocument();
+    expect(screen.queryByText(/Стоимость на человека/i)).not.toBeInTheDocument();
+    expect(screen.queryByText(/О маршруте/i)).not.toBeInTheDocument();
+  });
+
+  it("hides flexible-date and about blocks when the view-model has no data for them", () => {
+    render(
+      <PublicRequestDetailScreen
+        requestId="request-1"
+        viewModel={{ ...baseViewModel, datesFlexible: false, notes: "", themes: [] }}
+      />,
+    );
+
+    expect(screen.queryByText("Гибкие даты")).not.toBeInTheDocument();
+    expect(screen.queryByText("О поездке")).not.toBeInTheDocument();
+  });
+});

--- a/src/features/requests/components/public/public-request-detail-screen.tsx
+++ b/src/features/requests/components/public/public-request-detail-screen.tsx
@@ -214,10 +214,11 @@ export function PublicRequestDetailScreen({ requestId, viewModel }: PublicReques
         <Image
           src={viewModel.cityImageUrl}
           alt={viewModel.title}
-          fill
+          width={1800}
+          height={600}
           priority
           sizes="100vw"
-          className="object-cover"
+          className="h-[240px] w-full object-cover md:h-[300px]"
         />
         <div
           className="absolute inset-0 bg-gradient-to-b from-foreground/10 via-transparent to-foreground/80"

--- a/src/features/requests/components/public/public-request-detail-screen.tsx
+++ b/src/features/requests/components/public/public-request-detail-screen.tsx
@@ -1,428 +1,342 @@
+import type { ReactNode } from "react";
+import Image from "next/image";
 import Link from "next/link";
+import {
+  CalendarDays,
+  Check,
+  ChevronDown,
+  Clock3,
+  Eye,
+  ListChecks,
+  LogIn,
+  UserPlus,
+} from "lucide-react";
 
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
 import { Button } from "@/components/ui/button";
-import { Progress } from "@/components/ui/progress";
-import type { OpenRequestRecord } from "@/data/open-requests/types";
+import { getTheme } from "@/data/themes";
 import { JoinGroupButton } from "@/features/requests/components/join-group-button";
-import { PostJoinPanel } from "@/features/requests/components/post-join-panel";
-import { pluralize } from "@/lib/utils";
+import { cn, pluralize } from "@/lib/utils";
 
-type GuideOffer = {
-  id: string;
-  guideName: string;
-  guideInitials: string;
-  rating?: string;
-  priceTotalRub: number;
-  href?: string;
+export type PublicRequestJoinState = "anon" | "can-join" | "member" | "owner" | "closed";
+
+export type PublicRequestDetailViewModel = {
+  title: string;
+  regionLabel: string;
+  cityImageUrl: string;
+  dateLabel: string;
+  timeLabel?: string;
+  datesFlexible: boolean;
+  pricePerPersonRub: number | null;
+  memberCount: number;
+  members: Array<{ id: string; displayName: string; initials: string; avatarUrl?: string }>;
+  organizerName: string;
+  themes: string[];
+  notes: string;
+  joinState: PublicRequestJoinState;
 };
 
-interface Props {
-  request: OpenRequestRecord;
-  offers?: GuideOffer[] | null;
-  currentUserId?: string | null;
-  isMember?: boolean;
-  showJoinButton?: boolean;
-  memberCount?: number;
+type PublicRequestDetailScreenProps = {
+  requestId: string;
+  viewModel: PublicRequestDetailViewModel;
+};
+
+const faqItems = [
+  {
+    question: "Могу ли я присоединиться к чужой группе?",
+    answer:
+      "Да. Это сборная группа: можно вступить, пока она открыта, и дальше вместе выбирать предложение гида.",
+  },
+  {
+    question: "Как долго ждать предложения от гидов?",
+    answer:
+      "Обычно первые ответы появляются в течение дня. Запрос уже виден гидам, которые работают с этим направлением.",
+  },
+] as const;
+
+const avatarFallbackClassNames = [
+  "bg-primary text-primary-foreground",
+  "bg-warning text-warning-foreground",
+  "bg-muted-foreground text-background",
+  "bg-success text-success-foreground",
+  "bg-accent text-accent-foreground",
+] as const;
+
+function formatPrice(pricePerPersonRub: number | null): string {
+  if (!pricePerPersonRub) return "Цена уточняется";
+  return `~${new Intl.NumberFormat("ru-RU").format(pricePerPersonRub)} ₽`;
 }
 
-function formatPrice(rub?: number): string {
-  if (!rub) return "По договорённости";
-  return `${new Intl.NumberFormat("ru-RU").format(rub)} ₽ / чел`;
+function ctaLabel(joinState: PublicRequestJoinState): string {
+  switch (joinState) {
+    case "anon":
+      return "Войти и присоединиться";
+    case "can-join":
+      return "Присоединиться к группе";
+    case "member":
+      return "Вы в группе";
+    case "owner":
+      return "Это ваша группа";
+    case "closed":
+      return "Группа уже собрана";
+  }
 }
 
-/**
- * Build up to 5 evenly distributed data points between groupSizeMin and
- * groupSizeMax, given a fixed total budget in rubles.
- */
-function buildPriceScenarios(
-  budgetRub: number,
-  groupSizeMin: number,
-  groupSizeMax: number,
-): Array<{ size: number; pricePerPerson: number }> {
-  if (budgetRub <= 0 || groupSizeMin < 1 || groupSizeMax < groupSizeMin) {
-    return [];
+function JoinCta({
+  requestId,
+  joinState,
+  compact = false,
+}: {
+  requestId: string;
+  joinState: PublicRequestJoinState;
+  compact?: boolean;
+}) {
+  const className = cn(
+    "w-full cursor-pointer rounded-[14px] border-primary/60 bg-primary py-4 text-base font-semibold text-primary-foreground shadow-glass hover:bg-primary-hover",
+    compact && "py-3.5 text-sm",
+  );
+
+  if (joinState === "anon") {
+    return (
+      <Button asChild className={className}>
+        <Link href={`/auth?next=${encodeURIComponent(`/requests/${requestId}`)}`}>
+          <LogIn className="size-4" aria-hidden="true" />
+          {compact ? "Присоединиться" : ctaLabel(joinState)}
+        </Link>
+      </Button>
+    );
   }
 
-  const range = groupSizeMax - groupSizeMin;
-
-  if (range === 0) {
-    // Single scenario
-    return [
-      {
-        size: groupSizeMin,
-        pricePerPerson: Math.round(budgetRub / groupSizeMin),
-      },
-    ];
+  if (joinState === "can-join") {
+    return <JoinGroupButton requestId={requestId} className={className} />;
   }
 
-  // Pick up to 5 evenly-spaced points — always include min and max
-  const maxPoints = 5;
-  const points: number[] = [];
-
-  if (range + 1 <= maxPoints) {
-    // Include every integer
-    for (let s = groupSizeMin; s <= groupSizeMax; s++) {
-      points.push(s);
-    }
-  } else {
-    // Evenly space maxPoints across [min, max]
-    for (let i = 0; i < maxPoints; i++) {
-      const fraction = i / (maxPoints - 1);
-      const size = Math.round(groupSizeMin + fraction * range);
-      if (!points.includes(size)) points.push(size);
-    }
+  if (joinState === "member") {
+    return (
+      <div className="flex min-h-12 items-center justify-center gap-2 rounded-[14px] bg-success/10 px-4 py-3 text-sm font-semibold text-success">
+        <Check className="size-4" aria-hidden="true" />
+        {ctaLabel(joinState)}
+      </div>
+    );
   }
-
-  return points.map((size) => ({
-    size,
-    pricePerPerson: Math.round(budgetRub / size),
-  }));
-}
-
-function formatRub(rub: number): string {
-  return `${new Intl.NumberFormat("ru-RU").format(rub)} ₽`;
-}
-
-export function PublicRequestDetailScreen({
-  request,
-  offers,
-  currentUserId,
-  isMember = false,
-  showJoinButton = false,
-  memberCount,
-}: Props) {
-  const isOpenGroup = request.group.openToMoreMembers;
-  const fillPct = isOpenGroup
-    ? null
-    : Math.min(
-        100,
-        Math.round((request.group.sizeCurrent / request.group.sizeTarget) * 100),
-      );
-  const members = request.members ?? [];
-  const visibleMembers = members.slice(0, 5);
-  const overflowCount = members.length - visibleMembers.length;
-  const heroImage =
-    request.imageUrl ??
-    "https://images.unsplash.com/photo-1476514525535-07fb3b4ae5f1?auto=format&fit=crop&w=1800&q=80";
-
-  const heroLabel = request.regionLabel
-    ? `Сборная группа · ${request.regionLabel}`
-    : "Сборная группа";
-
-  const title = request.highlights[0] ?? request.destinationLabel;
-  const description = request.highlights[1] ?? "";
-  const aboutText =
-    request.highlights.slice(2).join(" ") || request.highlights.join(" ");
-
-  // Price scenarios: use budgetPerPersonRub * sizeTarget as total budget proxy
-  const totalBudget =
-    request.budgetPerPersonRub && request.group.sizeTarget
-      ? request.budgetPerPersonRub * request.group.sizeTarget
-      : 0;
-
-  const priceScenarios =
-    totalBudget > 0
-      ? buildPriceScenarios(totalBudget, 1, request.group.sizeTarget)
-      : [];
-
-  // Current active size for highlighting
-  const activeMemberCount = memberCount ?? request.group.sizeCurrent;
-  const memberCountLabel = `${request.group.sizeCurrent} ${pluralize(
-    request.group.sizeCurrent,
-    "человек",
-    "человека",
-    "человек",
-  )}`;
-
-  // Find the highlighted column — closest to current member count
-  const highlightedSize =
-    priceScenarios.length > 0
-      ? priceScenarios.reduce((prev, curr) =>
-          Math.abs(curr.size - activeMemberCount) <
-          Math.abs(prev.size - activeMemberCount)
-            ? curr
-            : prev,
-        ).size
-      : null;
 
   return (
-    <div>
-      {/* Hero */}
-      <section className="relative -mt-nav-h flex min-h-[480px] items-end overflow-hidden [--on-surface:#fff] [--on-surface-muted:rgba(255,255,255,0.72)]">
-        {/* Background image */}
-        {/* eslint-disable-next-line @next/next/no-img-element */}
-        <img
-          src={heroImage}
-          alt=""
-          aria-hidden="true"
-          className="absolute inset-0 h-full w-full object-cover"
+    <div className="flex min-h-12 items-center justify-center rounded-[14px] bg-muted px-4 py-3 text-sm font-semibold text-muted-foreground">
+      {ctaLabel(joinState)}
+    </div>
+  );
+}
+
+function ThemeChips({ themes }: { themes: string[] }) {
+  if (themes.length === 0) return null;
+
+  return (
+    <div className="mb-4 flex flex-wrap gap-2">
+      {themes.map((theme) => {
+        const themeData = getTheme(theme);
+        return (
+          <span
+            key={theme}
+            className="inline-flex rounded-full bg-surface-low px-3.5 py-1.5 text-[0.84rem] font-medium text-foreground"
+          >
+            {themeData?.label ?? theme}
+          </span>
+        );
+      })}
+    </div>
+  );
+}
+
+function AvatarGroupVisual({ children }: { children: ReactNode }) {
+  return <div className="flex -space-x-2.5">{children}</div>;
+}
+
+function MemberAvatars({ members }: { members: PublicRequestDetailViewModel["members"] }) {
+  return (
+    <AvatarGroupVisual>
+      {members.slice(0, 5).map((member, index) => (
+        <Avatar
+          key={member.id}
+          className="size-[42px] border-[2.5px] border-background shadow-sm"
+          title={member.displayName}
+        >
+          {member.avatarUrl ? <AvatarImage src={member.avatarUrl} alt={member.displayName} /> : null}
+          <AvatarFallback className={cn("font-semibold", avatarFallbackClassNames[index % avatarFallbackClassNames.length])}>
+            {member.initials}
+          </AvatarFallback>
+        </Avatar>
+      ))}
+    </AvatarGroupVisual>
+  );
+}
+
+function DecisionCard({
+  requestId,
+  viewModel,
+}: {
+  requestId: string;
+  viewModel: PublicRequestDetailViewModel;
+}) {
+  const price = formatPrice(viewModel.pricePerPersonRub);
+
+  return (
+    <aside className="lg:sticky lg:top-[108px]">
+      <div className="rounded-[22px] border border-border bg-surface-high p-6 shadow-glass">
+        <div className="font-display text-[2rem] font-bold leading-none tracking-[-0.02em] text-foreground">
+          {price}{" "}
+          {viewModel.pricePerPersonRub ? (
+            <small className="text-base font-medium text-muted-foreground">/ с человека</small>
+          ) : null}
+        </div>
+        <p className="mt-3 text-sm leading-[1.55] text-muted-foreground">
+          Добор открыт: группа сейчас {viewModel.memberCount}{" "}
+          {pluralize(viewModel.memberCount, "человек", "человека", "человек")}. Финальную цену предложат гиды.
+        </p>
+        <div className="mt-5 hidden lg:block">
+          <JoinCta requestId={requestId} joinState={viewModel.joinState} />
+        </div>
+        <div className="mt-4 flex items-center gap-2 border-t border-border pt-4 text-[0.84rem] text-muted-foreground">
+          <Eye className="size-4 text-primary" aria-hidden="true" />
+          Гиды уже видят этот запрос
+        </div>
+      </div>
+    </aside>
+  );
+}
+
+export function PublicRequestDetailScreen({ requestId, viewModel }: PublicRequestDetailScreenProps) {
+  const price = formatPrice(viewModel.pricePerPersonRub);
+  const hasAbout = viewModel.notes.trim().length > 0;
+
+  return (
+    <div className="bg-surface pb-24 lg:pb-0">
+      <section className="relative h-[240px] overflow-hidden bg-foreground md:h-[300px]">
+        <Image
+          src={viewModel.cityImageUrl}
+          alt={viewModel.title}
+          fill
+          priority
+          sizes="100vw"
+          className="object-cover"
         />
-        {/* Gradient overlay */}
         <div
-          className="absolute inset-0 pointer-events-none bg-gradient-to-t from-[rgba(15,23,42,0.78)] to-[rgba(15,23,42,0.06)]"
+          className="absolute inset-0 bg-gradient-to-b from-foreground/10 via-transparent to-foreground/80"
           aria-hidden="true"
         />
-        <div className="relative z-[2] mx-auto w-full max-w-page px-[clamp(20px,4vw,48px)] pb-14 pt-[calc(var(--nav-h)+48px)] [--outline-variant:rgba(255,255,255,0.20)]">
-          <div className="max-w-[760px]">
-            <p className="mb-3 font-sans text-[0.6875rem] font-medium uppercase tracking-[0.18em] text-white/75">
-              {heroLabel}
-            </p>
-            <h1 className="font-display text-[clamp(2.4rem,5vw,3rem)] font-semibold leading-[1.04] text-white">
-              {title}
+        <div className="absolute inset-x-0 bottom-0 z-[2]">
+          <div className="mx-auto w-full max-w-page px-[clamp(20px,4vw,48px)] pb-6">
+            <span className="inline-flex items-center gap-2 rounded-full border border-primary-foreground/20 bg-primary-foreground/15 px-3.5 py-1.5 text-[0.82rem] font-medium text-primary-foreground backdrop-blur-[8px]">
+              <span className="size-2 rounded-full bg-success shadow-[0_0_0_3px_rgba(127,227,182,0.25)]" aria-hidden="true" />
+              Сборная группа
+            </span>
+            <h1 className="mt-3 font-display text-[clamp(2.1rem,5vw,2.9rem)] font-bold leading-[1.05] tracking-[-0.02em] text-primary-foreground">
+              {viewModel.title}
             </h1>
-            {description && (
-              <p className="mt-4 text-base leading-[1.65] text-white/80">
-                {description}
-              </p>
-            )}
+            <p className="mt-1 text-sm text-primary-foreground/80">{viewModel.regionLabel}</p>
           </div>
         </div>
       </section>
 
-      {/* Content */}
-      <section className="bg-surface py-[56px] pb-20">
-        <div className="mx-auto w-full max-w-page px-[clamp(20px,4vw,48px)]">
-          <div className="grid items-start gap-8 lg:grid-cols-[minmax(0,2fr)_minmax(0,1fr)]">
-            {/* Left column */}
-            <div>
-              {/* Status card */}
-              <article className="mb-6 rounded-card bg-surface-high p-7 shadow-card">
-                <div className="mb-[18px] flex flex-col justify-between gap-4 sm:flex-row sm:items-center">
-                  <h2 className="text-base font-semibold text-on-surface">
-                    Участники группы
-                  </h2>
-                  <div className="flex items-center gap-2.5">
-                    {/* Avatar stack */}
-                    {visibleMembers.length > 0 && (
-                      <div className="flex items-center">
-                        {visibleMembers.map((m, i) => (
-                          <Avatar
-                            key={m.id}
-                            className={`size-7 border-2 border-surface-high ${i === 0 ? "ml-0" : "-ml-1.5"}`}
-                            title={m.displayName}
-                          >
-                            <AvatarImage
-                              src={m.avatarUrl ?? undefined}
-                              alt={m.displayName}
-                            />
-                            <AvatarFallback className="bg-surface-low text-[0.5625rem] font-semibold">
-                              {m.initials}
-                            </AvatarFallback>
-                          </Avatar>
-                        ))}
-                        {overflowCount > 0 && (
-                          <Avatar
-                            className="size-7 -ml-1.5 border-2 border-surface-high"
-                            title={`Ещё ${overflowCount} участник(а)`}
-                          >
-                            <AvatarFallback className="bg-surface-low text-[0.5625rem] font-semibold">
-                              +{overflowCount}
-                            </AvatarFallback>
-                          </Avatar>
-                        )}
-                      </div>
-                    )}
-                    <span className="text-[0.875rem] text-on-surface-muted">
-                      {isOpenGroup
-                        ? memberCountLabel
-                        : `${request.group.sizeCurrent} из ${request.group.sizeTarget} мест занято`}
-                    </span>
-                  </div>
-                </div>
+      <div className="mx-auto grid w-full max-w-page grid-cols-1 gap-8 px-[clamp(20px,4vw,48px)] py-8 lg:grid-cols-[minmax(0,1fr)_380px] lg:items-start lg:gap-9 lg:pb-24">
+        <main>
+          <div className="mb-8 flex flex-wrap gap-2.5">
+            <span className="inline-flex items-center gap-2 rounded-xl border border-border bg-surface-high px-3.5 py-2 text-sm font-medium text-foreground shadow-sm">
+              <CalendarDays className="size-4 text-primary" aria-hidden="true" />
+              {viewModel.dateLabel}
+            </span>
+            {viewModel.timeLabel ? (
+              <span className="inline-flex items-center gap-2 rounded-xl border border-border bg-surface-high px-3.5 py-2 text-sm font-medium text-foreground shadow-sm">
+                <Clock3 className="size-4 text-primary" aria-hidden="true" />
+                {viewModel.timeLabel}
+              </span>
+            ) : null}
+            {viewModel.datesFlexible ? (
+              <span className="inline-flex items-center gap-2 rounded-xl border border-primary/20 bg-primary/10 px-3.5 py-2 text-sm font-medium text-primary shadow-sm">
+                <ListChecks className="size-4" aria-hidden="true" />
+                Гибкие даты
+              </span>
+            ) : null}
+          </div>
 
-                {/* Progress bar */}
-                {fillPct != null ? (
-                  <Progress value={fillPct} className="mb-[22px] h-1" />
-                ) : null}
-
-                {/* Meta grid */}
-                <dl className="grid gap-x-5 gap-y-[18px] sm:grid-cols-2">
-                  <div>
-                    <dt className="mb-1.5 text-[0.75rem] font-semibold uppercase tracking-[0.14em] text-on-surface-muted">
-                      Даты
-                    </dt>
-                    <dd className="text-[0.9375rem] font-medium text-on-surface">
-                      {request.dateRangeLabel}
-                    </dd>
-                  </div>
-                  <div>
-                    <dt className="mb-1.5 text-[0.75rem] font-semibold uppercase tracking-[0.14em] text-on-surface-muted">
-                      Направление
-                    </dt>
-                    <dd className="text-[0.9375rem] font-medium text-on-surface">
-                      {request.destinationLabel.split(",")[0].trim()}
-                    </dd>
-                  </div>
-                  <div>
-                    <dt className="mb-1.5 text-[0.75rem] font-semibold uppercase tracking-[0.14em] text-on-surface-muted">
-                      Бюджет
-                    </dt>
-                    <dd className="text-[0.9375rem] font-medium text-on-surface">
-                      {formatPrice(request.budgetPerPersonRub)}
-                    </dd>
-                  </div>
-                  <div>
-                    <dt className="mb-1.5 text-[0.75rem] font-semibold uppercase tracking-[0.14em] text-on-surface-muted">
-                      Формат
-                    </dt>
-                    <dd className="text-[0.9375rem] font-medium text-on-surface">
-                      {request.group.openToMoreMembers
-                        ? "Открыта запись"
-                        : "Группа закрыта"}
-                    </dd>
-                  </div>
-                </dl>
-              </article>
-
-              {/* Price scenarios */}
-              {priceScenarios.length > 0 && (
-                <div className="mb-6">
-                  <p className="mb-3 font-sans text-[0.6875rem] font-medium uppercase tracking-[0.18em] text-muted-foreground">
-                    Стоимость на человека
-                  </p>
-                  <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-5">
-                    {priceScenarios.map(({ size, pricePerPerson }) => (
-                      <div
-                        key={size}
-                        className={`rounded-card border px-4 py-3 text-center shadow-card ${
-                          highlightedSize === size
-                            ? "border-primary/30 bg-primary/[0.08]"
-                            : "border-outline-variant/30 bg-surface-high"
-                        }`}
-                      >
-                        <div className="text-sm font-medium text-muted-foreground">
-                          {size} чел.
-                        </div>
-                        <div className="mt-1 text-base font-semibold text-foreground">
-                          {formatRub(pricePerPerson)}
-                        </div>
-                      </div>
-                    ))}
-                  </div>
-                </div>
-              )}
-
-              {/* О маршруте */}
-              <section className="pt-6">
-                <h2 className="mb-[14px] font-display text-[1.75rem] leading-[1.1] text-on-surface">
-                  О маршруте
-                </h2>
-                <p className="text-[0.9375rem] leading-[1.72] text-on-surface-muted">
-                  {aboutText}
+          <section className="mb-8">
+            <h2 className="mb-3.5 text-[0.8rem] font-semibold uppercase tracking-[0.08em] text-muted-foreground">
+              Кто едет
+            </h2>
+            <div className="rounded-[22px] border border-border bg-surface-high p-6 shadow-sm">
+              <div className="flex flex-wrap items-center justify-between gap-4">
+                <p className="text-[1.2rem] font-semibold text-foreground">
+                  В группе сейчас {viewModel.memberCount}{" "}
+                  {pluralize(viewModel.memberCount, "человек", "человека", "человек")}
                 </p>
-              </section>
+                <MemberAvatars members={viewModel.members} />
+              </div>
+              <p className="mt-3.5 text-sm text-muted-foreground">
+                Организатор — <b className="font-semibold text-foreground">{viewModel.organizerName}</b>
+              </p>
+              <div className="mt-3.5 inline-flex items-center gap-1.5 text-[0.84rem] font-medium text-primary">
+                <UserPlus className="size-4" aria-hidden="true" />
+                Группа открыта — можно присоединиться
+              </div>
+            </div>
+          </section>
 
-              {/* Что запланировано */}
-              {request.highlights.length > 1 && (
-                <section className="pt-8">
-                  <h2 className="mb-[14px] font-display text-[1.75rem] leading-[1.1] text-on-surface">
-                    Что запланировано
-                  </h2>
-                  <ul className="grid gap-3">
-                    {request.highlights.map((item, i) => (
-                      <li
-                        key={i}
-                        className="text-[0.9375rem] leading-[1.72] text-on-surface-muted"
-                      >
-                        {item}
-                      </li>
-                    ))}
-                  </ul>
-                </section>
+          {hasAbout ? (
+            <section className="mb-8">
+              <h2 className="mb-3.5 text-[0.8rem] font-semibold uppercase tracking-[0.08em] text-muted-foreground">
+                О поездке
+              </h2>
+              <ThemeChips themes={viewModel.themes} />
+              <p className="max-w-[60ch] text-[0.97rem] leading-[1.7] text-foreground/85">{viewModel.notes}</p>
+            </section>
+          ) : null}
+
+          <section className="mb-8">
+            <h2 className="mb-3.5 text-[0.8rem] font-semibold uppercase tracking-[0.08em] text-muted-foreground">
+              Как это работает
+            </h2>
+            <div className="grid gap-3.5 sm:grid-cols-3">
+              {["Присоединяешься к группе", "Гиды предлагают условия и цену", "Группа подтверждает бронь"].map(
+                (step, index) => (
+                  <div key={step} className="rounded-2xl border border-border bg-surface-high p-4 shadow-sm">
+                    <div className="mb-2.5 flex size-7 items-center justify-center rounded-full bg-primary/10 text-sm font-bold text-primary">
+                      {index + 1}
+                    </div>
+                    <p className="text-sm leading-[1.45] text-foreground">{step}</p>
+                  </div>
+                ),
               )}
             </div>
+          </section>
 
-            {/* Right column — sticky offer card */}
-            <aside>
-              <div className="sticky top-24 rounded-card bg-surface-high p-7 shadow-card">
-                {/* Price */}
-                <div className="mb-2 font-display text-[2.5rem] leading-none text-on-surface">
-                  {formatPrice(request.budgetPerPersonRub)}
-                </div>
-                <p className="mb-5 text-[0.875rem] text-on-surface-muted">
-                  на человека при заполнении группы
-                </p>
+          <section>
+            <div className="border-t border-border">
+              {faqItems.map((item) => (
+                <details key={item.question} className="group border-b border-border">
+                  <summary className="flex cursor-pointer list-none items-center justify-between gap-4 py-4 text-left text-[0.97rem] font-medium text-foreground marker:hidden">
+                    {item.question}
+                    <ChevronDown className="size-4 text-muted-foreground transition-transform group-open:rotate-180" aria-hidden="true" />
+                  </summary>
+                  <p className="pb-4 text-sm leading-[1.6] text-muted-foreground">{item.answer}</p>
+                </details>
+              ))}
+            </div>
+          </section>
+        </main>
 
-                {/* Join / Member state */}
-                {isMember ? (
-                  <PostJoinPanel />
-                ) : showJoinButton ? (
-                  <JoinGroupButton
-                    requestId={request.id}
-                    className="w-full"
-                    disabled={
-                      !isOpenGroup &&
-                      request.group.sizeCurrent >= request.group.sizeTarget
-                    }
-                  />
-                ) : !currentUserId ? (
-                  <Button asChild className="w-full justify-center">
-                    <Link href={`/auth?next=/requests/${request.id}`}>
-                      Войти и присоединиться
-                    </Link>
-                  </Button>
-                ) : null}
+        <DecisionCard requestId={requestId} viewModel={viewModel} />
+      </div>
 
-                {/* Divider */}
-                <div className="my-[22px] h-px bg-outline-variant/30" />
-
-                {/* Guide offers */}
-                <p className="mb-3 font-sans text-[0.6875rem] font-medium uppercase tracking-[0.18em] text-muted-foreground">
-                  Офферы гидов
-                </p>
-                <div className="grid gap-3">
-                  {offers && offers.length > 0 ? (
-                    offers.map((offer) => (
-                      <article
-                        key={offer.id}
-                        className="grid gap-3 rounded-card bg-background/70 p-4 shadow-card"
-                      >
-                        <div className="flex items-center justify-between gap-3">
-                          <div className="flex items-center gap-3">
-                            <Avatar className="size-[38px]">
-                              <AvatarFallback className="bg-surface-low text-[0.75rem] font-semibold text-primary">
-                                {offer.guideInitials}
-                              </AvatarFallback>
-                            </Avatar>
-                            <div>
-                              <strong className="block text-[0.9375rem] text-on-surface">
-                                {offer.guideName}
-                              </strong>
-                              {offer.rating && (
-                                <span className="text-[0.8125rem] text-on-surface-muted">
-                                  {offer.rating} ★
-                                </span>
-                              )}
-                            </div>
-                          </div>
-                          <span className="text-[0.875rem] font-semibold text-on-surface">
-                            {new Intl.NumberFormat("ru-RU").format(
-                              offer.priceTotalRub,
-                            )}{" "}
-                            ₽ / группа
-                          </span>
-                        </div>
-                        <Button
-                          asChild
-                          variant="outline"
-                          className="justify-center"
-                        >
-                          <Link href={offer.href ?? "#"}>Посмотреть</Link>
-                        </Button>
-                      </article>
-                    ))
-                  ) : (
-                    <p className="text-[0.9375rem] leading-[1.65] text-on-surface-muted">
-                      Пока нет предложений. Запрос уже виден гидам в системе.
-                    </p>
-                  )}
-                </div>
-              </div>
-            </aside>
-          </div>
+      <div className="fixed inset-x-0 bottom-0 z-50 flex items-center gap-3 border-t border-border bg-surface-high px-4 py-3 shadow-[0_-6px_24px_rgba(10,40,28,0.10)] lg:hidden">
+        <div className="shrink-0 font-display text-lg font-bold text-foreground">
+          {price}
+          {viewModel.pricePerPersonRub ? (
+            <small className="block text-xs font-medium text-muted-foreground">с человека</small>
+          ) : null}
         </div>
-      </section>
+        <div className="min-w-0 flex-1">
+          <JoinCta requestId={requestId} joinState={viewModel.joinState} compact />
+        </div>
+      </div>
     </div>
   );
 }

--- a/src/lib/city-image.test.ts
+++ b/src/lib/city-image.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, it } from "vitest";
+
+import { cityImage } from "./city-image";
+
+describe("cityImage", () => {
+  it("returns a deterministic online placeholder URL for a destination", () => {
+    const first = cityImage("Элиста");
+    const second = cityImage("Элиста");
+
+    expect(first).toBe(second);
+    expect(first).toMatch(/^https:\/\/images\.unsplash\.com\//);
+  });
+
+  it("normalizes destination case and surrounding whitespace", () => {
+    expect(cityImage("  ЭЛИСТА  ")).toBe(cityImage("элиста"));
+  });
+});

--- a/src/lib/city-image.ts
+++ b/src/lib/city-image.ts
@@ -1,0 +1,22 @@
+const CITY_IMAGES = [
+  "https://images.unsplash.com/photo-1469474968028-56623f02e42e?auto=format&fit=crop&w=1800&q=80",
+  "https://images.unsplash.com/photo-1500530855697-b586d89ba3ee?auto=format&fit=crop&w=1800&q=80",
+  "https://images.unsplash.com/photo-1500534314209-a25ddb2bd429?auto=format&fit=crop&w=1800&q=80",
+  "https://images.unsplash.com/photo-1470770903676-69b98201ea1c?auto=format&fit=crop&w=1800&q=80",
+  "https://images.unsplash.com/photo-1519681393784-d120267933ba?auto=format&fit=crop&w=1800&q=80",
+  "https://images.unsplash.com/photo-1518005020951-eccb494ad742?auto=format&fit=crop&w=1800&q=80",
+  "https://images.unsplash.com/photo-1527489377706-5bf97e608852?auto=format&fit=crop&w=1800&q=80",
+] as const;
+
+function hashDestination(destination: string): number {
+  return Array.from(destination.trim().toLocaleLowerCase("ru-RU")).reduce(
+    (hash, char) => (hash * 31 + char.charCodeAt(0)) >>> 0,
+    0,
+  );
+}
+
+export function cityImage(destination: string): string {
+  // TODO: replace with curated per-city CDN
+  const hash = hashDestination(destination);
+  return CITY_IMAGES[hash % CITY_IMAGES.length];
+}


### PR DESCRIPTION
Full redesign of the public request detail page to the approved mockup: server view-model, 5 content blocks + sticky decision card, сборная-only (private→notFound), city-image helper. Removes dead sections (scenario table, «мест занято», «О маршруте»/«Что запланировано»). Adds .cursor product-canon + request-detail rules. Gates green (762 tests), context7-verified. Hero height-collapse fixed (fill→sized image).