### PR TITLE
Design refresh — canonical Rubik light system (Phase 1: spine screens)

### DIFF
--- a/.cursorignore
+++ b/.cursorignore
@@ -10,4 +10,4 @@ coverage/
 .claude/prompts/out/
 .claude/worktrees/
 _archive/
-public/
+/public/

--- a/docs/design/DESIGN-SYSTEM.md
+++ b/docs/design/DESIGN-SYSTEM.md
@@ -1,0 +1,23 @@
+# Provodnik Redesign — Canonical Design System
+Single source of truth. Derived from the approved mockup 06-font-rubik. The look is LIGHT, soft, clean, high-contrast — solid white cards on a soft green-white surface. NO dark content backgrounds, NO glassmorphism / backdrop-blur. Font = Rubik everywhere (already the app font).
+
+## Tokens (already in src/app/globals.css)
+- Page background: var(--surface) #f7faf6. Cards: var(--surface-lowest) #fff. Soft-tint blocks: var(--brand-50) #eef7f2. Low surface: var(--surface-low) #edf2ee.
+- Text: ink var(--on-surface) #16241d; muted var(--on-surface-muted) #5d7669; ink-2 #47584e.
+- Brand: var(--primary) #1f7a5c, --primary-hover #1a6149, brand-50..950 (brand-950 #0a271e). Accent: var(--gold) #e0a126.
+- Border: var(--outline) #dce5df. Radii: cards var(--card-radius) 24px, nav/pills var(--pill-radius) 18px, buttons/inputs 14px, chips/steps 14-16px, tags/badges 30px (pill). Shadows: var(--card-shadow) 0 4px 24px #0a281c14; var(--lift-shadow) 0 18px 44px -22px #0a281c33.
+
+## Component recipes (match these exactly)
+- **Card**: bg #fff, border 1px var(--outline), rounded-[24px], shadow card-shadow, padding ~26px. Sticky/elevated: lift-shadow.
+- **Primary button (.btn / CTA)**: bg var(--primary), text #fff, Rubik font-semibold, px-24 py-15, rounded-[14px]; hover bg var(--primary-hover) + translateY(-2px) + soft shadow. ONE primary CTA per view.
+- **Inputs**: bg #fff, border 1px var(--outline), rounded-[14px], dark ink text, brand focus ring. Keep icons + password show/hide.
+- **Eyebrow/label**: Rubik font-semibold, 12px, UPPERCASE, letter-spacing .1em, color var(--primary).
+- **Lead heading**: Rubik font-semibold, clamp(30px,4.4vw,44px), line-height 1.04, ink; a muted span for the secondary clause.
+- **Nav**: white rounded card — bg #fff, border outline, rounded-[18px], shadow card-shadow.
+- **Hero/banner** (where a page has one): rounded-[28px] image, green gradient overlay linear-gradient(180deg, rgba(10,39,30,.12), rgba(10,39,30,.66)), white badge pill, big white Rubik title.
+- **Tag/chip**: bg var(--brand-50), color var(--primary), font-semibold, rounded-pill. **Momentum/live dot**: var(--gold), gentle pulse.
+- **Avatar stack**: overlapping circles, 2px white border, brand-scale fills, host gets a gold ring.
+- **Footer**: bg var(--brand-950) #0a271e, rounded top, muted text, links hover gold.
+
+## Principles (Jobs lens)
+One job per screen · one primary CTA · cut the non-essential · surface momentum/social-proof · high contrast (dark ink on light) · generous whitespace · brand greens with the single gold accent.

--- a/src/app/(auth)/auth/page.tsx
+++ b/src/app/(auth)/auth/page.tsx
@@ -55,11 +55,8 @@ export default async function AuthPage({ searchParams }: AuthPageProps) {
   }
 
   return (
-    <section className="relative flex min-h-screen items-center justify-center overflow-hidden px-[clamp(20px,4vw,48px)] py-16">
-      {/* Background layers */}
-      <div className="pointer-events-none absolute inset-0 bg-gradient-to-br from-brand-950 via-brand-900 to-brand-950" />
-      <div className="pointer-events-none absolute inset-x-1/4 top-0 h-1/2 rounded-full bg-primary/20 blur-3xl" />
-      <div className="pointer-events-none absolute bottom-0 left-0 right-0 h-64 bg-gradient-to-t from-primary/10 to-transparent" />
+    <section className="relative flex min-h-screen items-center justify-center overflow-hidden bg-[var(--surface)] px-[clamp(20px,4vw,48px)] py-16">
+      <div className="pointer-events-none absolute inset-x-0 top-[-18rem] mx-auto h-[34rem] max-w-[46rem] rounded-full bg-[radial-gradient(circle_at_center,rgba(214,236,224,0.72),rgba(238,247,242,0.28)_48%,rgba(247,250,246,0)_72%)]" />
       <AuthEntryScreen
         role={signupRole}
         next={next}

--- a/src/app/(protected)/admin/dashboard/page.tsx
+++ b/src/app/(protected)/admin/dashboard/page.tsx
@@ -35,16 +35,23 @@ export default async function AdminDashboardPage() {
   const stats = await getAdminDashboardStats();
 
   return (
-    <div className="space-y-8">
-      <div className="space-y-3">
-        <Badge variant="outline">Панель администратора</Badge>
-        <h1 className="text-3xl font-semibold tracking-tight text-foreground">
-          Обзор модерации
-        </h1>
-        <p className="max-w-3xl text-sm text-muted-foreground">
-          Следите за очередью проверки, открытыми спорами и общей нагрузкой на
-          админ-панель.
-        </p>
+    <div className="space-y-8 rounded-[28px] bg-[var(--surface)] p-4 text-[var(--on-surface)] sm:p-6 lg:p-8">
+      <div className="space-y-4">
+        <Badge
+          variant="outline"
+          className="w-fit rounded-[30px] border-[var(--outline)] bg-[var(--brand-50)] px-4 py-1.5 text-xs font-semibold uppercase tracking-[0.1em] text-[var(--primary)]"
+        >
+          Панель администратора
+        </Badge>
+        <div className="space-y-3">
+          <h1 className="max-w-3xl text-4xl font-semibold leading-[1.04] tracking-[-0.03em] text-[var(--on-surface)] md:text-5xl">
+            Обзор модерации
+          </h1>
+          <p className="max-w-3xl text-base leading-7 text-[var(--on-surface-muted)]">
+            Следите за очередью проверки, открытыми спорами и общей нагрузкой на
+            админ-панель.
+          </p>
+        </div>
       </div>
 
       <div className="grid gap-4 md:grid-cols-2 xl:grid-cols-4">
@@ -54,16 +61,18 @@ export default async function AdminDashboardPage() {
             <Link
               key={card.key}
               href={card.href}
-              className="rounded-[1.75rem] border border-border/70 bg-card p-6 shadow-card transition-transform hover:-translate-y-0.5"
+              className="group rounded-[20px] border border-[var(--outline)] bg-[var(--surface-lowest)] p-6 text-[var(--on-surface)] [box-shadow:var(--card-shadow)] transition hover:-translate-y-0.5 hover:border-[var(--primary)] focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[var(--primary)]"
             >
-              <div className="text-sm text-muted-foreground">{card.label}</div>
-              <div className="mt-3 text-4xl font-semibold tracking-tight text-foreground">
+              <div className="text-xs font-semibold uppercase tracking-[0.1em] text-[var(--primary)]">
+                {card.label}
+              </div>
+              <div className="mt-4 text-4xl font-semibold tracking-[-0.04em] text-[var(--on-surface)]">
                 {stats[card.key]}
               </div>
-              <div className="mt-2 text-xs text-muted-foreground">
+              <div className="mt-3 text-sm font-medium text-[var(--on-surface-muted)]">
                 {delta > 0 ? `+${delta}` : delta} за неделю
               </div>
-              <div className="mt-4 text-sm font-medium text-primary">
+              <div className="mt-5 text-sm font-semibold text-[var(--primary)] transition-colors group-hover:text-[var(--primary-hover)]">
                 Открыть раздел
               </div>
             </Link>
@@ -74,41 +83,65 @@ export default async function AdminDashboardPage() {
       <div className="grid gap-4 lg:grid-cols-3">
         <Link
           href="/admin/guides"
-          className="rounded-[1.75rem] border border-border/70 bg-card p-6 shadow-card"
+          className="group rounded-[24px] border border-[var(--outline)] bg-[var(--surface-lowest)] p-6 [box-shadow:var(--card-shadow)] transition hover:-translate-y-0.5 hover:border-[var(--primary)] focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[var(--primary)]"
         >
-          <div className="text-sm font-medium text-foreground">
-            Гиды ждут проверки
+          <div className="flex items-start justify-between gap-4">
+            <div className="text-xs font-semibold uppercase tracking-[0.1em] text-[var(--primary)]">
+              Гиды ждут проверки
+            </div>
+            <span className="rounded-[30px] bg-[var(--gold)]/15 px-3 py-1 text-sm font-semibold text-[var(--on-surface)]">
+              {stats.pendingGuideApplications}
+            </span>
           </div>
-          <p className="mt-2 text-sm text-muted-foreground">
+          <p className="mt-4 text-sm leading-6 text-[var(--on-surface-muted)]">
             Сейчас в очереди {stats.pendingGuideApplications} анкет. Проверьте
             документы и статус верификации.
           </p>
+          <div className="mt-5 text-sm font-semibold text-[var(--primary)] transition-colors group-hover:text-[var(--primary-hover)]">
+            Перейти к проверке
+          </div>
         </Link>
 
         <Link
           href="/admin/listings"
-          className="rounded-[1.75rem] border border-border/70 bg-card p-6 shadow-card"
+          className="group rounded-[24px] border border-[var(--outline)] bg-[var(--surface-lowest)] p-6 [box-shadow:var(--card-shadow)] transition hover:-translate-y-0.5 hover:border-[var(--primary)] focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[var(--primary)]"
         >
-          <div className="text-sm font-medium text-foreground">
-            Листинги на модерации
+          <div className="flex items-start justify-between gap-4">
+            <div className="text-xs font-semibold uppercase tracking-[0.1em] text-[var(--primary)]">
+              Листинги на модерации
+            </div>
+            <span className="rounded-[30px] bg-[var(--gold)]/15 px-3 py-1 text-sm font-semibold text-[var(--on-surface)]">
+              {stats.pendingListingReviews}
+            </span>
           </div>
-          <p className="mt-2 text-sm text-muted-foreground">
+          <p className="mt-4 text-sm leading-6 text-[var(--on-surface-muted)]">
             В проверке {stats.pendingListingReviews} предложений. Подтвердите
             публикацию или отклоните проблемные карточки.
           </p>
+          <div className="mt-5 text-sm font-semibold text-[var(--primary)] transition-colors group-hover:text-[var(--primary-hover)]">
+            Открыть очередь
+          </div>
         </Link>
 
         <Link
           href="/admin/disputes"
-          className="rounded-[1.75rem] border border-border/70 bg-card p-6 shadow-card"
+          className="group rounded-[24px] border border-[var(--outline)] bg-[var(--surface-lowest)] p-6 [box-shadow:var(--card-shadow)] transition hover:-translate-y-0.5 hover:border-[var(--primary)] focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[var(--primary)]"
         >
-          <div className="text-sm font-medium text-foreground">
-            Очередь споров
+          <div className="flex items-start justify-between gap-4">
+            <div className="text-xs font-semibold uppercase tracking-[0.1em] text-[var(--primary)]">
+              Очередь споров
+            </div>
+            <span className="rounded-[30px] bg-[var(--gold)]/15 px-3 py-1 text-sm font-semibold text-[var(--on-surface)]">
+              {stats.openDisputes}
+            </span>
           </div>
-          <p className="mt-2 text-sm text-muted-foreground">
+          <p className="mt-4 text-sm leading-6 text-[var(--on-surface-muted)]">
             Открытых кейсов: {stats.openDisputes}. Раздел споров остается
             отдельным рабочим потоком.
           </p>
+          <div className="mt-5 text-sm font-semibold text-[var(--primary)] transition-colors group-hover:text-[var(--primary-hover)]">
+            Разобрать споры
+          </div>
         </Link>
       </div>
     </div>

--- a/src/app/(site)/become-a-guide/page.tsx
+++ b/src/app/(site)/become-a-guide/page.tsx
@@ -1,5 +1,13 @@
 import type { Metadata } from "next";
 import Link from "next/link";
+import {
+  CalendarClock,
+  HandCoins,
+  ShieldCheck,
+  SlidersHorizontal,
+  UserRoundSearch,
+  WalletCards,
+} from "lucide-react";
 
 export const metadata: Metadata = {
   title: "Стать гидом",
@@ -10,61 +18,84 @@ const VALUE_PROPS = [
     title: "Большая часть дохода остаётся вам",
     description:
       "Вы оставляете себе большую часть выручки. Никаких скрытых сборов и платных подписок.",
+    Icon: WalletCards,
   },
   {
     title: "Эластичность аудитории",
     description: "Выбираете комфортное для вас количество людей в группе",
+    Icon: SlidersHorizontal,
   },
   {
     title: "Принцип торга",
     description:
       "Выбираете подходящую вам цену за человека в группе или предлагаете в ответ свою",
+    Icon: HandCoins,
   },
   {
     title: "Время и комфорт",
     description: "Вы выбираете какой запрос подходит вам по дате и времени экскурсии",
+    Icon: CalendarClock,
   },
   {
     title: "Модерация за 24–48 часов",
     description:
       "После заполнения анкеты и загрузки документов мы проверяем профиль в течение 1–2 рабочих дней и открываем доступ к запросам.",
+    Icon: ShieldCheck,
   },
   {
     title: "Спрос от реальных путешественников",
     description:
       "Запросы поступают напрямую от путешественников с подтверждёнными контактами — вы видите дату, город и количество людей перед тем, как откликнуться.",
+    Icon: UserRoundSearch,
   },
 ] as const;
 
 export default function BecomeAGuidePage() {
   return (
-    <article className="mx-auto w-full max-w-2xl px-[clamp(20px,4vw,48px)] py-16">
-      <h1 className="mb-4 font-display text-[clamp(1.75rem,4vw,2.25rem)] font-semibold leading-[1.2] text-foreground">
-        Станьте гидом на Проводнике
-      </h1>
-      <p className="mb-10 text-base text-muted-foreground">
-        Размещайте свои экскурсии, отвечайте на запросы путешественников и работайте в удобном вам ритме.
-      </p>
-
-      <div className="mb-10 space-y-4">
-        {VALUE_PROPS.map((prop) => (
-          <div
-            key={prop.title}
-            className="rounded-xl border border-border/70 bg-card/90 p-5"
+    <article className="bg-[var(--surface)] font-display">
+      <div className="mx-auto flex w-full max-w-6xl flex-col gap-14 px-[clamp(20px,4vw,48px)] py-16 md:py-24">
+        <section className="max-w-3xl">
+          <h1 className="mb-5 text-[clamp(2.25rem,6vw,4.75rem)] font-semibold leading-[0.98] tracking-[-0.04em] text-[var(--on-surface)]">
+            Станьте гидом на Проводнике
+          </h1>
+          <p className="mb-8 max-w-2xl text-lg leading-8 text-[var(--on-surface-muted)] md:text-xl">
+            Размещайте свои экскурсии, отвечайте на запросы путешественников и работайте в удобном вам ритме.
+          </p>
+          <Link
+            href="/auth?role=guide"
+            className="inline-flex min-h-14 items-center justify-center rounded-[14px] bg-[var(--primary)] px-8 py-4 text-base font-semibold text-white shadow-[0_18px_44px_-22px_rgba(10,40,28,0.45)] transition-[background-color,box-shadow,transform] duration-200 hover:-translate-y-0.5 hover:bg-[var(--primary-hover)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--primary)] focus-visible:ring-offset-2 focus-visible:ring-offset-[var(--surface)]"
           >
-            <p className="mb-1 text-sm font-semibold text-foreground">{prop.title}</p>
-            <p className="text-sm text-muted-foreground">{prop.description}</p>
-          </div>
-        ))}
-      </div>
+            Зарегистрироваться
+          </Link>
+        </section>
 
-      <div className="flex flex-col items-center gap-3">
-        <Link
-          href="/auth?role=guide"
-          className="inline-flex items-center justify-center rounded-xl bg-primary px-6 py-3 text-sm font-semibold text-primary-foreground transition-colors hover:bg-primary/90"
-        >
-          Зарегистрироваться
-        </Link>
+        <section className="grid gap-5 md:grid-cols-2 lg:grid-cols-3">
+          {VALUE_PROPS.map(({ Icon, ...prop }) => (
+            <div
+              key={prop.title}
+              className="rounded-[var(--card-radius)] border border-[var(--outline)] bg-[var(--surface-lowest)] p-6 shadow-[var(--card-shadow)]"
+            >
+              <div className="mb-5 flex size-12 items-center justify-center rounded-2xl bg-[var(--brand-50)] text-[var(--primary)]">
+                <Icon className="size-6" aria-hidden="true" />
+              </div>
+              <p className="mb-2 text-lg font-semibold leading-6 text-[var(--on-surface)]">
+                {prop.title}
+              </p>
+              <p className="text-sm leading-6 text-[var(--on-surface-muted)]">
+                {prop.description}
+              </p>
+            </div>
+          ))}
+        </section>
+
+        <section className="flex justify-center rounded-[var(--card-radius)] border border-[var(--outline)] bg-[var(--surface-lowest)] p-6 shadow-[var(--card-shadow)] md:p-8">
+          <Link
+            href="/auth?role=guide"
+            className="inline-flex min-h-14 items-center justify-center rounded-[14px] bg-[var(--primary)] px-8 py-4 text-base font-semibold text-white shadow-[0_18px_44px_-22px_rgba(10,40,28,0.45)] transition-[background-color,box-shadow,transform] duration-200 hover:-translate-y-0.5 hover:bg-[var(--primary-hover)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--primary)] focus-visible:ring-offset-2 focus-visible:ring-offset-[var(--surface-lowest)]"
+          >
+            Зарегистрироваться
+          </Link>
+        </section>
       </div>
     </article>
   );

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -74,9 +74,9 @@
   --card-shadow: 0 4px 24px rgba(10, 40, 28, 0.08);
   --card-radius: 24px;
 
-  --font-display: var(--font-cormorant-garamond);
-  --font-ui: var(--font-dm-sans);
-  --font-serif: var(--font-cormorant-garamond);
+  --font-display: var(--font-rubik);
+  --font-ui: var(--font-rubik);
+  --font-serif: var(--font-rubik);
   --font-mono: var(--font-geist-mono);
 
   --success: #1E9E63;

--- a/src/features/auth/components/auth-entry-screen.tsx
+++ b/src/features/auth/components/auth-entry-screen.tsx
@@ -232,15 +232,18 @@ export function AuthEntryScreen({
     : "Нет аккаунта? Создать профиль";
 
   return (
-    <div className="w-[min(100%,30rem)] rounded-glass border border-glass-border bg-glass p-[clamp(1.75rem,4vw,2.5rem)] shadow-glass backdrop-blur-[20px]">
+    <div className="relative z-10 w-[min(100%,26rem)] rounded-[var(--card-radius)] border border-[var(--outline-variant)] bg-white p-8 font-sans text-[var(--on-surface)] shadow-[var(--card-shadow)]">
       <div>
         <div className="flex items-start justify-between gap-4">
           <div className="space-y-3">
             <Link
               href="/"
-              className="inline-flex w-fit items-center text-muted-foreground transition-colors duration-200 hover:text-foreground"
+              className="inline-flex w-fit items-center gap-3 text-[var(--on-surface)] transition-colors duration-200 hover:text-[var(--primary)]"
             >
-              Provodnik
+              <span className="flex size-10 items-center justify-center rounded-[14px] bg-[var(--primary)] text-base font-bold text-white">
+                P
+              </span>
+              <span className="text-xl font-bold tracking-[-0.02em]">Provodnik</span>
             </Link>
           </div>
         </div>
@@ -248,7 +251,7 @@ export function AuthEntryScreen({
 
       <div>
         {!hasSupabaseEnv() ? (
-          <div className="mt-8 flex items-start gap-3 rounded-[1.5rem] border border-border/70 bg-muted/50 px-4 py-3 text-sm leading-6 text-muted-foreground">
+          <div className="mt-8 flex items-start gap-3 rounded-[14px] border border-[var(--outline-variant)] bg-[var(--brand-50)] px-4 py-3 text-sm leading-6 text-[var(--on-surface-muted)]">
             <AlertCircle className="mt-0.5 size-4 shrink-0 text-primary" />
             <p>
               Вход временно недоступен. Напишите в поддержку.
@@ -257,7 +260,7 @@ export function AuthEntryScreen({
         ) : null}
 
         {errorCode === "missing-role" ? (
-          <div className="mt-8 flex items-start gap-3 rounded-[1.5rem] border border-destructive/20 bg-destructive/5 px-4 py-3 text-sm leading-6 text-destructive">
+          <div className="mt-8 flex items-start gap-3 rounded-[14px] border border-destructive/20 bg-destructive/5 px-4 py-3 text-sm leading-6 text-destructive">
             <AlertCircle className="mt-0.5 size-4 shrink-0" />
             <p>
               Не удалось определить роль аккаунта. Выйдите и войдите снова или
@@ -267,7 +270,7 @@ export function AuthEntryScreen({
         ) : null}
 
         {errorCode === "admin-access-denied" ? (
-          <div className="mt-8 flex items-start gap-3 rounded-[1.5rem] border border-destructive/20 bg-destructive/5 px-4 py-3 text-sm leading-6 text-destructive">
+          <div className="mt-8 flex items-start gap-3 rounded-[14px] border border-destructive/20 bg-destructive/5 px-4 py-3 text-sm leading-6 text-destructive">
             <AlertCircle className="mt-0.5 size-4 shrink-0" />
             <p>
               Для входа в админку нужен аккаунт с ролью администратора. Войдите
@@ -280,11 +283,11 @@ export function AuthEntryScreen({
           {isSignUp ? (
             <>
               <div className="grid gap-2.5">
-                <label htmlFor="full-name" className="text-sm font-medium text-foreground">
+                <label htmlFor="full-name" className="text-sm font-medium text-[var(--on-surface)]">
                   Как к вам обращаться
                 </label>
                 <div className="relative">
-                  <UserRound className="pointer-events-none absolute left-4 top-1/2 size-4 -translate-y-1/2 text-muted-foreground" />
+                  <UserRound className="pointer-events-none absolute left-4 top-1/2 size-4 -translate-y-1/2 text-[var(--on-surface-muted)]" />
                   <Input
                     id="full-name"
                     type="text"
@@ -292,16 +295,16 @@ export function AuthEntryScreen({
                     placeholder="Например, Анна Смирнова"
                     value={fullName}
                     onChange={(event) => setFullName(event.target.value)}
-                    className="min-h-[3.25rem] w-full rounded-[1.2rem] border border-input bg-surface-high/[0.78] pl-11 shadow-none focus-visible:border-ring"
+                    className="min-h-[3.25rem] w-full rounded-[14px] border border-[var(--outline-variant)] bg-white pl-11 text-[var(--on-surface)] shadow-none placeholder:text-[var(--on-surface-muted)] focus-visible:border-[var(--primary)] focus-visible:ring-3 focus-visible:ring-primary/20"
                   />
                 </div>
               </div>
               <div className="grid gap-2.5">
-                <label htmlFor="phone" className="text-sm font-medium text-foreground">
+                <label htmlFor="phone" className="text-sm font-medium text-[var(--on-surface)]">
                   Телефон (необязательно)
                 </label>
                 <div className="relative">
-                  <Phone className="pointer-events-none absolute left-4 top-1/2 size-4 -translate-y-1/2 text-muted-foreground" />
+                  <Phone className="pointer-events-none absolute left-4 top-1/2 size-4 -translate-y-1/2 text-[var(--on-surface-muted)]" />
                   <Input
                     id="phone"
                     type="tel"
@@ -309,7 +312,7 @@ export function AuthEntryScreen({
                     placeholder="+7 900 123-45-67"
                     value={phone}
                     onChange={(event) => setPhone(event.target.value)}
-                    className="min-h-[3.25rem] w-full rounded-[1.2rem] border border-input bg-surface-high/[0.78] pl-11 shadow-none focus-visible:border-ring"
+                    className="min-h-[3.25rem] w-full rounded-[14px] border border-[var(--outline-variant)] bg-white pl-11 text-[var(--on-surface)] shadow-none placeholder:text-[var(--on-surface-muted)] focus-visible:border-[var(--primary)] focus-visible:ring-3 focus-visible:ring-primary/20"
                   />
                 </div>
               </div>
@@ -317,11 +320,11 @@ export function AuthEntryScreen({
           ) : null}
 
           <div className="grid gap-2.5">
-            <label htmlFor="email" className="text-sm font-medium text-foreground">
+            <label htmlFor="email" className="text-sm font-medium text-[var(--on-surface)]">
               Email
             </label>
             <div className="relative">
-              <Mail className="pointer-events-none absolute left-4 top-1/2 size-4 -translate-y-1/2 text-muted-foreground" />
+              <Mail className="pointer-events-none absolute left-4 top-1/2 size-4 -translate-y-1/2 text-[var(--on-surface-muted)]" />
               <Input
                 id="email"
                 type="email"
@@ -329,17 +332,17 @@ export function AuthEntryScreen({
                 placeholder="you@example.com"
                 value={email}
                 onChange={(event) => setEmail(event.target.value)}
-                className="min-h-[3.25rem] w-full rounded-[1.2rem] border border-input bg-surface-high/[0.78] pl-11 shadow-none focus-visible:border-ring"
+                className="min-h-[3.25rem] w-full rounded-[14px] border border-[var(--outline-variant)] bg-white pl-11 text-[var(--on-surface)] shadow-none placeholder:text-[var(--on-surface-muted)] focus-visible:border-[var(--primary)] focus-visible:ring-3 focus-visible:ring-primary/20"
               />
             </div>
           </div>
 
           <div className="grid gap-2.5">
-            <label htmlFor="password" className="text-sm font-medium text-foreground">
+            <label htmlFor="password" className="text-sm font-medium text-[var(--on-surface)]">
               {isSignUp ? "Создайте пароль" : "Пароль"}
             </label>
             <div className="relative">
-              <LockKeyhole className="pointer-events-none absolute left-4 top-1/2 size-4 -translate-y-1/2 text-muted-foreground" />
+              <LockKeyhole className="pointer-events-none absolute left-4 top-1/2 size-4 -translate-y-1/2 text-[var(--on-surface-muted)]" />
               <Input
                 id="password"
                 type={showPassword ? "text" : "password"}
@@ -347,12 +350,12 @@ export function AuthEntryScreen({
                 placeholder={isSignUp ? "Минимум 6 символов" : "Введите пароль"}
                 value={password}
                 onChange={(event) => setPassword(event.target.value)}
-                className="min-h-[3.25rem] w-full rounded-[1.2rem] border border-input bg-surface-high/[0.78] pl-11 pr-14 shadow-none focus-visible:border-ring"
+                className="min-h-[3.25rem] w-full rounded-[14px] border border-[var(--outline-variant)] bg-white pl-11 pr-14 text-[var(--on-surface)] shadow-none placeholder:text-[var(--on-surface-muted)] focus-visible:border-[var(--primary)] focus-visible:ring-3 focus-visible:ring-primary/20"
               />
               <button
                 type="button"
                 onClick={() => setShowPassword((current) => !current)}
-                className="absolute right-4 top-1/2 inline-flex -translate-y-1/2 items-center text-muted-foreground transition-colors duration-200 hover:text-foreground"
+                className="absolute right-4 top-1/2 inline-flex -translate-y-1/2 items-center text-[var(--on-surface-muted)] transition-colors duration-200 hover:text-[var(--on-surface)]"
                 aria-label={showPassword ? "Скрыть пароль" : "Показать пароль"}
                 aria-pressed={showPassword}
               >
@@ -369,7 +372,7 @@ export function AuthEntryScreen({
             <div className="flex justify-end">
               <Link
                 href="/auth/forgot-password"
-                className="text-sm text-muted-foreground transition-colors duration-200 hover:text-foreground"
+                className="text-sm font-medium text-[var(--primary)] transition-colors duration-200 hover:underline"
               >
                 Забыли пароль?
               </Link>
@@ -377,14 +380,14 @@ export function AuthEntryScreen({
           ) : null}
 
           {error ? (
-            <div className="flex items-start gap-2 rounded-[1.4rem] border border-destructive/20 bg-destructive/5 px-4 py-3 text-sm text-destructive">
+            <div className="flex items-start gap-2 rounded-[14px] border border-destructive/20 bg-destructive/5 px-4 py-3 text-sm text-destructive">
               <AlertCircle className="mt-0.5 size-4 shrink-0" />
               <p>{error}</p>
             </div>
           ) : null}
 
           {success ? (
-            <div className="flex items-start gap-2 rounded-[1.4rem] border border-primary/15 bg-primary/5 px-4 py-3 text-sm text-foreground">
+            <div className="flex items-start gap-2 rounded-[14px] border border-primary/15 bg-[var(--brand-50)] px-4 py-3 text-sm text-[var(--on-surface)]">
               <CheckCircle2 className="mt-0.5 size-4 shrink-0 text-primary" />
               <p>{success}</p>
             </div>
@@ -392,7 +395,7 @@ export function AuthEntryScreen({
 
           <Button
             type="submit"
-            className="h-12 w-full rounded-full"
+            className="h-12 w-full rounded-[14px] border-transparent bg-[var(--primary)] font-semibold text-white shadow-[0_10px_24px_-18px_rgba(10,40,28,0.45)] hover:-translate-y-0.5 hover:bg-[var(--primary-hover)] hover:shadow-[0_18px_32px_-22px_rgba(10,40,28,0.45)]"
             disabled={isSubmitting || !hasSupabaseEnv() || !hydrated}
           >
             {isSubmitting ? `${ctaLabel}...` : ctaLabel}
@@ -402,7 +405,7 @@ export function AuthEntryScreen({
         <button
           type="button"
           onClick={() => handleModeChange(isSignUp ? "sign-in" : "sign-up")}
-          className="mt-6 inline-flex w-fit items-center text-sm text-muted-foreground transition-colors duration-200 hover:text-foreground"
+          className="mt-6 inline-flex w-fit items-center text-sm font-medium text-[var(--primary)] transition-colors duration-200 hover:underline"
         >
           {toggleLabel}
         </button>

--- a/src/features/guide/components/public/guide-photo-grid.tsx
+++ b/src/features/guide/components/public/guide-photo-grid.tsx
@@ -8,11 +8,19 @@ export function GuidePhotoGrid({ photos }: GuidePhotoGridProps) {
   if (photos.length === 0) return null;
 
   return (
-    <section className="mt-8">
-      <h2 className="mb-4 text-lg font-semibold">Локации</h2>
+    <section className="rounded-[var(--card-radius)] border border-[var(--outline)] bg-[var(--surface-lowest)] p-[clamp(22px,4vw,30px)] shadow-[var(--card-shadow)]">
+      <p className="mb-3 font-sans text-[0.75rem] font-semibold tracking-[0.1em] text-[var(--primary)] uppercase">
+        Фото
+      </p>
+      <h2 className="mb-6 font-display text-[clamp(1.875rem,3.5vw,2.375rem)] font-semibold leading-[1.1] text-[var(--on-surface)]">
+        Локации
+      </h2>
       <div className="grid grid-cols-2 gap-3 sm:grid-cols-3">
-        {photos.map(photo => (
-          <div key={photo.id} className="relative aspect-square overflow-hidden rounded-xl">
+        {photos.map((photo) => (
+          <div
+            key={photo.id}
+            className="relative aspect-square overflow-hidden rounded-[20px] border border-[var(--outline)] bg-[var(--brand-50)]"
+          >
             <Image
               src={photo.imageUrl}
               alt={photo.locationName}
@@ -20,8 +28,10 @@ export function GuidePhotoGrid({ photos }: GuidePhotoGridProps) {
               sizes="(max-width: 640px) 50vw, 33vw"
               className="object-cover"
             />
-            <div className="absolute inset-x-0 bottom-0 bg-gradient-to-t from-black/60 to-transparent px-2 py-2">
-              <p className="text-xs font-medium text-white">{photo.locationName}</p>
+            <div className="absolute inset-x-2 bottom-2 rounded-full border border-[var(--outline)] bg-[var(--surface-lowest)] px-3 py-1.5 shadow-[var(--card-shadow)]">
+              <p className="truncate text-xs font-semibold text-[var(--on-surface)]">
+                {photo.locationName}
+              </p>
             </div>
           </div>
         ))}

--- a/src/features/guide/components/public/guide-profile-screen.tsx
+++ b/src/features/guide/components/public/guide-profile-screen.tsx
@@ -1,6 +1,6 @@
 import Image from "next/image";
+import Link from "next/link";
 
-import { TourCard } from "@/components/shared/tour-card";
 import type { PublicGuideProfile } from "@/data/public-guides/types";
 import { GuidePhotoGrid } from "./guide-photo-grid";
 
@@ -49,6 +49,7 @@ export function GuideProfileScreen({ guide, listings, reviews, photos = [] }: Pr
   const initials = getInitials(guide.displayName, guide.avatarInitials);
   const rating = guide.reviewsSummary.averageRating;
   const totalReviews = guide.reviewsSummary.totalReviews;
+  const isVerified = guide.verificationStatus === "approved";
 
   const tourCards =
     listings && listings.length > 0
@@ -67,11 +68,11 @@ export function GuideProfileScreen({ guide, listings, reviews, photos = [] }: Pr
   const reviewCards: GuideReview[] = reviews && reviews.length > 0 ? reviews : [];
 
   return (
-    <div>
-      <section className="bg-surface pt-[110px] pb-16">
+    <div className="bg-[var(--surface)] text-[var(--on-surface)]">
+      <section className="pt-[110px] pb-12 md:pb-16">
         <div className="mx-auto w-full max-w-page px-[clamp(20px,4vw,48px)]">
-          <div className="grid grid-cols-1 items-start gap-8 lg:grid-cols-[380px_minmax(0,1fr)] lg:gap-14">
-            <div className="relative aspect-[3/4] overflow-hidden rounded-[28px] bg-surface-low">
+          <div className="grid grid-cols-1 gap-8 rounded-[var(--card-radius)] border border-[var(--outline)] bg-[var(--surface-lowest)] p-[clamp(22px,4vw,36px)] shadow-[var(--card-shadow)] lg:grid-cols-[minmax(260px,380px)_minmax(0,1fr)] lg:gap-12">
+            <div className="relative aspect-[4/5] overflow-hidden rounded-[28px] border border-[var(--outline)] bg-[var(--brand-50)]">
               {guide.avatarImageUrl ? (
                 <Image
                   src={guide.avatarImageUrl.replace("w=400&h=400", "w=600&h=800")}
@@ -82,64 +83,73 @@ export function GuideProfileScreen({ guide, listings, reviews, photos = [] }: Pr
                   priority
                 />
               ) : (
-                <div className="flex h-full w-full items-center justify-center font-display text-[4rem] text-primary">
+                <div className="flex h-full w-full items-center justify-center font-display text-[4.5rem] font-semibold text-[var(--primary)]">
                   {initials}
                 </div>
               )}
             </div>
 
-            <div className="pt-2">
-              <p className="mb-2 font-sans text-[0.6875rem] font-medium tracking-[0.18em] uppercase text-muted-foreground">
-                {guide.homeBase}
-              </p>
+            <div className="flex flex-col justify-center">
+              <div className="mb-4 flex flex-wrap items-center gap-2">
+                <span className="inline-flex items-center rounded-full bg-[var(--brand-50)] px-4 py-2 text-[0.8125rem] font-semibold text-[var(--primary)]">
+                  {guide.homeBase}
+                </span>
+                {isVerified ? (
+                  <span className="inline-flex items-center gap-1.5 rounded-full bg-[var(--brand-50)] px-4 py-2 text-[0.8125rem] font-semibold text-[var(--primary)]">
+                    <span aria-hidden="true">✓</span>
+                    Проверенный гид
+                  </span>
+                ) : null}
+              </div>
 
-              <h1 className="mt-2 mb-4 font-display text-[clamp(2.5rem,5vw,3.5rem)] leading-[1.05] text-foreground">
+              <h1 className="mb-4 font-display text-[clamp(2.5rem,5vw,3.75rem)] font-semibold leading-[1.04] text-[var(--on-surface)]">
                 {guide.displayName}
               </h1>
 
-              <p className="mb-6 max-w-[36rem] text-[1.0625rem] leading-[1.65] text-muted-foreground">
+              <p className="max-w-[40rem] text-[1.125rem] leading-[1.65] text-[var(--on-surface-muted)]">
                 {guide.headline}
               </p>
 
-              <div className="mb-6 flex flex-wrap gap-2">
-                <span className="inline-flex items-center rounded-full bg-surface-low px-3.5 py-1.5 text-[0.8125rem] text-muted-foreground">
-                  {rating.toFixed(1)} / 5 · {totalReviews} отзывов
-                </span>
-                <span className="inline-flex items-center rounded-full bg-surface-low px-3.5 py-1.5 text-[0.8125rem] text-muted-foreground">
-                  {guide.yearsExperience} лет опыта
-                </span>
-              </div>
-
-              <div className="mb-7 grid w-fit grid-cols-3 gap-8 border-b border-outline-variant pb-7">
-                <div className="flex flex-col">
-                  <strong className="font-sans text-[2rem] font-semibold leading-[1] tabular-nums text-foreground">
+              <div className="my-7 grid grid-cols-2 gap-3 sm:grid-cols-4">
+                <div className="rounded-[18px] bg-[var(--brand-50)] px-4 py-3">
+                  <strong className="block font-sans text-[1.625rem] font-semibold leading-[1] tabular-nums text-[var(--on-surface)]">
                     {rating.toFixed(1)}
                   </strong>
-                  <span className="mt-1 text-[0.8125rem] text-muted-foreground">рейтинг</span>
+                  <span className="mt-1 block text-[0.8125rem] font-medium text-[var(--on-surface-muted)]">
+                    рейтинг
+                  </span>
                 </div>
-                <div className="flex flex-col">
-                  <strong className="font-sans text-[2rem] font-semibold leading-[1] tabular-nums text-foreground">
+                <div className="rounded-[18px] bg-[var(--brand-50)] px-4 py-3">
+                  <strong className="block font-sans text-[1.625rem] font-semibold leading-[1] tabular-nums text-[var(--on-surface)]">
                     {totalReviews}
                   </strong>
-                  <span className="mt-1 text-[0.8125rem] text-muted-foreground">поездок</span>
+                  <span className="mt-1 block text-[0.8125rem] font-medium text-[var(--on-surface-muted)]">
+                    отзывов
+                  </span>
                 </div>
-                <div className="flex flex-col">
-                  <strong className="font-sans text-[2rem] font-semibold leading-[1] tabular-nums text-foreground">
+                <div className="rounded-[18px] bg-[var(--brand-50)] px-4 py-3">
+                  <strong className="block font-sans text-[1.625rem] font-semibold leading-[1] tabular-nums text-[var(--on-surface)]">
+                    {guide.completedTours}
+                  </strong>
+                  <span className="mt-1 block text-[0.8125rem] font-medium text-[var(--on-surface-muted)]">
+                    поездок
+                  </span>
+                </div>
+                <div className="rounded-[18px] bg-[var(--brand-50)] px-4 py-3">
+                  <strong className="block font-sans text-[1.625rem] font-semibold leading-[1] tabular-nums text-[var(--on-surface)]">
                     {guide.yearsExperience}
                   </strong>
-                  <span className="mt-1 text-[0.8125rem] text-muted-foreground">лет опыта</span>
+                  <span className="mt-1 block text-[0.8125rem] font-medium text-[var(--on-surface-muted)]">
+                    лет опыта
+                  </span>
                 </div>
               </div>
 
-              <p className="mb-6 max-w-[38rem] leading-[1.7] text-muted-foreground">
-                {guide.bio}
-              </p>
-
-              <div className="mb-8 flex flex-wrap gap-2">
+              <div className="mb-8 flex flex-wrap gap-2.5">
                 {guide.languages.map((lang) => (
                   <span
                     key={lang}
-                    className="inline-flex items-center rounded-full bg-surface-low px-3.5 py-1.5 text-[0.8125rem] text-muted-foreground"
+                    className="inline-flex items-center rounded-full bg-[var(--brand-50)] px-4 py-2 text-[0.875rem] font-semibold text-[var(--primary)]"
                   >
                     {lang}
                   </span>
@@ -147,109 +157,175 @@ export function GuideProfileScreen({ guide, listings, reviews, photos = [] }: Pr
                 {guide.specialties.map((specialty) => (
                   <span
                     key={specialty}
-                    className="inline-flex items-center rounded-full bg-surface-low px-3.5 py-1.5 text-[0.8125rem] text-muted-foreground"
+                    className="inline-flex items-center rounded-full bg-[var(--brand-50)] px-4 py-2 text-[0.875rem] font-semibold text-[var(--primary)]"
                   >
                     {specialty}
                   </span>
                 ))}
               </div>
 
+              <div className="flex flex-col gap-3 sm:flex-row sm:items-center">
+                <a
+                  href="#guide-listings"
+                  className="inline-flex w-full items-center justify-center rounded-[14px] bg-[var(--primary)] px-6 py-[15px] font-semibold text-white shadow-[0_14px_28px_-18px_var(--primary)] transition-all duration-200 hover:-translate-y-0.5 hover:bg-[var(--primary-hover)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--primary)] focus-visible:ring-offset-2 sm:w-auto"
+                >
+                  Выбрать экскурсию
+                </a>
+                <p className="text-[0.9375rem] leading-[1.5] text-[var(--on-surface-muted)]">
+                  Профиль, опыт и отзывы помогают выбрать гида до заявки.
+                </p>
+              </div>
             </div>
           </div>
         </div>
       </section>
 
+      <section className="pb-8 md:pb-10">
+        <div className="mx-auto w-full max-w-page px-[clamp(20px,4vw,48px)]">
+          <article className="rounded-[var(--card-radius)] border border-[var(--outline)] bg-[var(--surface-lowest)] p-[clamp(22px,4vw,30px)] shadow-[var(--card-shadow)]">
+            <p className="mb-3 font-sans text-[0.75rem] font-semibold tracking-[0.1em] text-[var(--primary)] uppercase">
+              О гиде
+            </p>
+            <h2 className="mb-4 font-display text-[clamp(1.875rem,3.5vw,2.375rem)] font-semibold leading-[1.1] text-[var(--on-surface)]">
+              Почему с {guide.displayName} спокойно ехать
+            </h2>
+            <p className="max-w-[52rem] text-[1rem] leading-[1.75] text-[var(--on-surface-muted)]">
+              {guide.bio}
+            </p>
+          </article>
+        </div>
+      </section>
+
       {photos.length > 0 && (
-        <section className="py-sec-pad">
+        <section className="pb-8 md:pb-10">
           <div className="mx-auto w-full max-w-page px-[clamp(20px,4vw,48px)]">
             <GuidePhotoGrid photos={photos} />
           </div>
         </section>
       )}
 
-      <section className="bg-surface-low py-sec-pad">
+      <section id="guide-listings" className="scroll-mt-28 pb-8 md:pb-10">
         <div className="mx-auto w-full max-w-page px-[clamp(20px,4vw,48px)]">
-          <h2 className="mb-7 font-display text-[clamp(1.875rem,3.5vw,2.375rem)] font-semibold leading-[1.1]">
-            Готовые экскурсии
-          </h2>
-          {tourCards ? (
-            <div className="grid grid-cols-1 gap-4 md:grid-cols-2 lg:grid-cols-3">
-              {tourCards.map((tour) => (
-                <TourCard
-                  key={tour.href}
-                  href={tour.href}
-                  imageUrl={tour.imageUrl}
-                  title={tour.title}
-                  guide={tour.guide}
-                  rating={tour.rating}
-                  price={tour.price}
-                />
-              ))}
-            </div>
-          ) : (
-            <p className="text-muted-foreground">У этого гида пока нет экскурсий.</p>
-          )}
+          <article className="rounded-[var(--card-radius)] border border-[var(--outline)] bg-[var(--surface-lowest)] p-[clamp(22px,4vw,30px)] shadow-[var(--card-shadow)]">
+            <p className="mb-3 font-sans text-[0.75rem] font-semibold tracking-[0.1em] text-[var(--primary)] uppercase">
+              Экскурсии
+            </p>
+            <h2 className="mb-7 font-display text-[clamp(1.875rem,3.5vw,2.375rem)] font-semibold leading-[1.1] text-[var(--on-surface)]">
+              Готовые экскурсии
+            </h2>
+            {tourCards ? (
+              <div className="grid grid-cols-1 gap-4 md:grid-cols-2 lg:grid-cols-3">
+                {tourCards.map((tour) => (
+                  <Link
+                    key={tour.href}
+                    href={tour.href}
+                    className="group overflow-hidden rounded-[22px] border border-[var(--outline)] bg-[var(--surface-lowest)] shadow-[var(--card-shadow)] transition-all duration-200 hover:-translate-y-0.5 hover:shadow-[0_18px_44px_-22px_rgba(10,40,28,0.22)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--primary)] focus-visible:ring-offset-2"
+                  >
+                    <div className="relative aspect-[4/3] overflow-hidden bg-[var(--brand-50)]">
+                      <Image
+                        src={tour.imageUrl}
+                        alt={tour.title}
+                        fill
+                        sizes="(max-width: 768px) 100vw, (max-width: 1200px) 50vw, 33vw"
+                        className="object-cover transition-transform duration-300 group-hover:scale-[1.02]"
+                      />
+                    </div>
+                    <div className="p-5">
+                      <h3 className="font-display text-[1.35rem] font-semibold leading-[1.15] text-[var(--on-surface)]">
+                        {tour.title}
+                      </h3>
+                      <p className="mt-3 text-[0.875rem] text-[var(--on-surface-muted)]">
+                        {tour.guide}
+                        {tour.rating !== undefined ? ` · ${tour.rating} ★` : null}
+                      </p>
+                      <div className="mt-4 inline-flex rounded-full bg-[var(--brand-50)] px-4 py-2 text-[0.875rem] font-semibold text-[var(--primary)]">
+                        {tour.price}
+                      </div>
+                    </div>
+                  </Link>
+                ))}
+              </div>
+            ) : (
+              <p className="text-[var(--on-surface-muted)]">У этого гида пока нет экскурсий.</p>
+            )}
+          </article>
         </div>
       </section>
 
-      <section className="bg-surface-low py-sec-pad">
+      <section className="pb-16 md:pb-20">
         <div className="mx-auto w-full max-w-page px-[clamp(20px,4vw,48px)]">
-          <p className="mb-2 font-sans text-[0.6875rem] font-medium tracking-[0.18em] uppercase text-muted-foreground">
-            Отзывы
-          </p>
-          <h2 className="mb-7 font-display text-[clamp(1.875rem,3.5vw,2.375rem)] font-semibold leading-[1.1]">
-            Что говорят путешественники
-          </h2>
-          {reviewCards.length > 0 ? (
-            <div className="grid grid-cols-1 gap-4 md:grid-cols-2 lg:grid-cols-3">
-              {reviewCards.map((rev) => {
-                const reviewInitials =
-                  rev.initials ||
-                  (rev.author?.displayName
-                    ? rev.author.displayName
-                        .split(/\s+/)
-                        .filter(Boolean)
-                        .slice(0, 2)
-                        .map((p: string) => p[0])
-                        .join("")
-                        .toUpperCase()
-                    : "??");
-                const reviewName =
-                  rev.name || rev.author?.displayName || "Путешественник";
-                const reviewDate =
-                  rev.date ||
-                  (rev.createdAt
-                    ? new Date(rev.createdAt).toLocaleDateString("ru-RU", {
-                        month: "long",
-                        year: "numeric",
-                      })
-                    : "");
-                const reviewRating = rev.rating ?? 5;
-                const reviewBody = rev.body || rev.title || "";
+          <article className="rounded-[var(--card-radius)] border border-[var(--outline)] bg-[var(--surface-lowest)] p-[clamp(22px,4vw,30px)] shadow-[var(--card-shadow)]">
+            <div className="mb-7 flex flex-col gap-3 sm:flex-row sm:items-end sm:justify-between">
+              <div>
+                <p className="mb-3 font-sans text-[0.75rem] font-semibold tracking-[0.1em] text-[var(--primary)] uppercase">
+                  Отзывы
+                </p>
+                <h2 className="font-display text-[clamp(1.875rem,3.5vw,2.375rem)] font-semibold leading-[1.1] text-[var(--on-surface)]">
+                  Что говорят путешественники
+                </h2>
+              </div>
+              <div className="w-fit rounded-full bg-[var(--brand-50)] px-4 py-2 text-[0.9375rem] font-semibold text-[var(--primary)]">
+                {rating.toFixed(1)} ★ · {totalReviews} отзывов
+              </div>
+            </div>
+            {reviewCards.length > 0 ? (
+              <div className="grid grid-cols-1 gap-4 md:grid-cols-2 lg:grid-cols-3">
+                {reviewCards.map((rev) => {
+                  const reviewInitials =
+                    rev.initials ||
+                    (rev.author?.displayName
+                      ? rev.author.displayName
+                          .split(/\s+/)
+                          .filter(Boolean)
+                          .slice(0, 2)
+                          .map((p: string) => p[0])
+                          .join("")
+                          .toUpperCase()
+                      : "??");
+                  const reviewName =
+                    rev.name || rev.author?.displayName || "Путешественник";
+                  const reviewDate =
+                    rev.date ||
+                    (rev.createdAt
+                      ? new Date(rev.createdAt).toLocaleDateString("ru-RU", {
+                          month: "long",
+                          year: "numeric",
+                        })
+                      : "");
+                  const reviewRating = rev.rating ?? 5;
+                  const reviewBody = rev.body || rev.title || "";
 
-                return (
-                  <article key={rev.id} className="flex items-start gap-3.5">
-                    <div className="flex h-[42px] w-[42px] shrink-0 items-center justify-center rounded-full bg-surface-low text-xs font-semibold text-primary">
-                      {reviewInitials}
-                    </div>
-                    <div>
-                      <strong className="mb-1 block">{reviewName}</strong>
-                      <small className="mb-2 block text-muted-foreground">
-                        {reviewDate}
-                        {reviewDate ? " · " : ""}
-                        {reviewRating.toFixed(1)}
-                      </small>
-                      <p className="text-[0.9375rem] leading-[1.65] text-muted-foreground">
+                  return (
+                    <article
+                      key={rev.id}
+                      className="rounded-[22px] border border-[var(--outline)] bg-[var(--surface-lowest)] p-5"
+                    >
+                      <div className="mb-4 flex items-start gap-3.5">
+                        <div className="flex h-[44px] w-[44px] shrink-0 items-center justify-center rounded-full bg-[var(--brand-50)] text-xs font-semibold text-[var(--primary)]">
+                          {reviewInitials}
+                        </div>
+                        <div>
+                          <strong className="mb-1 block text-[var(--on-surface)]">
+                            {reviewName}
+                          </strong>
+                          <small className="block text-[var(--on-surface-muted)]">
+                            {reviewDate}
+                            {reviewDate ? " · " : ""}
+                            {reviewRating.toFixed(1)} ★
+                          </small>
+                        </div>
+                      </div>
+                      <p className="text-[0.9375rem] leading-[1.65] text-[var(--on-surface-muted)]">
                         {reviewBody}
                       </p>
-                    </div>
-                  </article>
-                );
-              })}
-            </div>
-          ) : (
-            <p className="text-muted-foreground">Отзывов пока нет.</p>
-          )}
+                    </article>
+                  );
+                })}
+              </div>
+            ) : (
+              <p className="text-[var(--on-surface-muted)]">Отзывов пока нет.</p>
+            )}
+          </article>
         </div>
       </section>
     </div>

--- a/src/features/guide/components/public/public-guide-card.tsx
+++ b/src/features/guide/components/public/public-guide-card.tsx
@@ -39,34 +39,37 @@ export function PublicGuideCard({
     <Link
       href={`/guides/${guide.slug}`}
       className={cn(
-        "bg-glass backdrop-blur-[20px] border border-glass-border shadow-glass flex gap-4 rounded-[1.5rem] p-4 transition-all duration-300",
-        "items-start focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/50",
-        "motion-safe:hover:-translate-y-0.5 motion-safe:hover:shadow-lg",
+        "flex gap-4 rounded-[var(--card-radius)] border border-[var(--outline)] bg-[var(--surface-lowest)] p-4 shadow-[var(--card-shadow)] transition-all duration-200",
+        "items-start text-[var(--on-surface)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--primary)] focus-visible:ring-offset-2",
+        "motion-safe:hover:-translate-y-0.5 motion-safe:hover:shadow-[0_18px_44px_-22px_rgba(10,40,28,0.22)]",
         className,
       )}
     >
-      <div className="relative size-14 shrink-0 overflow-hidden rounded-full border border-border/40 bg-muted">
+      <div className="relative size-16 shrink-0 overflow-hidden rounded-full border-2 border-white bg-[var(--brand-50)] shadow-[0_0_0_1px_var(--outline)]">
         <Image
           src={guide.avatarUrl}
           alt=""
           fill
           className="object-cover"
-          sizes="56px"
+          sizes="64px"
         />
       </div>
 
       <div className="min-w-0 flex-1 space-y-2">
         <div className="flex flex-wrap items-baseline gap-x-2 gap-y-1">
-          <span className="text-base font-semibold text-foreground">
+          <span className="text-base font-semibold text-[var(--on-surface)]">
             {guide.name}
           </span>
           {hasRating ? (
-            <span className="text-sm text-amber-500" aria-label={`Рейтинг ${ratingLabel}`}>
+            <span
+              className="text-sm font-semibold text-[var(--gold)]"
+              aria-label={`Рейтинг ${ratingLabel}`}
+            >
               ★ {ratingLabel}
             </span>
           ) : null}
           {hasTours ? (
-            <span className="text-xs text-muted-foreground">
+            <span className="text-xs font-medium text-[var(--on-surface-muted)]">
               {guide.tourCount} {toursWord(guide.tourCount)}
             </span>
           ) : null}
@@ -78,7 +81,7 @@ export function PublicGuideCard({
               <Badge
                 key={s}
                 variant="outline"
-                className="rounded-full px-2.5 py-0.5 text-[0.65rem] font-semibold tracking-normal normal-case"
+                className="rounded-full border-transparent bg-[var(--brand-50)] px-2.5 py-0.5 text-[0.65rem] font-semibold tracking-normal text-[var(--primary)] normal-case"
               >
                 {s}
               </Badge>
@@ -87,7 +90,9 @@ export function PublicGuideCard({
         ) : null}
 
         {guide.cities.length > 0 ? (
-          <p className="text-xs text-muted-foreground">{guide.cities.join(" · ")}</p>
+          <p className="text-xs text-[var(--on-surface-muted)]">
+            {guide.cities.join(" · ")}
+          </p>
         ) : null}
       </div>
     </Link>

--- a/src/features/guide/components/requests/guide-inbox-card-header.tsx
+++ b/src/features/guide/components/requests/guide-inbox-card-header.tsx
@@ -33,41 +33,41 @@ export function GuideInboxCardHeader({
   );
 
   return (
-    <div className="flex items-start gap-3">
-      <ProfileAvatar
-        profile={{
-          full_name: item.requesterName ?? null,
-          avatar_url: item.requesterAvatarUrl ?? null,
-        }}
-        size={40}
-        className="shrink-0"
-      />
-      <div className="min-w-0 flex-1 space-y-0.5">
-        <p className="truncate text-sm font-semibold leading-snug text-foreground">
-          {travelerDisplayName}
-        </p>
-        <p className="text-sm leading-snug text-muted-foreground">
-          в{" "}
-          <span className="font-medium text-foreground">
+    <div className="flex flex-col gap-4 sm:flex-row sm:items-start sm:justify-between">
+      <div className="flex min-w-0 items-start gap-3">
+        <ProfileAvatar
+          profile={{
+            full_name: item.requesterName ?? null,
+            avatar_url: item.requesterAvatarUrl ?? null,
+          }}
+          size={44}
+          className="shrink-0 ring-2 ring-white"
+        />
+        <div className="min-w-0 flex-1 space-y-1">
+          <p className="truncate text-sm font-semibold leading-snug text-[var(--on-surface-muted)]">
+            {travelerDisplayName}
+          </p>
+          <p className="text-xl font-semibold leading-tight text-[var(--on-surface)]">
             {item.destination}
-          </span>
-        </p>
+          </p>
+        </div>
       </div>
-      <div className="flex shrink-0 flex-col items-end gap-1.5 pt-0.5">
+      <div className="flex shrink-0 flex-col items-start gap-2 sm:items-end">
+        <span className="inline-flex items-center gap-1.5 rounded-full bg-[var(--surface)] px-3 py-1 text-xs font-semibold text-[var(--on-surface-muted)]">
+          <span className="size-2 rounded-full bg-[var(--gold)]" aria-hidden="true" />
+          Новый · {formatPublishedAt(item.createdAt)}
+        </span>
         {item.interests.length > 0 ? (
           <span
             className={
               matched
-                ? "inline-flex items-center gap-1.5 whitespace-normal rounded-full bg-primary/10 px-2.5 py-1 text-xs font-semibold text-primary"
-                : "inline-flex items-center gap-1.5 whitespace-normal rounded-full bg-muted px-2.5 py-1 text-xs font-medium text-muted-foreground"
+                ? "inline-flex items-center gap-1.5 whitespace-normal rounded-full bg-[var(--brand-50)] px-3 py-1 text-xs font-semibold text-[var(--primary)]"
+                : "inline-flex items-center gap-1.5 whitespace-normal rounded-full border border-[var(--outline)] bg-[var(--surface-lowest)] px-3 py-1 text-xs font-semibold text-[var(--on-surface-muted)]"
             }
           >
             {item.interests.map((s) => INTEREST_LABEL_BY_ID[s] ?? s).join(" · ")}
           </span>
         ) : null}
-        <span className="text-xs text-muted-foreground/60">
-          {formatPublishedAt(item.createdAt)}
-        </span>
       </div>
     </div>
   );

--- a/src/features/guide/components/requests/guide-requests-inbox-screen.test.tsx
+++ b/src/features/guide/components/requests/guide-requests-inbox-screen.test.tsx
@@ -191,7 +191,7 @@ describe("GuideRequestsInboxScreen meta layout", () => {
     });
   });
 
-  it("keeps the request time inline with the date meta row", () => {
+  it("keeps the request time inline with the date meta card", () => {
     const source = readFileSync(
       join(
         process.cwd(),
@@ -202,11 +202,11 @@ describe("GuideRequestsInboxScreen meta layout", () => {
     const metaBlock = source.match(/\{\/\* Meta \*\/\}([\s\S]*?)\{\/\* Actions \*\/\}/)?.[1];
 
     expect(metaBlock).toContain(
-      'className="mt-3 space-y-1.5 text-xs leading-relaxed text-muted-foreground"',
+      'className="mt-4 grid gap-3 text-sm leading-relaxed text-[var(--on-surface-muted)] sm:grid-cols-3"',
     );
     expect(metaBlock).not.toContain("sm:grid-cols-2");
     expect(metaBlock).toMatch(
-      /<p>[\s\S]*Даты:[\s\S]*formatTimeRange\(item\.startTime, item\.endTime\)[\s\S]*Время:[\s\S]*<\/p>/,
+      /<p[\s\S]*Даты[\s\S]*formatTimeRange\(item\.startTime, item\.endTime\)[\s\S]*Время:[\s\S]*<\/p>/,
     );
   });
 

--- a/src/features/guide/components/requests/guide-requests-inbox-screen.tsx
+++ b/src/features/guide/components/requests/guide-requests-inbox-screen.tsx
@@ -216,7 +216,7 @@ export function GuideRequestsInboxScreen() {
               Биржа запросов
             </p>
             <div className="space-y-2">
-              <h1 className="font-[family:var(--font-rubik)] text-[clamp(30px,4.4vw,44px)] font-semibold leading-[1.04] text-[var(--on-surface)]">
+              <h1 className="font-sans text-[clamp(30px,4.4vw,44px)] font-semibold leading-[1.04] text-[var(--on-surface)]">
                 Открытые запросы, на которые можно откликнуться сейчас
               </h1>
               <p className="max-w-2xl text-sm leading-6 text-[var(--on-surface-muted)] sm:text-base">

--- a/src/features/guide/components/requests/guide-requests-inbox-screen.tsx
+++ b/src/features/guide/components/requests/guide-requests-inbox-screen.tsx
@@ -11,8 +11,6 @@ import { formatTimeRange } from "@/lib/dates";
 
 import { EmptyState } from "@/components/shared/empty-state";
 import { Button } from "@/components/ui/button";
-import { Card, CardContent, CardHeader } from "@/components/ui/card";
-import { Separator } from "@/components/ui/separator";
 
 import { BidFormPanel } from "./bid-form-panel-lazy";
 import { GuideInboxCardHeader } from "./guide-inbox-card-header";
@@ -31,11 +29,11 @@ interface OffersByRequest {
   offerIdByRequestId: Map<string, OfferMeta>;
 }
 
-const requestChipClassName = "inline-flex items-center rounded-full px-2.5 py-0.5 text-xs font-medium";
-const assemblyChipClassName = `${requestChipClassName} bg-sky-100 text-sky-700`;
-const privateChipClassName = `${requestChipClassName} bg-purple-100 text-purple-700`;
-const flexibleDatesChipClassName = `${requestChipClassName} bg-emerald-100 text-emerald-700`;
-const exactDateChipClassName = `${requestChipClassName} bg-rose-100 text-rose-700`;
+const requestChipClassName = "inline-flex items-center rounded-full px-3 py-1 text-xs font-semibold";
+const assemblyChipClassName = `${requestChipClassName} bg-[var(--brand-50)] text-[var(--primary)]`;
+const privateChipClassName = `${requestChipClassName} border border-[var(--outline)] bg-[var(--surface-lowest)] text-[var(--on-surface-muted)]`;
+const flexibleDatesChipClassName = `${requestChipClassName} bg-[var(--brand-50)] text-[var(--primary)]`;
+const exactDateChipClassName = `${requestChipClassName} bg-[var(--surface)] text-[var(--on-surface-muted)]`;
 
 async function fetchOfferedRequestIds(guideId: string): Promise<OffersByRequest> {
   const supabase = createSupabaseBrowserClient();
@@ -210,21 +208,63 @@ export function GuideRequestsInboxScreen() {
       : "Подтверждённых бронирований пока нет.";
 
   return (
-    <div className="space-y-6">
-      <Card className="border-border/70 bg-card/90">
-        <CardHeader className="space-y-1">
-        </CardHeader>
-        <CardContent className="space-y-4">
-          {isLoading ? (
-            <p className="text-sm text-muted-foreground">Загрузка запросов…</p>
-          ) : items.length === 0 ? (
-            <EmptyState
-              icon={<Inbox className="size-7" strokeWidth={1.5} />}
-              title="Запросов пока нет"
-              description="Путешественники публикуют новые запросы каждый день — скоро здесь появятся подходящие заявки."
-            />
-          ) : (
-            <>
+    <div className="space-y-6 bg-[var(--surface)] text-[var(--on-surface)]">
+      <section className="rounded-[28px] border border-[var(--outline)] bg-[var(--surface-lowest)] p-6 shadow-[var(--card-shadow)] sm:p-7">
+        <div className="grid gap-6 lg:grid-cols-[1fr_360px] lg:items-end">
+          <div className="max-w-3xl space-y-3">
+            <p className="text-xs font-semibold uppercase tracking-[0.1em] text-[var(--primary)]">
+              Биржа запросов
+            </p>
+            <div className="space-y-2">
+              <h1 className="font-[family:var(--font-rubik)] text-[clamp(30px,4.4vw,44px)] font-semibold leading-[1.04] text-[var(--on-surface)]">
+                Открытые запросы, на которые можно откликнуться сейчас
+              </h1>
+              <p className="max-w-2xl text-sm leading-6 text-[var(--on-surface-muted)] sm:text-base">
+                Выберите подходящий запрос, быстро оцените дату, группу и бюджет, затем отправьте предложение путешественнику.
+              </p>
+            </div>
+          </div>
+          <div className="grid grid-cols-3 gap-2 sm:gap-3 lg:grid-cols-1">
+            <div className="rounded-[18px] border border-[var(--outline)] bg-[var(--surface-lowest)] p-3 shadow-[var(--card-shadow)]">
+              <p className="text-[11px] font-semibold uppercase tracking-[0.08em] text-[var(--on-surface-muted)]">
+                Новые
+              </p>
+              <p className="mt-1 text-2xl font-semibold text-[var(--on-surface)] tabular-nums">
+                {newCount}
+              </p>
+            </div>
+            <div className="rounded-[18px] border border-[var(--outline)] bg-[var(--surface-lowest)] p-3 shadow-[var(--card-shadow)]">
+              <p className="text-[11px] font-semibold uppercase tracking-[0.08em] text-[var(--on-surface-muted)]">
+                Отклики
+              </p>
+              <p className="mt-1 text-2xl font-semibold text-[var(--on-surface)] tabular-nums">
+                {myOffersCount}
+              </p>
+            </div>
+            <div className="rounded-[18px] border border-[var(--outline)] bg-[var(--surface-lowest)] p-3 shadow-[var(--card-shadow)]">
+              <p className="text-[11px] font-semibold uppercase tracking-[0.08em] text-[var(--on-surface-muted)]">
+                Брони
+              </p>
+              <p className="mt-1 text-2xl font-semibold text-[var(--on-surface)] tabular-nums">
+                {activeBookings.length}
+              </p>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <section className="rounded-[var(--card-radius)] border border-[var(--outline)] bg-[var(--surface-lowest)] p-5 shadow-[var(--card-shadow)] sm:p-6">
+        {isLoading ? (
+          <p className="text-sm font-medium text-[var(--on-surface-muted)]">Загрузка запросов…</p>
+        ) : items.length === 0 ? (
+          <EmptyState
+            icon={<Inbox className="size-7 text-[var(--primary)]" strokeWidth={1.5} />}
+            title="Запросов пока нет"
+            description="Путешественники публикуют новые запросы каждый день — скоро здесь появятся подходящие заявки."
+          />
+        ) : (
+          <div className="space-y-5">
+            <div className="flex flex-col gap-3 lg:flex-row lg:items-center lg:justify-between">
               <div
                 role="tablist"
                 aria-label="Фильтр запросов"
@@ -241,16 +281,16 @@ export function GuideRequestsInboxScreen() {
                       onClick={() => setFilter(tab.key)}
                       className={
                         isSelected
-                          ? "inline-flex items-center gap-2 rounded-full border border-transparent bg-foreground px-4 py-2 text-sm font-medium text-background transition"
-                          : "inline-flex items-center gap-2 rounded-full border border-border bg-background/60 px-4 py-2 text-sm font-medium text-foreground transition hover:bg-background"
+                          ? "inline-flex cursor-pointer items-center gap-2 rounded-full border border-[var(--primary)] bg-[var(--brand-50)] px-4 py-2 text-sm font-semibold text-[var(--primary)] transition-colors duration-200 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--primary)] focus-visible:ring-offset-2"
+                          : "inline-flex cursor-pointer items-center gap-2 rounded-full border border-[var(--outline)] bg-[var(--surface-lowest)] px-4 py-2 text-sm font-semibold text-[var(--on-surface-muted)] transition-colors duration-200 hover:border-[var(--primary)] hover:text-[var(--primary)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--primary)] focus-visible:ring-offset-2"
                       }
                     >
                       <span>{tab.label}</span>
                       <span
                         className={
                           isSelected
-                            ? "rounded-full bg-background/20 px-2 py-0.5 text-xs tabular-nums"
-                            : "rounded-full bg-muted/40 px-2 py-0.5 text-xs tabular-nums"
+                            ? "rounded-full bg-[var(--primary)] px-2 py-0.5 text-xs text-white tabular-nums"
+                            : "rounded-full bg-[var(--surface)] px-2 py-0.5 text-xs text-[var(--on-surface-muted)] tabular-nums"
                         }
                       >
                         {tab.count}
@@ -259,180 +299,201 @@ export function GuideRequestsInboxScreen() {
                   );
                 })}
               </div>
-              {/* City filter + sort */}
-              {items.length > 0 ? (
-                <div className="flex flex-wrap items-center gap-3">
-                  {uniqueCities.length > 1 ? (
-                    <select
-                      value={cityFilter}
-                      onChange={(e) => setCityFilter(e.target.value)}
-                      className="rounded-lg border border-border bg-surface-high px-3 py-1.5 text-sm text-foreground outline-none focus:border-primary"
-                      aria-label="Фильтр по городу"
-                    >
-                      <option value="all">Все направления</option>
-                      {uniqueCities.map((city) => (
-                        <option key={city} value={city}>
-                          {city}
-                        </option>
-                      ))}
-                    </select>
-                  ) : null}
+              <div className="flex flex-wrap items-center gap-3">
+                {uniqueCities.length > 1 ? (
                   <select
-                    value={sortKey}
-                    onChange={(e) => setSortKey(e.target.value as typeof sortKey)}
-                    className="rounded-lg border border-border bg-surface-high px-3 py-1.5 text-sm text-foreground outline-none focus:border-primary"
-                    aria-label="Сортировка"
+                    value={cityFilter}
+                    onChange={(e) => setCityFilter(e.target.value)}
+                    className="h-10 rounded-[14px] border border-[var(--outline)] bg-[var(--surface-lowest)] px-3 text-sm font-medium text-[var(--on-surface)] outline-none transition-colors focus:border-[var(--primary)] focus:ring-2 focus:ring-[var(--brand-50)]"
+                    aria-label="Фильтр по городу"
                   >
-                    <option value="newest">Новые сначала</option>
-                    <option value="date">По дате запроса</option>
-                    <option value="size">По размеру группы</option>
+                    <option value="all">Все направления</option>
+                    {uniqueCities.map((city) => (
+                      <option key={city} value={city}>
+                        {city}
+                      </option>
+                    ))}
                   </select>
-                </div>
-              ) : null}
-
-              <div className="space-y-3">
-                {filter === "confirmed" ? (
-                  activeBookings.length === 0 ? (
-                    <p className="text-center text-sm text-muted-foreground">{emptyText}</p>
-                  ) : (
-                    activeBookings.map((booking) => (
-                      <Link
-                        key={booking.id}
-                        href={`/guide/bookings/${booking.id}`}
-                        className="block rounded-xl border border-border/70 bg-background/60 p-4 transition hover:border-primary/40"
-                      >
-                        <div className="flex items-start justify-between gap-3">
-                          <div className="space-y-1">
-                            <p className="font-medium text-foreground">{booking.destination}</p>
-                            <p className="text-xs text-muted-foreground">{booking.dateLabel}</p>
-                          </div>
-                          <span className="rounded-full bg-primary/10 px-3 py-1 text-xs font-semibold text-primary">
-                            Подтверждено
-                          </span>
-                        </div>
-                        {booking.priceRub > 0 ? (
-                          <p className="mt-2 text-sm text-muted-foreground">
-                            {booking.priceRub.toLocaleString("ru-RU")} ₽
-                          </p>
-                        ) : null}
-                      </Link>
-                    ))
-                  )
                 ) : null}
-                {filter !== "confirmed" && filteredItems.length === 0 ? (
-                  <p className="text-center text-sm text-muted-foreground">
+                <select
+                  value={sortKey}
+                  onChange={(e) => setSortKey(e.target.value as typeof sortKey)}
+                  className="h-10 rounded-[14px] border border-[var(--outline)] bg-[var(--surface-lowest)] px-3 text-sm font-medium text-[var(--on-surface)] outline-none transition-colors focus:border-[var(--primary)] focus:ring-2 focus:ring-[var(--brand-50)]"
+                  aria-label="Сортировка"
+                >
+                  <option value="newest">Новые сначала</option>
+                  <option value="date">По дате запроса</option>
+                  <option value="size">По размеру группы</option>
+                </select>
+              </div>
+            </div>
+
+            <div className="space-y-4">
+              {filter === "confirmed" ? (
+                activeBookings.length === 0 ? (
+                  <p className="rounded-[18px] border border-[var(--outline)] bg-[var(--surface)] px-4 py-6 text-center text-sm text-[var(--on-surface-muted)]">
                     {emptyText}
                   </p>
-                ) : null}
-                {filter !== "confirmed" && filteredItems.map((item, index) => {
-                  const alreadyOffered = offeredIds.has(item.id);
-                  const matched = isMatchedRequest(item, specializations);
-                  const offerMeta = offerIdByRequestId.get(item.id);
-                  const offerId = offerMeta?.id;
-                  const showQaPanel = alreadyOffered && !!offerId;
-                  const hasFlexibleDates = item.dateFlexibility === "few_days" || item.date_locked === false;
-                  return (
-                    <div key={item.id} className="space-y-3">
-                      <div className="rounded-xl border border-border/70 bg-background/60 p-4 transition hover:border-primary/40">
-                        {/* Card header */}
-                        <GuideInboxCardHeader item={item} matched={matched} />
-
-                        <div className="mt-3 flex flex-wrap gap-2">
-                          <span className={item.mode === "assembly" ? assemblyChipClassName : privateChipClassName}>
-                            {item.mode === "assembly" ? "Сборная группа" : "Своя группа"}
-                          </span>
-                          <span className={hasFlexibleDates ? flexibleDatesChipClassName : exactDateChipClassName}>
-                            {hasFlexibleDates ? "Гибкие даты" : "Точная дата"}
-                          </span>
+                ) : (
+                  activeBookings.map((booking) => (
+                    <Link
+                      key={booking.id}
+                      href={`/guide/bookings/${booking.id}`}
+                      className="block rounded-[var(--card-radius)] border border-[var(--outline)] bg-[var(--surface-lowest)] p-5 shadow-[var(--card-shadow)] transition-colors duration-200 hover:border-[var(--primary)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--primary)] focus-visible:ring-offset-2"
+                    >
+                      <div className="flex items-start justify-between gap-3">
+                        <div className="space-y-1">
+                          <p className="font-semibold text-[var(--on-surface)]">{booking.destination}</p>
+                          <p className="text-sm text-[var(--on-surface-muted)]">{booking.dateLabel}</p>
                         </div>
+                        <span className="rounded-full bg-[var(--brand-50)] px-3 py-1 text-xs font-semibold text-[var(--primary)]">
+                          Подтверждено
+                        </span>
+                      </div>
+                      {booking.priceRub > 0 ? (
+                        <p className="mt-3 text-sm font-medium text-[var(--on-surface-muted)]">
+                          {booking.priceRub.toLocaleString("ru-RU")} ₽
+                        </p>
+                      ) : null}
+                    </Link>
+                  ))
+                )
+              ) : null}
+              {filter !== "confirmed" && filteredItems.length === 0 ? (
+                <p className="rounded-[18px] border border-[var(--outline)] bg-[var(--surface)] px-4 py-6 text-center text-sm text-[var(--on-surface-muted)]">
+                  {emptyText}
+                </p>
+              ) : null}
+              {filter !== "confirmed" && filteredItems.map((item) => {
+                const alreadyOffered = offeredIds.has(item.id);
+                const matched = isMatchedRequest(item, specializations);
+                const offerMeta = offerIdByRequestId.get(item.id);
+                const offerId = offerMeta?.id;
+                const showQaPanel = alreadyOffered && !!offerId;
+                const hasFlexibleDates = item.dateFlexibility === "few_days" || item.date_locked === false;
+                return (
+                  <article
+                    key={item.id}
+                    className="rounded-[var(--card-radius)] border border-[var(--outline)] bg-[var(--surface-lowest)] p-5 shadow-[var(--card-shadow)] transition-colors duration-200 hover:border-[var(--primary)] sm:p-6"
+                  >
+                    {/* Card header */}
+                    <GuideInboxCardHeader item={item} matched={matched} />
 
-                        {/* Meta */}
-                        <div className="mt-3 space-y-1.5 text-xs leading-relaxed text-muted-foreground">
-                          <p>
-                            <span className="font-medium text-foreground">
-                              Даты:
-                            </span>{" "}
-                            {item.dateLabel}
-                            {formatTimeRange(item.startTime, item.endTime) && (
-                              <>
-                                {" · "}
-                                <span className="font-medium text-foreground">Время:</span>{" "}
-                                {formatTimeRange(item.startTime, item.endTime)}
-                              </>
-                            )}
-                          </p>
-                          <p>
-                            <span className="font-medium text-foreground">
-                              Бюджет:
-                            </span>{" "}
-                            {item.budgetLabel} · {item.groupSize} чел.
-                          </p>
+                    <div className="mt-4 flex flex-wrap gap-2">
+                      <span className={item.mode === "assembly" ? assemblyChipClassName : privateChipClassName}>
+                        {item.mode === "assembly" ? "Сборная группа" : "Своя группа"}
+                      </span>
+                      <span className={hasFlexibleDates ? flexibleDatesChipClassName : exactDateChipClassName}>
+                        {hasFlexibleDates ? "Гибкие даты" : "Точная дата"}
+                      </span>
+                      <span className="inline-flex items-center gap-1.5 rounded-full bg-[var(--surface)] px-3 py-1 text-xs font-semibold text-[var(--on-surface-muted)]">
+                        <span className="size-2 rounded-full bg-[var(--gold)]" aria-hidden="true" />
+                        {item.offerCount > 0
+                          ? `${item.offerCount} откл. гидов`
+                          : "Откликов пока нет"}
+                      </span>
+                    </div>
+
+                    {/* Meta */}
+                    <div className="mt-4 grid gap-3 text-sm leading-relaxed text-[var(--on-surface-muted)] sm:grid-cols-3">
+                      <p className="rounded-[18px] bg-[var(--surface)] px-4 py-3">
+                        <span className="block text-xs font-semibold uppercase tracking-[0.08em] text-[var(--primary)]">
+                          Даты
+                        </span>
+                        <span className="font-medium text-[var(--on-surface)]">
+                          {item.dateLabel}
+                        </span>
+                        {formatTimeRange(item.startTime, item.endTime) && (
+                          <>
+                            {" · "}
+                            <span className="font-medium text-[var(--on-surface)]">Время:</span>{" "}
+                            {formatTimeRange(item.startTime, item.endTime)}
+                          </>
+                        )}
+                      </p>
+                      <p className="rounded-[18px] bg-[var(--surface)] px-4 py-3">
+                        <span className="block text-xs font-semibold uppercase tracking-[0.08em] text-[var(--primary)]">
+                          Группа
+                        </span>
+                        <span className="font-medium text-[var(--on-surface)]">
+                          {item.groupSize} чел.
+                        </span>
+                      </p>
+                      <p className="rounded-[18px] bg-[var(--surface)] px-4 py-3">
+                        <span className="block text-xs font-semibold uppercase tracking-[0.08em] text-[var(--primary)]">
+                          Бюджет
+                        </span>
+                        <span className="font-medium text-[var(--on-surface)]">
+                          {item.budgetLabel}
+                        </span>
+                      </p>
+                    </div>
+
+                    {/* Actions */}
+                    <div className="mt-5 flex flex-col gap-3 border-t border-[var(--outline)] pt-5 sm:flex-row sm:items-center">
+                      {alreadyOffered ? (
+                        <div className="flex flex-col gap-2">
+                          <span className="inline-flex w-fit items-center gap-1.5 whitespace-nowrap rounded-full bg-[var(--brand-50)] px-3.5 py-1.5 text-xs font-semibold text-[var(--primary)]">
+                            Предложение отправлено
+                          </span>
+                          {offerMeta && (offerMeta.starts_at != null || offerMeta.capacity != null || offerMeta.price_minor != null) ? (
+                            <p className="text-xs leading-relaxed text-[var(--on-surface-muted)]">
+                              Вы предложили:
+                              {offerMeta.starts_at ? ` ${new Date(offerMeta.starts_at).toLocaleDateString("ru-RU", { day: "numeric", month: "long" })}` : ""}
+                              {offerMeta.capacity != null ? ` · ${offerMeta.capacity} чел.` : ""}
+                              {offerMeta.price_minor != null ? ` · ${Math.round(offerMeta.price_minor / 100 / (offerMeta.capacity ?? 1)).toLocaleString("ru-RU")} ₽/чел.` : ""}
+                            </p>
+                          ) : null}
                         </div>
-
-
-                        {/* Actions */}
-                        <div className="mt-4 flex flex-wrap items-center gap-3">
-                          {alreadyOffered ? (
-                            <div className="flex flex-col gap-2">
-                              <span className="inline-flex items-center gap-1.5 whitespace-nowrap rounded-full bg-primary/10 px-3.5 py-1.5 text-xs font-semibold text-primary">
-                                ✓ Предложение отправлено
-                              </span>
-                              {offerMeta && (offerMeta.starts_at != null || offerMeta.capacity != null || offerMeta.price_minor != null) ? (
-                                <p className="text-xs leading-relaxed text-muted-foreground">
-                                  Вы предложили:
-                                  {offerMeta.starts_at ? ` ${new Date(offerMeta.starts_at).toLocaleDateString("ru-RU", { day: "numeric", month: "long" })}` : ""}
-                                  {offerMeta.capacity != null ? ` · ${offerMeta.capacity} чел.` : ""}
-                                  {offerMeta.price_minor != null ? ` · ${Math.round(offerMeta.price_minor / 100 / (offerMeta.capacity ?? 1)).toLocaleString("ru-RU")} ₽/чел.` : ""}
-                                </p>
-                              ) : null}
-                            </div>
-                          ) : isApproved ? (
-                            <Button
-                              variant="default"
-                              size="sm"
-                              onClick={() => setPanelRequestId(item.id)}
-                            >
-                              Сделать предложение
-                            </Button>
-                          ) : (
-                            <div className="flex flex-wrap items-center gap-2">
-                              <Button variant="default" size="sm" disabled>
-                                Доступно после верификации
-                              </Button>
-                              <Link
-                                href="/guide/profile#verification"
-                                className="text-xs text-primary underline-offset-2 hover:underline"
-                              >
-                                Пройти верификацию →
-                              </Link>
-                            </div>
-                          )}
-                          <Link
-                            href={`/guide/inbox/${item.id}`}
-                            className="ml-auto text-sm font-medium text-primary underline-offset-2 hover:underline"
-                            aria-label={`Открыть полный запрос: ${item.destination}`}
+                      ) : isApproved ? (
+                        <Button
+                          variant="default"
+                          size="sm"
+                          onClick={() => setPanelRequestId(item.id)}
+                          className="rounded-[14px] bg-[var(--primary)] px-5 text-white shadow-[0_12px_24px_-16px_var(--primary)] hover:-translate-y-0.5 hover:bg-[var(--primary-hover)]"
+                        >
+                          Сделать предложение
+                        </Button>
+                      ) : (
+                        <div className="flex flex-wrap items-center gap-2">
+                          <Button
+                            variant="default"
+                            size="sm"
+                            disabled
+                            className="rounded-[14px] bg-[var(--primary)] px-5 text-white"
                           >
-                            Подробнее →
+                            Доступно после верификации
+                          </Button>
+                          <Link
+                            href="/guide/profile#verification"
+                            className="text-xs font-semibold text-[var(--primary)] underline-offset-2 hover:underline"
+                          >
+                            Пройти верификацию →
                           </Link>
                         </div>
-
-                        {/* Q&A panel — shown when guide has sent an offer */}
-                        {showQaPanel ? (
-                          <div className="mt-4 pt-4 border-t border-border/50">
-                              <GuideOfferQaPanel key={offerId} offerId={offerId} />
-                          </div>
-                        ) : null}
-                      </div>
-
-                      {index < filteredItems.length - 1 ? <Separator /> : null}
+                      )}
+                      <Link
+                        href={`/guide/inbox/${item.id}`}
+                        className="text-sm font-semibold text-[var(--primary)] underline-offset-2 hover:underline sm:ml-auto"
+                        aria-label={`Открыть полный запрос: ${item.destination}`}
+                      >
+                        Подробнее →
+                      </Link>
                     </div>
-                  );
-                })}
-              </div>
-            </>
-          )}
-        </CardContent>
-      </Card>
+
+                    {/* Q&A panel — shown when guide has sent an offer */}
+                    {showQaPanel ? (
+                      <div className="mt-5 border-t border-[var(--outline)] pt-5">
+                        <GuideOfferQaPanel key={offerId} offerId={offerId} />
+                      </div>
+                    ) : null}
+                  </article>
+                );
+              })}
+            </div>
+          </div>
+        )}
+      </section>
 
       {panelRequestId && panelRequest ? (
         <BidFormPanel

--- a/src/features/homepage/components/hero-conversation.tsx
+++ b/src/features/homepage/components/hero-conversation.tsx
@@ -121,66 +121,35 @@ export function HeroConversation() {
 
   return (
     <section
-      className="relative flex min-h-[calc(100svh-var(--nav-h))] flex-col items-center justify-center overflow-hidden px-[clamp(20px,4vw,48px)] py-12"
+      className="relative flex min-h-[calc(100svh-var(--nav-h))] flex-col items-center justify-center overflow-hidden bg-[var(--surface)] px-[clamp(20px,4vw,48px)] py-[clamp(72px,10vw,128px)] font-display"
       aria-label="Создать запрос гида"
     >
-      {/* Frosted full-bleed background: heavily blurred + light-washed photo → soft texture, not a vivid hero */}
-      <div aria-hidden="true" className="pointer-events-none absolute inset-0 -z-10 overflow-hidden bg-[#eaf1ec]">
-        <div
-          className="absolute inset-0"
-          style={{
-            backgroundImage: "url('/hero-valley.jpg')",
-            backgroundPosition: "center 42%",
-            backgroundSize: "cover",
-            backgroundRepeat: "no-repeat",
-            filter: "blur(13px) saturate(0.92) brightness(1.04)",
-            transform: "scale(1.14)",
-          }}
-        />
-        {/* Light wash → keeps text legible over the photo (frosted lens at center) */}
-        <div
-          className="absolute inset-0"
-          style={{
-            background:
-              "radial-gradient(74% 46% at 50% 47%, rgba(248,251,247,0.90) 0%, rgba(248,251,247,0.55) 40%, rgba(248,251,247,0.14) 66%, transparent 82%), linear-gradient(180deg, rgba(243,248,244,0.36) 0%, rgba(243,248,244,0.04) 26%, transparent 56%, rgba(233,242,236,0.44) 100%)",
-          }}
-        />
-        {/* Subtle gold glow, top-right */}
-        <div
-          className="absolute inset-0"
-          style={{ background: "radial-gradient(38% 26% at 84% 10%, rgba(224,161,38,0.12), transparent 60%)" }}
-        />
+      <div aria-hidden="true" className="pointer-events-none absolute inset-0 -z-10 overflow-hidden">
+        <div className="absolute left-1/2 top-0 h-[420px] w-[min(760px,90vw)] -translate-x-1/2 rounded-full bg-[radial-gradient(circle_at_center,rgba(31,122,92,0.16),rgba(238,247,242,0.42)_38%,transparent_72%)]" />
       </div>
 
-      <div className="mx-auto flex w-full max-w-xl flex-col items-center">
+      <div className="mx-auto flex w-full max-w-3xl flex-col items-center">
         <h1
-          className="animate-in fade-in-50 slide-in-from-bottom-2 mb-3 text-center font-display text-[clamp(2rem,6vw,3.25rem)] leading-[1.08] duration-700"
-          style={{
-            backgroundImage: "linear-gradient(135deg,#2E9B74 0%,#1F7A5C 50%,#145C44 100%)",
-            WebkitBackgroundClip: "text",
-            backgroundClip: "text",
-            color: "transparent",
-          }}
+          className="animate-in fade-in-50 slide-in-from-bottom-2 mb-4 text-center text-[clamp(2.5rem,7vw,4.5rem)] font-semibold leading-[1.02] tracking-[-0.04em] text-[var(--on-surface)] duration-700"
         >
-          Расскажите о поездке
+          Расскажите <span className="text-[var(--primary)]">о поездке</span>
         </h1>
 
         <p
-          className="animate-in fade-in-50 mb-7 flex min-h-[2.5rem] items-center justify-center text-center text-[15px] leading-snug text-muted-foreground duration-700"
+          className="animate-in fade-in-50 mb-8 flex min-h-[2.5rem] max-w-2xl items-center justify-center text-center text-[clamp(1rem,2vw,1.125rem)] leading-relaxed text-[var(--on-surface-muted)] duration-700"
           aria-live="polite"
         >
           {assistantMessage}
         </p>
 
-        {/* The one bar — frosted glass */}
         <form
           onSubmit={handleSend}
           className="animate-in fade-in-50 slide-in-from-bottom-3 w-full duration-700"
         >
           <div
             className={cn(
-              "flex items-center gap-2 rounded-2xl border border-white/80 bg-[rgba(255,255,255,0.62)] p-2 pl-4 shadow-panel backdrop-blur-xl backdrop-saturate-150 transition-shadow",
-              "focus-within:border-primary/50",
+              "flex items-center gap-3 rounded-[20px] border border-[var(--outline)] bg-white p-3 pl-5 shadow-[0_18px_48px_-28px_rgba(10,40,28,0.38),0_4px_24px_rgba(10,40,28,0.08)] transition-shadow",
+              "focus-within:border-[var(--primary)] focus-within:shadow-[0_20px_54px_-28px_rgba(10,40,28,0.45),0_0_0_4px_rgba(31,122,92,0.10)]",
             )}
           >
             <input
@@ -191,19 +160,19 @@ export function HeroConversation() {
               autoFocus
               placeholder="Москва, завтра, вдвоём, 5000 ₽, история и еда"
               aria-label="Опишите вашу поездку"
-              className="min-w-0 flex-1 bg-transparent text-[16px] text-foreground placeholder:text-muted-foreground/70 focus:outline-none"
+              className="min-w-0 flex-1 bg-transparent py-2 text-[16px] font-normal leading-6 text-[var(--on-surface)] placeholder:text-[var(--on-surface-muted)] focus:outline-none"
             />
             <Button
               type="submit"
               size="icon"
               disabled={isParsing || !input.trim()}
               aria-label="Отправить"
-              className="h-11 w-11 shrink-0 rounded-xl"
+              className="h-12 w-12 shrink-0 rounded-[14px] bg-[var(--primary)] text-white shadow-[0_12px_24px_-16px_rgba(10,39,30,0.7)] transition-all hover:-translate-y-0.5 hover:bg-[var(--primary-hover)] hover:text-white focus-visible:ring-[rgba(31,122,92,0.30)]"
             >
               {isParsing ? (
-                <span className="h-4 w-4 animate-spin rounded-full border-2 border-primary-foreground/40 border-t-primary-foreground" />
+                <span className="h-4 w-4 animate-spin rounded-full border-2 border-white/40 border-t-white" />
               ) : (
-                <span aria-hidden="true" className="text-lg leading-none">
+                <span aria-hidden="true" className="text-xl leading-none">
                   ↑
                 </span>
               )}
@@ -211,7 +180,7 @@ export function HeroConversation() {
           </div>
         </form>
 
-        <p className="mt-3 text-center text-xs text-muted-foreground">
+        <p className="mt-4 text-center text-xs font-medium text-[var(--on-surface-muted)]">
           Бесплатно · без регистрации · местный гид, а не турбюро
         </p>
 
@@ -221,17 +190,15 @@ export function HeroConversation() {
           </p>
         )}
 
-        <SlotChips fields={fields} className="mt-8 w-full" />
+        <SlotChips
+          fields={fields}
+          className="mt-8 w-full [&_[data-filled]]:border-[var(--outline)] [&_[data-filled]]:px-4 [&_[data-filled]]:py-2 [&_[data-filled]]:font-semibold [&_[data-filled]]:text-[var(--primary)] [&_[data-filled=false]]:border-solid [&_[data-filled=false]]:bg-white [&_[data-filled=true]]:bg-[var(--brand-50)] [&_p]:font-medium [&_p]:text-[var(--on-surface-muted)]"
+        />
 
         {/* Honest, deferred urgency — appears only once a date is set; the deadline is the traveler's own */}
         {fields.startDate && !complete && (
           <p
-            className="animate-in fade-in-50 mt-6 flex items-center justify-center gap-2 rounded-xl px-3 py-2 text-center text-[13px] leading-snug duration-500"
-            style={{
-              color: "#8A6A12",
-              background: "rgba(224,161,38,0.12)",
-              border: "1px solid rgba(224,161,38,0.3)",
-            }}
+            className="animate-in fade-in-50 mt-6 flex items-center justify-center gap-2 rounded-[14px] border border-[rgba(224,161,38,0.30)] bg-[rgba(224,161,38,0.12)] px-3 py-2 text-center text-[13px] leading-snug text-[#8A6A12] duration-500"
           >
             <span aria-hidden="true">⏳</span>
             На популярные даты гидов разбирают быстро — отправьте запрос, пока выбор большой.
@@ -250,16 +217,16 @@ export function HeroConversation() {
               type="button"
               onClick={handleCreate}
               disabled={isCreating}
-              className="h-14 w-full rounded-2xl text-base"
+              className="h-14 w-full rounded-[14px] bg-[var(--primary)] text-base font-semibold text-white shadow-[0_16px_34px_-22px_rgba(10,39,30,0.75)] transition-all hover:-translate-y-0.5 hover:bg-[var(--primary-hover)] hover:text-white"
             >
               {isCreating ? "Отправляем…" : "Подобрать гида"}
             </Button>
           </div>
         )}
 
-        <p className="mt-6 text-center text-xs text-muted-foreground">
+        <p className="mt-6 text-center text-xs text-[var(--on-surface-muted)]">
           Предпочитаете заполнить вручную?{" "}
-          <Link href="/" className="font-medium text-primary underline-offset-2 hover:underline">
+          <Link href="/" className="font-semibold text-[var(--primary)] underline-offset-2 hover:underline">
             Обычная форма
           </Link>
         </p>

--- a/src/features/listings/components/public/public-listing-discovery-screen.tsx
+++ b/src/features/listings/components/public/public-listing-discovery-screen.tsx
@@ -1,43 +1,107 @@
 "use client";
 
 import { useMemo, useState } from "react";
+import Image from "next/image";
 import Link from "next/link";
-import { Compass } from "lucide-react";
+import { Clock, Compass, MapPin, Users } from "lucide-react";
 
 import { Input } from "@/components/ui/input";
-import { ListingCard } from "@/components/shared/listing-card";
-import type { ListingRecord } from "@/data/supabase/queries";
 import type { PublicListing } from "@/data/public-listings/types";
-import { THEMES, type ThemeSlug } from "@/data/themes";
+import { getTheme, THEMES, type ThemeSlug } from "@/data/themes";
+import { cn, pluralize } from "@/lib/utils";
 
-function mapListing(listing: PublicListing): ListingRecord {
-  return {
-    id: listing.slug,
-    slug: listing.slug,
-    title: listing.title,
-    destinationSlug: listing.city.toLowerCase().replaceAll(" ", "-"),
-    destinationName: listing.city,
-    destinationRegion: listing.region,
-    imageUrl:
-      listing.coverImageUrl ??
-      "https://images.unsplash.com/photo-1476514525535-07fb3b4ae5f1?auto=format&fit=crop&w=1600&q=80",
-    priceRub: listing.priceFromRub,
-    durationDays: listing.durationDays,
-    durationLabel: `${listing.durationDays} дн.`,
-    groupSize: listing.groupSizeMax,
-    difficulty: "Средняя",
-    departure: listing.city,
-    format: listing.themes[0] ?? "Маршрут",
-    description: listing.highlights.join(". "),
-    inclusions: [...listing.inclusions],
-    exclusions: [],
-    guideSlug: listing.guideSlug,
-    guideName: "Локальный гид",
-    guideHomeBase: listing.city,
-    rating: 0,
-    reviewCount: 0,
-    status: "active",
-  };
+const fallbackImageUrl =
+  "https://images.unsplash.com/photo-1476514525535-07fb3b4ae5f1?auto=format&fit=crop&w=1600&q=80";
+
+const priceFormatter = new Intl.NumberFormat("ru-RU");
+
+function getDurationLabel(days: number): string {
+  return `${days} ${pluralize(days, "день", "дня", "дней")}`;
+}
+
+function PublicListingCard({
+  listing,
+  priority,
+}: {
+  listing: PublicListing;
+  priority: boolean;
+}) {
+  return (
+    <Link
+      href={`/listings/${listing.slug}`}
+      className="group flex h-full cursor-pointer flex-col overflow-hidden rounded-[24px] border border-[var(--outline)] bg-[var(--surface-lowest)] shadow-[var(--card-shadow)] transition duration-200 hover:-translate-y-1 hover:shadow-[var(--lift-shadow)] focus-visible:outline-none focus-visible:ring-3 focus-visible:ring-[var(--primary)]/25"
+    >
+      <div className="relative aspect-[4/3] overflow-hidden bg-[var(--surface-low)]">
+        <Image
+          src={listing.coverImageUrl ?? fallbackImageUrl}
+          alt={listing.title}
+          fill
+          priority={priority}
+          fetchPriority={priority ? "high" : "auto"}
+          sizes="(max-width: 767px) 100vw, (max-width: 1279px) 50vw, 33vw"
+          className="object-cover transition duration-500 group-hover:scale-[1.03]"
+        />
+      </div>
+
+      <div className="flex flex-1 flex-col gap-5 p-6">
+        <div className="space-y-3">
+          <div className="flex flex-wrap gap-2">
+            {listing.themes.map((slug) => {
+              const theme = getTheme(slug);
+              if (!theme) return null;
+              const { Icon, label } = theme;
+              return (
+                <span
+                  key={slug}
+                  className="inline-flex items-center gap-1.5 rounded-full bg-[var(--brand-50)] px-3 py-1 text-xs font-semibold text-[var(--primary)]"
+                >
+                  <Icon className="size-3.5 shrink-0" aria-hidden />
+                  {label}
+                </span>
+              );
+            })}
+          </div>
+
+          <h2 className="text-[1.35rem] font-semibold leading-[1.12] text-[var(--on-surface)]">
+            {listing.title}
+          </h2>
+
+          <p className="flex items-center gap-2 text-sm font-medium text-[var(--on-surface-muted)]">
+            <MapPin className="size-4 shrink-0 text-[var(--primary)]" aria-hidden />
+            <span>
+              {listing.city}, {listing.region}
+            </span>
+          </p>
+        </div>
+
+        <p className="line-clamp-2 text-sm leading-6 text-[var(--on-surface-muted)]">
+          {listing.highlights.join(". ")}
+        </p>
+
+        <div className="mt-auto flex flex-wrap items-end justify-between gap-4 border-t border-[var(--outline)] pt-5">
+          <div>
+            <p className="text-xs font-semibold uppercase tracking-[0.1em] text-[var(--primary)]">
+              Стоимость
+            </p>
+            <p className="mt-1 text-[1.35rem] font-bold leading-none text-[var(--on-surface)]">
+              от {priceFormatter.format(listing.priceFromRub)} ₽
+            </p>
+          </div>
+
+          <div className="flex flex-wrap gap-2 text-xs font-semibold text-[var(--on-surface-muted)]">
+            <span className="inline-flex items-center gap-1.5 rounded-full border border-[var(--outline)] bg-white px-3 py-1.5">
+              <Clock className="size-3.5 text-[var(--primary)]" aria-hidden />
+              {getDurationLabel(listing.durationDays)}
+            </span>
+            <span className="inline-flex items-center gap-1.5 rounded-full border border-[var(--outline)] bg-white px-3 py-1.5">
+              <Users className="size-3.5 text-[var(--primary)]" aria-hidden />
+              до {listing.groupSizeMax} чел.
+            </span>
+          </div>
+        </div>
+      </div>
+    </Link>
+  );
 }
 
 export function PublicListingDiscoveryScreen({
@@ -73,80 +137,94 @@ export function PublicListingDiscoveryScreen({
   }, [activeFilter, listings, search]);
 
   return (
-    <div className="space-y-10">
-      <section>
-        <h1 className="text-[clamp(2.5rem,5vw,4rem)] font-semibold leading-[1.05] text-ink">
-          Готовые экскурсии
-        </h1>
-      </section>
+    <div className="bg-[var(--surface)] px-4 py-10 sm:px-6 lg:px-8">
+      <div className="mx-auto max-w-7xl space-y-8">
+        <section className="max-w-3xl space-y-4">
+          <p className="text-xs font-semibold uppercase tracking-[0.1em] text-[var(--primary)]">
+            Каталог гидов
+          </p>
+          <h1 className="text-[clamp(2rem,4.4vw,3.25rem)] font-semibold leading-[1.04] text-[var(--on-surface)]">
+            Готовые экскурсии
+          </h1>
+          <p className="max-w-2xl text-base leading-7 text-[var(--on-surface-muted)] sm:text-lg">
+            Выбирайте готовые маршруты от локальных гидов: понятная цена, формат группы и
+            длительность уже собраны в карточке.
+          </p>
+        </section>
 
-      <div className="max-w-[32rem]">
-        <Input
-          type="search"
-          value={search}
-          onChange={(event) => setSearch(event.target.value)}
-          placeholder="Поиск по названию, описанию или направлению…"
-          aria-label="Поиск по экскурсиям"
-        />
-      </div>
+        <div className="max-w-[36rem]">
+          <Input
+            type="search"
+            value={search}
+            onChange={(event) => setSearch(event.target.value)}
+            placeholder="Поиск по названию, описанию или направлению…"
+            aria-label="Поиск по экскурсиям"
+            className="h-12 rounded-[14px] border-[var(--outline)] bg-[var(--surface-lowest)] text-[var(--on-surface)] shadow-[var(--card-shadow)] placeholder:text-[var(--on-surface-muted)] focus-visible:border-[var(--primary)] focus-visible:ring-[var(--primary)]/20"
+          />
+        </div>
 
-      <div className="flex flex-wrap gap-3">
-        <button
-          key="all"
-          type="button"
-          onClick={() => setActiveFilter("all")}
-          className={
-            activeFilter === "all"
-              ? "inline-flex h-10 cursor-pointer items-center justify-center rounded-full bg-brand px-5 text-[0.9rem] font-semibold text-white shadow-[0_8px_24px_rgba(0,88,190,0.28)]"
-              : "inline-flex h-10 cursor-pointer items-center justify-center rounded-full bg-surface-low px-5 text-[0.9rem] font-medium text-ink-2 transition-colors hover:bg-brand/10 hover:text-brand"
-          }
-        >
-          Все
-        </button>
-        {THEMES.map(({ slug, label, Icon }) => (
+        <div className="flex flex-wrap gap-3">
           <button
-            key={slug}
+            key="all"
             type="button"
-            onClick={() => setActiveFilter(slug)}
-            className={
-              activeFilter === slug
-                ? "inline-flex h-10 cursor-pointer items-center gap-2 rounded-full bg-brand px-5 text-[0.9rem] font-semibold text-white shadow-[0_8px_24px_rgba(0,88,190,0.28)]"
-                : "inline-flex h-10 cursor-pointer items-center gap-2 rounded-full bg-surface-low px-5 text-[0.9rem] font-medium text-ink-2 transition-colors hover:bg-brand/10 hover:text-brand"
-            }
+            onClick={() => setActiveFilter("all")}
+            className={cn(
+              "inline-flex h-10 cursor-pointer items-center justify-center rounded-full border px-5 text-[0.9rem] transition-colors focus-visible:outline-none focus-visible:ring-3 focus-visible:ring-[var(--primary)]/20",
+              activeFilter === "all"
+                ? "border-[var(--brand-50)] bg-[var(--brand-50)] font-semibold text-[var(--primary)]"
+                : "border-[var(--outline)] bg-[var(--surface-lowest)] font-medium text-[var(--on-surface-muted)] hover:border-[var(--primary)] hover:text-[var(--primary)]",
+            )}
           >
-            <Icon className="size-4 shrink-0" aria-hidden />
-            {label}
+            Все
           </button>
-        ))}
-      </div>
-
-      {filteredListings.length > 0 ? (
-        <div className="grid grid-cols-1 gap-5 md:grid-cols-2 lg:grid-cols-3">
-          {filteredListings.map((listing, index) => (
-            <ListingCard
-              key={listing.slug}
-              listing={mapListing(listing)}
-              priority={index === 0}
-            />
+          {THEMES.map(({ slug, label, Icon }) => (
+            <button
+              key={slug}
+              type="button"
+              onClick={() => setActiveFilter(slug)}
+              className={cn(
+                "inline-flex h-10 cursor-pointer items-center gap-2 rounded-full border px-5 text-[0.9rem] transition-colors focus-visible:outline-none focus-visible:ring-3 focus-visible:ring-[var(--primary)]/20",
+                activeFilter === slug
+                  ? "border-[var(--brand-50)] bg-[var(--brand-50)] font-semibold text-[var(--primary)]"
+                  : "border-[var(--outline)] bg-[var(--surface-lowest)] font-medium text-[var(--on-surface-muted)] hover:border-[var(--primary)] hover:text-[var(--primary)]",
+              )}
+            >
+              <Icon className="size-4 shrink-0" aria-hidden />
+              {label}
+            </button>
           ))}
         </div>
-      ) : (
-        <div className="bg-glass backdrop-blur-[20px] border border-glass-border shadow-glass flex flex-col items-center justify-center rounded-[1.5rem] px-6 py-16 text-center">
-          <span className="flex size-14 items-center justify-center rounded-full bg-brand-light text-brand">
-            <Compass className="size-6" strokeWidth={1.9} />
-          </span>
-          <h2 className="mt-5 text-[1.35rem] font-semibold text-ink">Маршруты не найдены</h2>
-          <p className="mt-2 max-w-[30rem] text-[0.95rem] leading-7 text-ink-2">
-            Попробуйте другой фильтр или создайте запрос на индивидуальный маршрут.
-          </p>
-          <Link
-            href="/"
-            className="mt-6 inline-flex h-11 items-center justify-center rounded-full bg-brand px-6 text-[0.9rem] font-semibold text-white shadow-[0_8px_24px_rgba(0,88,190,0.28)]"
-          >
-            Создать запрос
-          </Link>
-        </div>
-      )}
+
+        {filteredListings.length > 0 ? (
+          <div className="grid grid-cols-1 gap-6 md:grid-cols-2 xl:grid-cols-3">
+            {filteredListings.map((listing, index) => (
+              <PublicListingCard
+                key={listing.slug}
+                listing={listing}
+                priority={index === 0}
+              />
+            ))}
+          </div>
+        ) : (
+          <div className="flex flex-col items-center justify-center rounded-[24px] border border-[var(--outline)] bg-[var(--surface-lowest)] px-6 py-16 text-center shadow-[var(--card-shadow)]">
+            <span className="flex size-14 items-center justify-center rounded-full bg-[var(--brand-50)] text-[var(--primary)]">
+              <Compass className="size-6" strokeWidth={1.9} />
+            </span>
+            <h2 className="mt-5 text-[1.35rem] font-semibold text-[var(--on-surface)]">
+              Маршруты не найдены
+            </h2>
+            <p className="mt-2 max-w-[30rem] text-[0.95rem] leading-7 text-[var(--on-surface-muted)]">
+              Попробуйте другой фильтр или измените поисковый запрос.
+            </p>
+            <Link
+              href="/"
+              className="mt-6 inline-flex h-11 items-center justify-center rounded-[14px] bg-[var(--primary)] px-6 text-[0.9rem] font-semibold text-white transition duration-200 hover:-translate-y-0.5 hover:bg-[var(--primary-hover)] focus-visible:outline-none focus-visible:ring-3 focus-visible:ring-[var(--primary)]/25"
+            >
+              Создать запрос
+            </Link>
+          </div>
+        )}
+      </div>
     </div>
   );
 }

--- a/src/features/requests/components/request-detail-screen.tsx
+++ b/src/features/requests/components/request-detail-screen.tsx
@@ -134,6 +134,10 @@ const assemblyChip = `${chipBase} bg-sky-100 text-sky-700`;
 const privateChip = `${chipBase} bg-purple-100 text-purple-700`;
 const flexibleChip = `${chipBase} bg-emerald-100 text-emerald-700`;
 const exactChip = `${chipBase} bg-rose-100 text-rose-700`;
+const publicCardClassName =
+  "rounded-[24px] border border-[var(--outline-variant)] bg-[var(--surface-lowest)] p-6 shadow-[var(--card-shadow)] md:p-[26px]";
+const publicEyebrowClassName =
+  "mb-4 text-[12px] font-semibold uppercase tracking-[0.1em] text-[var(--primary)]";
 
 function formatPublicPrice(pricePerPersonRub: number | null): string {
   if (!pricePerPersonRub) return "Цена уточняется";
@@ -165,7 +169,7 @@ function JoinCta({
   compact?: boolean;
 }) {
   const className = cn(
-    "w-full cursor-pointer rounded-[14px] border-primary/60 bg-primary py-4 text-base font-semibold text-primary-foreground shadow-glass hover:bg-primary-hover",
+    "w-full cursor-pointer rounded-[14px] border border-[var(--primary)] bg-[var(--primary)] py-4 text-base font-semibold text-white shadow-[0_14px_28px_-18px_rgba(10,39,30,0.55)] transition duration-200 hover:-translate-y-0.5 hover:bg-[var(--primary-hover)] hover:shadow-[0_18px_36px_-20px_rgba(10,39,30,0.65)]",
     compact && "py-3.5 text-sm",
   );
 
@@ -210,7 +214,7 @@ function ThemeChips({ themes }: { themes: string[] }) {
         return (
           <span
             key={theme}
-            className="inline-flex rounded-full bg-surface-low px-3.5 py-1.5 text-[0.84rem] font-medium text-foreground"
+            className="inline-flex rounded-full bg-[var(--brand-50)] px-3.5 py-1.5 text-[0.84rem] font-semibold text-[var(--primary)]"
           >
             {themeData?.label ?? theme}
           </span>
@@ -221,7 +225,7 @@ function ThemeChips({ themes }: { themes: string[] }) {
 }
 
 function AvatarGroupVisual({ children }: { children: ReactNode }) {
-  return <div className="flex -space-x-2.5">{children}</div>;
+  return <div className="flex -space-x-3">{children}</div>;
 }
 
 function MemberAvatars({ members }: { members: PublicRequestDetailViewModel["members"] }) {
@@ -230,7 +234,10 @@ function MemberAvatars({ members }: { members: PublicRequestDetailViewModel["mem
       {members.slice(0, 5).map((member, index) => (
         <Avatar
           key={member.id}
-          className="size-[42px] border-[2.5px] border-background shadow-sm"
+          className={cn(
+            "size-[44px] border-[2.5px] border-white shadow-sm",
+            index === 0 && "ring-2 ring-[var(--gold)] ring-offset-2 ring-offset-white",
+          )}
           title={member.displayName}
         >
           {member.avatarUrl ? <AvatarImage src={member.avatarUrl} alt={member.displayName} /> : null}
@@ -254,23 +261,45 @@ function DecisionCard({
 
   return (
     <aside className="lg:sticky lg:top-[108px]">
-      <div className="rounded-[22px] border border-border bg-surface-high p-6 shadow-glass">
-        <div className="font-display text-[2rem] font-bold leading-none tracking-[-0.02em] text-foreground">
+      <div className={cn(publicCardClassName, "lg:p-7")}>
+        <p className="mb-3 text-[12px] font-semibold uppercase tracking-[0.1em] text-[var(--primary)]">
+          Бронирование
+        </p>
+        <div className="font-display text-[clamp(2rem,4vw,2.55rem)] font-bold leading-none tracking-[-0.03em] text-[var(--on-surface)]">
           {price}{" "}
           {viewModel.pricePerPersonRub ? (
-            <small className="text-base font-medium text-muted-foreground">/ с человека</small>
+            <small className="text-base font-medium tracking-normal text-[var(--on-surface-muted)]">
+              / с человека
+            </small>
           ) : null}
         </div>
-        <p className="mt-3 text-sm leading-[1.55] text-muted-foreground">
-          Добор открыт: группа сейчас {viewModel.memberCount}{" "}
-          {pluralize(viewModel.memberCount, "человек", "человека", "человек")}. Финальную цену предложат гиды.
-        </p>
+        <div className="mt-4 rounded-[16px] bg-[var(--brand-50)] px-4 py-3 text-sm font-medium leading-[1.5] text-[var(--primary)]">
+          Ничего не платите сейчас. Финальную цену предложат гиды.
+        </div>
+        <div className="mt-5 flex items-center gap-3 rounded-[18px] border border-[var(--outline-variant)] bg-white px-4 py-3">
+          <MemberAvatars members={viewModel.members} />
+          <div className="min-w-0 text-sm leading-[1.4] text-[var(--on-surface-muted)]">
+            <span className="mr-1 inline-flex size-2 rounded-full bg-[var(--gold)] shadow-[0_0_0_5px_rgba(224,161,38,0.18)]" />
+            Сейчас в группе {viewModel.memberCount}{" "}
+            {pluralize(viewModel.memberCount, "человек", "человека", "человек")}
+          </div>
+        </div>
         <div className="mt-5 hidden lg:block">
           <JoinCta requestId={requestId} joinState={viewModel.joinState} />
         </div>
-        <div className="mt-4 flex items-center gap-2 border-t border-border pt-4 text-[0.84rem] text-muted-foreground">
-          <Eye className="size-4 text-primary" aria-hidden="true" />
-          Гиды уже видят этот запрос
+        <div className="mt-5 grid gap-3 border-t border-[var(--outline-variant)] pt-5 text-[0.84rem] font-medium text-[var(--on-surface-muted)]">
+          <div className="flex items-center gap-2">
+            <span className="flex size-8 items-center justify-center rounded-full bg-[var(--brand-50)] text-[var(--primary)]">
+              <Eye className="size-4" aria-hidden="true" />
+            </span>
+            Гиды уже видят этот запрос
+          </div>
+          <div className="flex items-center gap-2">
+            <span className="flex size-8 items-center justify-center rounded-full bg-[var(--brand-50)] text-[var(--primary)]">
+              <Check className="size-4" aria-hidden="true" />
+            </span>
+            Присоединиться можно без предоплаты
+          </div>
         </div>
       </div>
     </aside>
@@ -288,115 +317,153 @@ function PublicDetailBranch({
   const hasAbout = viewModel.notes.trim().length > 0;
 
   return (
-    <div className="bg-surface pb-24 lg:pb-0">
-      <section className="relative h-[240px] overflow-hidden bg-foreground md:h-[300px]">
-        <Image
-          src={viewModel.cityImageUrl}
-          alt={viewModel.title}
-          width={1800}
-          height={600}
-          priority
-          sizes="100vw"
-          className="h-[240px] w-full object-cover md:h-[300px]"
-        />
-        <div
-          className="absolute inset-0 bg-gradient-to-b from-foreground/10 via-transparent to-foreground/80"
-          aria-hidden="true"
-        />
-        <div className="absolute inset-x-0 bottom-0 z-[2]">
-          <div className="mx-auto w-full max-w-page px-[clamp(20px,4vw,48px)] pb-6">
-            <span className="inline-flex items-center gap-2 rounded-full border border-primary-foreground/20 bg-primary-foreground/15 px-3.5 py-1.5 text-[0.82rem] font-medium text-primary-foreground backdrop-blur-[8px]">
-              <span className="size-2 rounded-full bg-success shadow-[0_0_0_3px_rgba(127,227,182,0.25)]" aria-hidden="true" />
+    <div className="bg-[var(--surface)] pb-24 lg:pb-0">
+      <section className="mx-auto w-full max-w-page px-[clamp(20px,4vw,48px)] pt-6">
+        <div className="relative h-[320px] overflow-hidden rounded-[28px] bg-[var(--brand-950)] shadow-[var(--card-shadow)] md:h-[420px]">
+          <Image
+            src={viewModel.cityImageUrl}
+            alt={viewModel.title}
+            width={1800}
+            height={720}
+            priority
+            sizes="(min-width: 1200px) 1120px, calc(100vw - 40px)"
+            className="h-full w-full object-cover"
+          />
+          <div
+            className="absolute inset-0 bg-[linear-gradient(180deg,rgba(10,39,30,.12),rgba(10,39,30,.66))]"
+            aria-hidden="true"
+          />
+          <div className="absolute inset-x-0 bottom-0 z-[2] p-[clamp(22px,4vw,44px)]">
+            <span className="inline-flex items-center gap-2 rounded-full bg-white px-4 py-2 text-[0.82rem] font-semibold text-[var(--primary)] shadow-[0_10px_24px_rgba(10,39,30,0.16)]">
+              <span className="size-2 rounded-full bg-[var(--gold)] shadow-[0_0_0_4px_rgba(224,161,38,0.18)]" aria-hidden="true" />
               Сборная группа
             </span>
-            <h1 className="mt-3 font-display text-[clamp(2.1rem,5vw,2.9rem)] font-bold leading-[1.05] tracking-[-0.02em] text-primary-foreground">
+            <h1 className="mt-4 font-display text-[clamp(2.75rem,7vw,5.25rem)] font-bold leading-[0.96] tracking-[-0.045em] text-white">
               {viewModel.title}
             </h1>
-            <p className="mt-1 text-sm text-primary-foreground/80">{viewModel.regionLabel}</p>
+            <p className="mt-3 text-base font-medium text-white/85 md:text-lg">{viewModel.regionLabel}</p>
           </div>
         </div>
       </section>
 
       <div className="mx-auto grid w-full max-w-page grid-cols-1 gap-8 px-[clamp(20px,4vw,48px)] py-8 lg:grid-cols-[minmax(0,1fr)_380px] lg:items-start lg:gap-9 lg:pb-24">
-        <main>
-          <div className="mb-8 flex flex-wrap gap-2.5">
-            <span className="inline-flex items-center gap-2 rounded-xl border border-border bg-surface-high px-3.5 py-2 text-sm font-medium text-foreground shadow-sm">
-              <CalendarDays className="size-4 text-primary" aria-hidden="true" />
-              {viewModel.dateLabel}
+        <main className="space-y-8">
+          <div className="flex flex-wrap gap-3">
+            <span className="inline-flex items-center gap-3 rounded-full border border-[var(--outline-variant)] bg-white px-4 py-3 text-sm font-semibold text-[var(--on-surface)] shadow-[var(--card-shadow)]">
+              <span className="flex size-9 items-center justify-center rounded-full bg-[var(--brand-50)] text-[var(--primary)]">
+                <CalendarDays className="size-4" aria-hidden="true" />
+              </span>
+              <span>
+                <span className="block text-[11px] font-semibold uppercase tracking-[0.1em] text-[var(--on-surface-muted)]">
+                  Когда
+                </span>
+                {viewModel.dateLabel}
+              </span>
             </span>
             {viewModel.timeLabel ? (
-              <span className="inline-flex items-center gap-2 rounded-xl border border-border bg-surface-high px-3.5 py-2 text-sm font-medium text-foreground shadow-sm">
-                <Clock3 className="size-4 text-primary" aria-hidden="true" />
-                {viewModel.timeLabel}
+              <span className="inline-flex items-center gap-3 rounded-full border border-[var(--outline-variant)] bg-white px-4 py-3 text-sm font-semibold text-[var(--on-surface)] shadow-[var(--card-shadow)]">
+                <span className="flex size-9 items-center justify-center rounded-full bg-[var(--brand-50)] text-[var(--primary)]">
+                  <Clock3 className="size-4" aria-hidden="true" />
+                </span>
+                <span>
+                  <span className="block text-[11px] font-semibold uppercase tracking-[0.1em] text-[var(--on-surface-muted)]">
+                    Время
+                  </span>
+                  {viewModel.timeLabel}
+                </span>
               </span>
             ) : null}
+            <span className="inline-flex items-center gap-3 rounded-full border border-[var(--outline-variant)] bg-white px-4 py-3 text-sm font-semibold text-[var(--on-surface)] shadow-[var(--card-shadow)]">
+              <span className="flex size-9 items-center justify-center rounded-full bg-[var(--brand-50)] text-[var(--primary)]">
+                <Users className="size-4" aria-hidden="true" />
+              </span>
+              <span>
+                <span className="block text-[11px] font-semibold uppercase tracking-[0.1em] text-[var(--on-surface-muted)]">
+                  В группе
+                </span>
+                {viewModel.memberCount} {pluralize(viewModel.memberCount, "человек", "человека", "человек")}
+              </span>
+            </span>
+            <span className="inline-flex items-center gap-3 rounded-full border border-[var(--outline-variant)] bg-white px-4 py-3 text-sm font-semibold text-[var(--primary)] shadow-[var(--card-shadow)]">
+              <span className="flex size-9 items-center justify-center rounded-full bg-[var(--brand-50)] text-[var(--primary)]">
+                <UserPlus className="size-4" aria-hidden="true" />
+              </span>
+              <span>
+                <span className="block text-[11px] font-semibold uppercase tracking-[0.1em] text-[var(--on-surface-muted)]">
+                  Статус
+                </span>
+                Открыта для добора
+              </span>
+            </span>
             {viewModel.datesFlexible ? (
-              <span className="inline-flex items-center gap-2 rounded-xl border border-primary/20 bg-primary/10 px-3.5 py-2 text-sm font-medium text-primary shadow-sm">
-                <ListChecks className="size-4" aria-hidden="true" />
-                Гибкие даты
+              <span className="inline-flex items-center gap-3 rounded-full border border-[var(--outline-variant)] bg-white px-4 py-3 text-sm font-semibold text-[var(--primary)] shadow-[var(--card-shadow)]">
+                <span className="flex size-9 items-center justify-center rounded-full bg-[var(--brand-50)] text-[var(--primary)]">
+                  <ListChecks className="size-4" aria-hidden="true" />
+                </span>
+                <span>
+                  <span className="block text-[11px] font-semibold uppercase tracking-[0.1em] text-[var(--on-surface-muted)]">
+                    Даты
+                  </span>
+                  Гибкие
+                </span>
               </span>
             ) : null}
           </div>
 
-          <section className="mb-8">
-            <h2 className="mb-3.5 text-[0.8rem] font-semibold uppercase tracking-[0.08em] text-muted-foreground">
-              Кто едет
-            </h2>
-            <div className="rounded-[22px] border border-border bg-surface-high p-6 shadow-sm">
-              <div className="flex flex-wrap items-center justify-between gap-4">
-                <p className="text-[1.2rem] font-semibold text-foreground">
-                  В группе сейчас {viewModel.memberCount}{" "}
-                  {pluralize(viewModel.memberCount, "человек", "человека", "человек")}
-                </p>
-                <MemberAvatars members={viewModel.members} />
-              </div>
-              <p className="mt-3.5 text-sm text-muted-foreground">
-                Организатор — <b className="font-semibold text-foreground">{viewModel.organizerName}</b>
-              </p>
-              <div className="mt-3.5 inline-flex items-center gap-1.5 text-[0.84rem] font-medium text-primary">
-                <UserPlus className="size-4" aria-hidden="true" />
-                Группа открыта — можно присоединиться
-              </div>
-            </div>
-          </section>
-
           {hasAbout ? (
-            <section className="mb-8">
-              <h2 className="mb-3.5 text-[0.8rem] font-semibold uppercase tracking-[0.08em] text-muted-foreground">
-                О поездке
-              </h2>
+            <section className={publicCardClassName}>
+              <h2 className={publicEyebrowClassName}>О поездке</h2>
               <ThemeChips themes={viewModel.themes} />
-              <p className="max-w-[60ch] text-[0.97rem] leading-[1.7] text-foreground/85">{viewModel.notes}</p>
+              <p className="max-w-[64ch] text-[1rem] leading-[1.75] text-[var(--ink-2)]">{viewModel.notes}</p>
             </section>
           ) : null}
 
-          <section className="mb-8">
-            <h2 className="mb-3.5 text-[0.8rem] font-semibold uppercase tracking-[0.08em] text-muted-foreground">
-              Как это работает
-            </h2>
+          <section className={publicCardClassName}>
+            <h2 className={publicEyebrowClassName}>Кто едет</h2>
+            <div className="flex flex-wrap items-center justify-between gap-5">
+              <div>
+                <p className="font-display text-[1.45rem] font-semibold leading-tight text-[var(--on-surface)]">
+                  В группе сейчас {viewModel.memberCount}{" "}
+                  {pluralize(viewModel.memberCount, "человек", "человека", "человек")}
+                </p>
+                <p className="mt-2 text-sm text-[var(--on-surface-muted)]">
+                  Организатор — <b className="font-semibold text-[var(--on-surface)]">{viewModel.organizerName}</b>
+                </p>
+              </div>
+              <MemberAvatars members={viewModel.members} />
+            </div>
+            <div className="mt-5 inline-flex items-center gap-2 rounded-full bg-[var(--brand-50)] px-4 py-2 text-[0.9rem] font-semibold text-[var(--primary)]">
+              <UserPlus className="size-4" aria-hidden="true" />
+              Группа открыта — можно присоединиться
+            </div>
+          </section>
+
+          <section className={publicCardClassName}>
+            <h2 className={publicEyebrowClassName}>Как это работает</h2>
             <div className="grid gap-3.5 sm:grid-cols-3">
               {["Присоединяешься к группе", "Гиды предлагают условия и цену", "Группа подтверждает бронь"].map(
                 (step, index) => (
-                  <div key={step} className="rounded-2xl border border-border bg-surface-high p-4 shadow-sm">
-                    <div className="mb-2.5 flex size-7 items-center justify-center rounded-full bg-primary/10 text-sm font-bold text-primary">
+                  <div key={step} className="rounded-[18px] bg-[var(--brand-50)] p-4">
+                    <div className="mb-3 flex size-9 items-center justify-center rounded-full bg-white text-sm font-bold text-[var(--primary)] shadow-sm">
                       {index + 1}
                     </div>
-                    <p className="text-sm leading-[1.45] text-foreground">{step}</p>
+                    <p className="text-sm font-medium leading-[1.5] text-[var(--on-surface)]">{step}</p>
                   </div>
                 ),
               )}
             </div>
           </section>
 
-          <section>
-            <div className="border-t border-border">
+          <section className={publicCardClassName}>
+            <h2 className={publicEyebrowClassName}>FAQ</h2>
+            <div className="space-y-3">
               {faqItems.map((item) => (
-                <details key={item.question} className="group border-b border-border">
-                  <summary className="flex cursor-pointer list-none items-center justify-between gap-4 py-4 text-left text-[0.97rem] font-medium text-foreground marker:hidden">
+                <details key={item.question} className="group rounded-[18px] bg-[var(--brand-50)] px-4">
+                  <summary className="flex cursor-pointer list-none items-center justify-between gap-4 py-4 text-left text-[0.97rem] font-semibold text-[var(--on-surface)] marker:hidden">
                     {item.question}
-                    <ChevronDown className="size-4 text-muted-foreground transition-transform group-open:rotate-180" aria-hidden="true" />
+                    <ChevronDown className="size-4 text-[var(--primary)] transition-transform group-open:rotate-180" aria-hidden="true" />
                   </summary>
-                  <p className="pb-4 text-sm leading-[1.6] text-muted-foreground">{item.answer}</p>
+                  <p className="pb-4 text-sm leading-[1.65] text-[var(--on-surface-muted)]">{item.answer}</p>
                 </details>
               ))}
             </div>
@@ -406,11 +473,11 @@ function PublicDetailBranch({
         <DecisionCard requestId={requestId} viewModel={viewModel} />
       </div>
 
-      <div className="fixed inset-x-0 bottom-0 z-50 flex items-center gap-3 border-t border-border bg-surface-high px-4 py-3 shadow-[0_-6px_24px_rgba(10,40,28,0.10)] lg:hidden">
-        <div className="shrink-0 font-display text-lg font-bold text-foreground">
+      <div className="fixed inset-x-0 bottom-0 z-50 flex items-center gap-3 border-t border-[var(--outline-variant)] bg-white px-4 py-3 shadow-[0_-10px_30px_rgba(10,40,28,0.12)] lg:hidden">
+        <div className="shrink-0 font-display text-lg font-bold text-[var(--on-surface)]">
           {price}
           {viewModel.pricePerPersonRub ? (
-            <small className="block text-xs font-medium text-muted-foreground">с человека</small>
+            <small className="block text-xs font-medium text-[var(--on-surface-muted)]">с человека</small>
           ) : null}
         </div>
         <div className="min-w-0 flex-1">

--- a/src/features/traveler/components/requests/traveler-requests-screen.tsx
+++ b/src/features/traveler/components/requests/traveler-requests-screen.tsx
@@ -139,14 +139,14 @@ function CategoryEmptyState({
   children: ReactNode
 }) {
   return (
-    <div className="rounded-lg border border-dashed p-6 text-center text-sm text-muted-foreground">
+    <div className="rounded-[var(--card-radius)] border border-dashed border-[var(--outline)] bg-[var(--surface-lowest)] p-8 text-center text-sm text-[var(--on-surface-muted)] shadow-[var(--card-shadow)]">
       {children}
     </div>
   )
 }
 
 function CategoryGrid({ children }: { children: ReactNode }) {
-  return <div className="grid gap-3">{children}</div>
+  return <div className="grid gap-4">{children}</div>
 }
 
 function RequestsCategoryTabs({
@@ -175,19 +175,28 @@ function RequestsCategoryTabs({
 
   return (
     <Tabs value={categoryTab} onValueChange={handleCategoryTabChange}>
-      <TabsList className="mb-4 grid w-full grid-cols-3">
-        <TabsTrigger value="active" onClick={() => setCategoryTab('active')}>
+      <TabsList className="mb-5 grid h-auto w-full grid-cols-3 gap-1 rounded-[18px] border border-[var(--outline)] bg-[var(--surface-lowest)] p-1 shadow-[var(--card-shadow)]">
+        <TabsTrigger
+          value="active"
+          onClick={() => setCategoryTab('active')}
+          className="rounded-[14px] px-3 py-2.5 text-sm font-semibold text-[var(--on-surface-muted)] transition-colors data-[state=active]:bg-[var(--brand-50)] data-[state=active]:text-[var(--primary)] data-[state=active]:shadow-none"
+        >
           Активные
           {activeRequests.length > 0 ? ` (${activeRequests.length})` : ''}
         </TabsTrigger>
         <TabsTrigger
           value="confirmed"
           onClick={() => setCategoryTab('confirmed')}
+          className="rounded-[14px] px-3 py-2.5 text-sm font-semibold text-[var(--on-surface-muted)] transition-colors data-[state=active]:bg-[var(--brand-50)] data-[state=active]:text-[var(--primary)] data-[state=active]:shadow-none"
         >
           Подтверждённые
           {confirmedBookings.length > 0 ? ` (${confirmedBookings.length})` : ''}
         </TabsTrigger>
-        <TabsTrigger value="joined" onClick={() => setCategoryTab('joined')}>
+        <TabsTrigger
+          value="joined"
+          onClick={() => setCategoryTab('joined')}
+          className="rounded-[14px] px-3 py-2.5 text-sm font-semibold text-[var(--on-surface-muted)] transition-colors data-[state=active]:bg-[var(--brand-50)] data-[state=active]:text-[var(--primary)] data-[state=active]:shadow-none"
+        >
           Мои группы
           {joinedGroups.length > 0 ? ` (${joinedGroups.length})` : ''}
         </TabsTrigger>
@@ -201,8 +210,13 @@ function RequestsCategoryTabs({
           </CategoryGrid>
         ) : (
           <CategoryEmptyState>
-            <p className="mb-4">У вас ещё нет запросов</p>
-            <Button asChild>
+            <p className="mb-4 text-base font-medium text-[var(--on-surface)]">
+              У вас ещё нет запросов
+            </p>
+            <Button
+              asChild
+              className="rounded-[14px] bg-[var(--primary)] px-6 py-3 font-semibold text-white shadow-none transition hover:-translate-y-0.5 hover:bg-[var(--primary-hover)]"
+            >
               <Link href="/">Создать первый запрос</Link>
             </Button>
           </CategoryEmptyState>
@@ -221,7 +235,9 @@ function RequestsCategoryTabs({
           </CategoryGrid>
         ) : (
           <CategoryEmptyState>
-            <p>Подтверждённых поездок пока нет</p>
+            <p className="text-base font-medium text-[var(--on-surface)]">
+              Подтверждённых поездок пока нет
+            </p>
           </CategoryEmptyState>
         )}
       </TabsContent>
@@ -238,10 +254,14 @@ function RequestsCategoryTabs({
           </CategoryGrid>
         ) : (
           <CategoryEmptyState>
-            <p className="mb-4">
+            <p className="mb-4 text-base font-medium text-[var(--on-surface)]">
               Вы пока не присоединились ни к одной группе
             </p>
-            <Button asChild variant="outline">
+            <Button
+              asChild
+              variant="outline"
+              className="rounded-[14px] border-[var(--outline)] bg-[var(--surface-lowest)] px-6 py-3 font-semibold text-[var(--primary)] transition hover:-translate-y-0.5 hover:bg-[var(--brand-50)]"
+            >
               <Link href="/requests">Найти группу</Link>
             </Button>
           </CategoryEmptyState>
@@ -263,16 +283,35 @@ export function TravelerRequestsScreen({
     joinedGroups.length > 0
 
   if (!hasTrips) {
-    return <EmptyCabinet inspirations={inspirations} />
+    return (
+      <section className="bg-[var(--surface)] px-4 py-8 text-[var(--on-surface)]">
+        <EmptyCabinet inspirations={inspirations} />
+      </section>
+    )
   }
 
   return (
-    <div className="mx-auto max-w-2xl space-y-6 px-4 py-6">
-      <RequestsCategoryTabs
-        activeRequests={activeRequests}
-        confirmedBookings={confirmedBookings}
-        joinedGroups={joinedGroups}
-      />
-    </div>
+    <section className="bg-[var(--surface)] px-4 py-8 text-[var(--on-surface)]">
+      <div className="mx-auto max-w-3xl space-y-7">
+        <header className="space-y-3">
+          <p className="text-xs font-semibold uppercase tracking-[0.1em] text-[var(--primary)]">
+            Кабинет путешественника
+          </p>
+          <div className="space-y-2">
+            <h1 className="text-[clamp(30px,4.4vw,44px)] font-semibold leading-[1.04] text-[var(--on-surface)]">
+              Мои поездки
+            </h1>
+            <p className="max-w-2xl text-base leading-7 text-[var(--on-surface-muted)]">
+              Статусы запросов, предложений и подтверждённых поездок собраны в одном месте.
+            </p>
+          </div>
+        </header>
+        <RequestsCategoryTabs
+          activeRequests={activeRequests}
+          confirmedBookings={confirmedBookings}
+          joinedGroups={joinedGroups}
+        />
+      </div>
+    </section>
   )
 }

--- a/src/features/traveler/components/requests/traveler-requests-screen.tsx
+++ b/src/features/traveler/components/requests/traveler-requests-screen.tsx
@@ -1,5 +1,6 @@
 'use client'
 
+import Image from 'next/image'
 import Link from 'next/link'
 import { useState, type ReactNode } from 'react'
 
@@ -16,10 +17,7 @@ import type {
   JoinedGroupSummary,
 } from '@/lib/supabase/traveler-requests'
 
-import {
-  EmptyCabinet,
-  type Inspiration,
-} from '../empty-cabinet/empty-cabinet'
+import type { Inspiration } from '../empty-cabinet/empty-cabinet'
 import { TripCard } from '../trip-card/trip-card'
 import {
   mapBookingToTrip,
@@ -147,6 +145,59 @@ function CategoryEmptyState({
 
 function CategoryGrid({ children }: { children: ReactNode }) {
   return <div className="grid gap-4">{children}</div>
+}
+
+function TravelerRequestsEmptyState({
+  inspirations,
+}: {
+  inspirations: Inspiration[]
+}) {
+  return (
+    <section className="bg-[var(--surface)] px-4 py-10 text-[var(--on-surface)]">
+      <div className="mx-auto max-w-3xl rounded-[var(--card-radius)] border border-[var(--outline)] bg-[var(--surface-lowest)] p-8 text-center shadow-[var(--card-shadow)] md:p-10">
+        <p className="text-xs font-semibold uppercase tracking-[0.1em] text-[var(--primary)]">
+          Первый маршрут
+        </p>
+        <h1 className="mt-3 text-[clamp(30px,4.4vw,44px)] font-semibold leading-[1.04] text-[var(--on-surface)]">
+          Куда поедем?
+        </h1>
+        <p className="mx-auto mt-3 max-w-xl text-base leading-7 text-[var(--on-surface-muted)]">
+          Опишите поездку, а мы поможем собрать понятные предложения под ваш маршрут.
+        </p>
+        <Link
+          href="/"
+          className="mt-6 inline-flex rounded-[14px] bg-[var(--primary)] px-6 py-3 font-semibold text-white transition hover:-translate-y-0.5 hover:bg-[var(--primary-hover)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--primary)] focus-visible:ring-offset-2"
+        >
+          Создать запрос
+        </Link>
+
+        {inspirations.length > 0 ? (
+          <div className="mt-8 grid gap-3 text-left md:grid-cols-3">
+            {inspirations.map((destination) => (
+              <Link
+                key={destination.slug}
+                href={`/destinations/${destination.slug}`}
+                className="overflow-hidden rounded-[20px] border border-[var(--outline)] bg-[var(--surface-lowest)] transition hover:-translate-y-0.5 hover:border-[var(--primary)] hover:shadow-[var(--card-shadow)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--primary)] focus-visible:ring-offset-2"
+              >
+                <div className="relative aspect-video">
+                  <Image
+                    src={destination.imageUrl}
+                    alt={destination.label}
+                    fill
+                    className="object-cover"
+                    sizes="(max-width: 767px) 100vw, 240px"
+                  />
+                </div>
+                <p className="p-3 font-semibold text-[var(--on-surface)]">
+                  {destination.label}
+                </p>
+              </Link>
+            ))}
+          </div>
+        ) : null}
+      </div>
+    </section>
+  )
 }
 
 function RequestsCategoryTabs({
@@ -283,11 +334,7 @@ export function TravelerRequestsScreen({
     joinedGroups.length > 0
 
   if (!hasTrips) {
-    return (
-      <section className="bg-[var(--surface)] px-4 py-8 text-[var(--on-surface)]">
-        <EmptyCabinet inspirations={inspirations} />
-      </section>
-    )
+    return <TravelerRequestsEmptyState inspirations={inspirations} />
   }
 
   return (

--- a/src/features/traveler/components/trip-card/trip-card.tsx
+++ b/src/features/traveler/components/trip-card/trip-card.tsx
@@ -2,8 +2,6 @@ import Image from "next/image";
 import Link from "next/link";
 import { CalendarDays, Clock, Users, Wallet } from "lucide-react";
 
-import { Badge } from "@/components/ui/badge";
-import { BADGE_CLASS } from "@/lib/styles";
 import { cn } from "@/lib/utils";
 
 import type { TripCardModel, TripPhase } from "./trip-card-types";
@@ -62,6 +60,59 @@ function formatTimeLabel(time: string) {
   return time.slice(0, 5);
 }
 
+const factChipClassName =
+  "inline-flex items-center gap-2 rounded-full border border-[var(--outline)] bg-[var(--surface-lowest)] px-3 py-1.5 text-xs font-semibold text-[var(--on-surface-muted)]";
+
+const brandChipClassName =
+  "inline-flex items-center gap-1.5 rounded-full bg-[var(--brand-50)] px-3 py-1 text-xs font-semibold text-[var(--primary)]";
+
+const neutralChipClassName =
+  "inline-flex items-center gap-1.5 rounded-full border border-[var(--outline)] bg-[var(--surface-lowest)] px-3 py-1 text-xs font-semibold text-[var(--on-surface-muted)]";
+
+const statusBaseClassName =
+  "inline-flex shrink-0 items-center rounded-full px-3 py-1 text-xs font-semibold";
+
+function getStatusBadge(phase: TripPhase): { label: string; className: string } {
+  if (phase === "awaiting_decision") {
+    return {
+      label: "Есть предложения",
+      className: `${statusBaseClassName} bg-[var(--gold)] text-white`,
+    };
+  }
+
+  if (phase === "waiting_offers") {
+    return {
+      label: "Набирается",
+      className: `${statusBaseClassName} bg-[var(--brand-50)] text-[var(--primary)]`,
+    };
+  }
+
+  if (phase === "today") {
+    return {
+      label: "Сегодня",
+      className: `${statusBaseClassName} bg-[var(--gold)] text-white`,
+    };
+  }
+
+  if (phase === "completed") {
+    return {
+      label: "Завершено",
+      className: `${statusBaseClassName} border border-[var(--outline)] bg-[var(--surface-lowest)] text-[var(--on-surface-muted)]`,
+    };
+  }
+
+  return {
+    label: "Подтверждено",
+    className: `${statusBaseClassName} bg-[var(--brand-50)] text-[var(--primary)]`,
+  };
+}
+
+function TripStatus({ phase }: { phase: TripPhase }) {
+  const status = getStatusBadge(phase);
+
+  return <span className={status.className}>{status.label}</span>;
+}
+
 function TripPhoto({
   phase,
   trip,
@@ -73,7 +124,7 @@ function TripPhoto({
     const slots = [0, 1, 2].map((i) => trip.topOffersPhotos?.[i] ?? null);
 
     return (
-      <div className="grid grid-cols-3 gap-1">
+      <div className="grid overflow-hidden rounded-[20px] border border-[var(--outline)] bg-[var(--surface)] grid-cols-3 gap-1">
         {slots.map((url, i) => (
           <div key={i} data-testid="photo-slot" className="aspect-square">
             {url ? (
@@ -86,7 +137,7 @@ function TripPhoto({
                 className="h-full w-full object-cover"
               />
             ) : (
-              <div className="h-full w-full bg-muted" />
+              <div className="h-full w-full bg-[var(--surface)]" />
             )}
           </div>
         ))}
@@ -108,7 +159,7 @@ function TripPhoto({
       alt={trip.destination}
       width={1200}
       height={675}
-      className="aspect-video w-full object-cover"
+      className="aspect-video w-full rounded-[20px] object-cover"
     />
   );
 }
@@ -134,25 +185,25 @@ function FlexPills({
   if (!openToJoin && !datesFlexible && !groupType) return null;
 
   return (
-    <div className="flex flex-wrap gap-1.5">
+    <div className="flex flex-wrap gap-2">
       {groupType ? (
         <span
           className={
             groupType === "assembly"
-              ? "rounded-full bg-sky-100 px-2 py-0.5 text-xs font-medium text-sky-700"
-              : "rounded-full bg-purple-100 px-2 py-0.5 text-xs font-medium text-purple-700"
+              ? brandChipClassName
+              : neutralChipClassName
           }
         >
           {groupType === "assembly" ? "Сборная группа" : "Своя группа"}
         </span>
       ) : null}
       {openToJoin ? (
-        <span className="rounded-full bg-sky-100 px-2 py-0.5 text-xs font-medium text-sky-700">
+        <span className={brandChipClassName}>
           + к группе
         </span>
       ) : null}
       {datesFlexible ? (
-        <span className="rounded-full bg-emerald-100 px-2 py-0.5 text-xs font-medium text-emerald-700">
+        <span className="inline-flex items-center rounded-full bg-[var(--gold)] px-3 py-1 text-xs font-semibold text-white">
           ± даты
         </span>
       ) : null}
@@ -175,7 +226,7 @@ function RequestMetaRow({ trip }: { trip: TripCardModel }) {
         groupType={trip.groupType}
       />
       {publishedAt ? (
-        <p className="shrink-0 whitespace-nowrap text-xs text-muted-foreground">
+        <p className="shrink-0 whitespace-nowrap text-xs text-muted-foreground text-[var(--on-surface-muted)]">
           Опубликован: {publishedAt}
         </p>
       ) : null}
@@ -190,33 +241,32 @@ function RequestFacts({ trip }: { trip: TripCardModel }) {
 
   return (
     <div className="flex flex-wrap gap-2">
-      <Badge variant="outline" className={BADGE_CLASS}>
-        <CalendarDays className="size-3.5" />
+      <span className={factChipClassName}>
+        <CalendarDays className="size-3.5 text-[var(--primary)]" />
         {formatDateRange(trip.startsOn, trip.endsOn)}
-      </Badge>
+      </span>
       {trip.startTime ? (
-        <Badge variant="outline" className={BADGE_CLASS}>
-          <Clock className="size-3.5" />
+        <span className={factChipClassName}>
+          <Clock className="size-3.5 text-[var(--primary)]" />
           {formatTimeLabel(trip.startTime)}
-        </Badge>
+        </span>
       ) : null}
       {shouldShowParticipants ? (
-        <Badge variant="outline" className={BADGE_CLASS}>
-          <Users className="size-3.5" />
+        <span className={factChipClassName}>
+          <Users className="size-3.5 text-[var(--primary)]" />
           {formatPeople(participantsCount)}
-        </Badge>
+        </span>
       ) : null}
       {budgetRub != null ? (
-        <Badge
-          variant="outline"
+        <span
           className={cn(
-            BADGE_CLASS,
-            "border-success/30 bg-success/10 text-success",
+            factChipClassName,
+            "border-[var(--primary)] bg-[var(--brand-50)] text-[var(--primary)]",
           )}
         >
           <Wallet className="size-3.5" />
           {formatRub(budgetRub)}
-        </Badge>
+        </span>
       ) : null}
     </div>
   );
@@ -235,9 +285,9 @@ function OfferCount({ count }: { count?: number }) {
         : "откликов";
 
   return (
-    <Badge variant="secondary" className="text-xs font-semibold">
+    <span className="inline-flex w-fit items-center rounded-full bg-[var(--gold)] px-3 py-1 text-xs font-semibold text-white">
       {count} {noun}
-    </Badge>
+    </span>
   );
 }
 
@@ -251,83 +301,112 @@ function TripCardContent({
   const meetingPoint = trip.routeStops?.[0]?.address;
   const isRequestBacked =
     phase === "waiting_offers" || phase === "awaiting_decision";
+  const actionLabel = isRequestBacked ? "Смотреть запрос" : "Смотреть поездку";
 
   return (
     <>
       <TripPhoto phase={phase} trip={trip} />
-      <h3 className="text-lg font-medium">{trip.destination}</h3>
-      {isRequestBacked ? (
-        <>
-          <RequestFacts trip={trip} />
-          <RequestMetaRow trip={trip} />
-          {phase === "awaiting_decision" ? (
-            <OfferCount count={trip.offerCount} />
-          ) : null}
-        </>
-      ) : (
-        <FlexPills
-          openToJoin={trip.openToJoin}
-          datesFlexible={trip.datesFlexible}
-          groupType={trip.groupType}
-        />
-      )}
-      {!trip.isOwnRequest && trip.organizerName && (
-        <p className="text-sm">
-          Сборная группа · организатор: {trip.organizerName}
-        </p>
-      )}
-      {shouldShowMeetingPoint(phase, trip.startsOn) && meetingPoint && (
-        <p className="text-sm">{meetingPoint}</p>
-      )}
-      {phase === "upcoming" &&
-        trip.routeStops &&
-        trip.routeStops.length >= 3 && (
+      <div className="space-y-4">
+        <div className="flex items-start justify-between gap-4">
+          <div className="min-w-0 space-y-1">
+            <h3 className="truncate text-xl font-semibold leading-7 text-[var(--on-surface)]">
+              {trip.destination}
+            </h3>
+          </div>
+          <TripStatus phase={phase} />
+        </div>
+
+        <RequestFacts trip={trip} />
+
+        {isRequestBacked ? (
           <>
-            <div className="flex gap-1">
-              {trip.routeStops.slice(0, 3).map((stop, i) => (
-                <Image
-                  key={i}
-                  unoptimized
-                  src={stop.photoUrl}
-                  alt=""
-                  width={48}
-                  height={48}
-                  className="size-12 rounded object-cover"
-                />
-              ))}
-            </div>
-            {trip.inclusions && (
-              <p className="text-sm">
-                Что входит: {trip.inclusions.join(", ")}
-              </p>
-            )}
-            {trip.guideName && (
-              <div className="flex items-center gap-2">
-                {trip.guideAvatarUrl && (
-                  <Image
-                    unoptimized
-                    src={trip.guideAvatarUrl}
-                    alt=""
-                    width={32}
-                    height={32}
-                    className="size-8 rounded-full object-cover"
-                  />
-                )}
-                <span>{trip.guideName}</span>
-              </div>
-            )}
-            <span className="text-sm font-medium text-primary">Написать гиду</span>
-            {trip.price && (
-              <p>{(trip.price.amount / 100).toLocaleString("ru-RU")} ₽</p>
-            )}
+            <RequestMetaRow trip={trip} />
+            {phase === "awaiting_decision" ? (
+              <OfferCount count={trip.offerCount} />
+            ) : null}
           </>
-        )}
-      {phase === "completed" &&
-        (trip.hasReview ? (
-          <p>Ваш отзыв · ★ {trip.reviewRating}</p>
         ) : (
-          <span className="text-sm font-medium text-primary">Оставить отзыв</span>
-        ))}
+          <FlexPills
+            openToJoin={trip.openToJoin}
+            datesFlexible={trip.datesFlexible}
+            groupType={trip.groupType}
+          />
+        )}
+
+        {!trip.isOwnRequest && trip.organizerName && (
+          <p className="text-sm font-medium text-[var(--on-surface)]">
+            Сборная группа · организатор: {trip.organizerName}
+          </p>
+        )}
+        {shouldShowMeetingPoint(phase, trip.startsOn) && meetingPoint && (
+          <p className="rounded-[14px] bg-[var(--brand-50)] px-3 py-2 text-sm font-medium text-[var(--primary)]">
+            {meetingPoint}
+          </p>
+        )}
+        {phase === "upcoming" &&
+          trip.routeStops &&
+          trip.routeStops.length >= 3 && (
+            <>
+              <div className="flex gap-2">
+                {trip.routeStops.slice(0, 3).map((stop, i) => (
+                  <Image
+                    key={i}
+                    unoptimized
+                    src={stop.photoUrl}
+                    alt=""
+                    width={48}
+                    height={48}
+                    className="size-12 rounded-[14px] object-cover"
+                  />
+                ))}
+              </div>
+              {trip.inclusions && (
+                <p className="text-sm leading-6 text-[var(--on-surface-muted)]">
+                  Что входит: {trip.inclusions.join(", ")}
+                </p>
+              )}
+              {trip.guideName && (
+                <div className="flex items-center gap-2 text-sm font-medium text-[var(--on-surface)]">
+                  {trip.guideAvatarUrl && (
+                    <Image
+                      unoptimized
+                      src={trip.guideAvatarUrl}
+                      alt=""
+                      width={32}
+                      height={32}
+                      className="size-8 rounded-full object-cover"
+                    />
+                  )}
+                  <span>{trip.guideName}</span>
+                </div>
+              )}
+              <span className="text-sm font-semibold text-[var(--primary)]">
+                Написать гиду
+              </span>
+              {trip.price && (
+                <p className="text-lg font-semibold text-[var(--on-surface)]">
+                  {(trip.price.amount / 100).toLocaleString("ru-RU")} ₽
+                </p>
+              )}
+            </>
+          )}
+        {phase === "completed" &&
+          (trip.hasReview ? (
+            <p className="text-sm font-medium text-[var(--on-surface)]">
+              Ваш отзыв · ★ {trip.reviewRating}
+            </p>
+          ) : (
+            <span className="text-sm font-semibold text-[var(--primary)]">
+              Оставить отзыв
+            </span>
+          ))}
+
+        <div className="flex items-center justify-between border-t border-[var(--outline)] pt-4">
+          <span className="text-sm font-semibold text-[var(--primary)]">
+            {actionLabel}
+          </span>
+        </div>
+      </div>
     </>
   );
 }

--- a/src/features/traveler/components/trip-card/trip-card.tsx
+++ b/src/features/traveler/components/trip-card/trip-card.tsx
@@ -422,16 +422,16 @@ export function TripCard({
     phase === "waiting_offers" || phase === "awaiting_decision";
 
   const cardClassName =
-    "block cursor-pointer rounded-lg border bg-card p-4 transition-colors hover:bg-accent/50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2";
+    "block cursor-pointer rounded-[var(--card-radius)] border border-[var(--outline)] bg-[var(--surface-lowest)] p-5 shadow-[var(--card-shadow)] transition hover:-translate-y-0.5 hover:border-[var(--primary)] hover:shadow-[var(--lift-shadow)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--primary)] focus-visible:ring-offset-2";
 
   if (isRequestBacked) {
     const hasUnread = (trip.unreadOfferCount ?? 0) > 0;
     return (
       <Link
         href={`/requests/${trip.id}`}
-        className={cn(cardClassName, hasUnread && "border-l-4 border-primary")}
+        className={cn(cardClassName, hasUnread && "border-l-4 border-l-[var(--primary)]")}
       >
-        <article className="space-y-3">
+        <article className="space-y-4">
           <TripCardContent phase={phase} trip={trip} />
         </article>
       </Link>
@@ -440,7 +440,7 @@ export function TripCard({
 
   return (
     <Link href={`/bookings/${trip.id}`} className={cardClassName}>
-      <article className="space-y-3">
+      <article className="space-y-4">
         <TripCardContent phase={phase} trip={trip} />
       </article>
     </Link>


### PR DESCRIPTION
Isolated design refresh on the **design** branch → staging **https://design.provodnik.app** (public). **Do NOT merge yet** — for stakeholder review.

## Canonical design system
Rubik (one typeface) + brand greens, LIGHT white-card aesthetic (docs/design/DESIGN-SYSTEM.md), derived from the approved 06-font-rubik mockup. Fixed the broken font system (Rubik now actually applies) and anchored .cursorignore.

## Phase-1 screens redesigned (8)
auth · homepage · request-detail (Элиста) · listings · guide-profile · become-a-guide · trips · guide-dashboard · admin-dashboard

## Verification
typecheck green; 790 tests pass (160 files); public pages screenshot-verified live on staging. Styling-only — all data/logic/role-variants preserved.

Next phase after sign-off: remaining ~47 pages.