### PR TITLE
fix(guides): repair public guide profile + list pages

### DIFF
--- a/src/data/supabase/queries.ts
+++ b/src/data/supabase/queries.ts
@@ -486,7 +486,9 @@ async function fetchMembersForRequests(
 }
 
 function mapGuideRow(gp: Record<string, unknown>, profile: Record<string, unknown> | null): GuideRecord {
-  const fullName = resolveDisplayName("guide", { full_name: profile?.full_name as string | null | undefined });
+  const fullName = resolveDisplayName("guide", {
+    full_name: (profile?.full_name as string | null | undefined) ?? (gp.display_name as string | null | undefined),
+  });
   const regions = (gp.regions as string[]) ?? [];
   return {
     id: gp.user_id as string,
@@ -814,7 +816,7 @@ export async function getGuideBySlug(
   try {
     const { data, error } = await client
       .from("guide_profiles")
-      .select("*, profiles:user_id(id, full_name, avatar_url)")
+      .select("*, profiles:user_id!guide_profiles_user_id_fkey(id, full_name, avatar_url)")
       .eq("slug", slug)
       .maybeSingle();
 

--- a/supabase/migrations/20260617120000_fix_search_guides_rowtype.sql
+++ b/supabase/migrations/20260617120000_fix_search_guides_rowtype.sql
@@ -1,0 +1,136 @@
+-- =============================================================================
+-- FIX: search_guides RPC errors 42804 ("Returned type text does not match
+-- expected type boolean in column 33").
+-- Root cause: public.guide_search_result_row is a VIEW (a rowtype carrier,
+-- "SELECT <explicit cols>, false AS is_partial_match FROM guide_profiles WHERE false")
+-- frozen to an OLDER guide_profiles shape; a later migration added `display_name`,
+-- so the function's `select g.*, is_partial_match` returns one more column than the
+-- view's rowtype expects -> mismatch at column 33.
+-- Fix: drop the dependent function, drop+recreate the view to mirror the CURRENT
+-- guide_profiles columns (via gp.*), recreate the function body verbatim, re-grant.
+-- NOTE: a view still freezes gp.* at creation time; if guide_profiles columns change
+-- again, re-run this migration. (Pre-existing design; out of scope to refactor here.)
+-- =============================================================================
+
+-- function returns SETOF the view's rowtype -> drop it first, then the stale view.
+drop function if exists public.search_guides(text, text[], text, boolean);
+drop view if exists public.guide_search_result_row;
+
+create view public.guide_search_result_row as
+  select gp.*, false::boolean as is_partial_match
+  from public.guide_profiles gp
+  where false;
+
+grant select on public.guide_search_result_row to anon, authenticated, service_role;
+
+CREATE OR REPLACE FUNCTION public.search_guides(q text DEFAULT ''::text, p_specializations text[] DEFAULT NULL::text[], p_region text DEFAULT NULL::text, p_has_listings boolean DEFAULT NULL::boolean)
+ RETURNS SETOF guide_search_result_row
+ LANGUAGE plpgsql
+ STABLE SECURITY DEFINER
+ SET search_path TO 'public'
+AS $function$
+declare
+  tokens text[] := array[]::text[];
+  raw_part text;
+  cleaned text;
+begin
+  if trim(coalesce(q, '')) = '' then
+    return query
+    select g.*, false::boolean as is_partial_match
+    from public.guide_profiles g
+    where g.verification_status = 'approved'
+      and g.is_available = true
+      and (p_specializations is null or g.specializations && p_specializations)
+      and (p_region is null or g.regions @> array[p_region])
+      and (p_has_listings is null or p_has_listings = false or exists (
+        select 1 from public.listings l
+        where l.guide_id = g.user_id and l.status = 'published'
+      ))
+    order by g.created_at desc;
+    return;
+  end if;
+
+  foreach raw_part in array string_to_array(q, ',')
+  loop
+    cleaned := lower(trim(raw_part));
+    if cleaned = '' then continue; end if;
+    if cleaned !~ '^[a-zA-Zа-яА-ЯёЁ0-9 -]+$' then continue; end if;
+    tokens := array_append(tokens, cleaned);
+  end loop;
+
+  if coalesce(array_length(tokens, 1), 0) = 0 then
+    return query
+    select g.*, false::boolean as is_partial_match
+    from public.guide_profiles g
+    where g.verification_status = 'approved'
+      and g.is_available = true
+      and (p_specializations is null or g.specializations && p_specializations)
+      and (p_region is null or g.regions @> array[p_region])
+      and (p_has_listings is null or p_has_listings = false or exists (
+        select 1 from public.listings l
+        where l.guide_id = g.user_id and l.status = 'published'
+      ))
+    order by g.created_at desc;
+    return;
+  end if;
+
+  return query
+  with visible as (
+    select g, p.full_name
+    from public.guide_profiles g
+    left join public.profiles p on p.id = g.user_id
+    where g.verification_status = 'approved'
+      and g.is_available = true
+      and (p_specializations is null or g.specializations && p_specializations)
+      and (p_region is null or g.regions @> array[p_region])
+      and (p_has_listings is null or p_has_listings = false or exists (
+        select 1 from public.listings l
+        where l.guide_id = g.user_id and l.status = 'published'
+      ))
+  ),
+  strict as (
+    select v.g
+    from visible v
+    where not exists (
+      select 1
+      from unnest(tokens) as tok(token)
+      where not (
+        v.full_name ilike '%' || tok.token || '%'
+        or (v.g).bio ilike '%' || tok.token || '%'
+        or (v.g).base_city ilike '%' || tok.token || '%'
+        or exists (select 1 from unnest((v.g).languages) as lang(value) where lower(lang.value) ilike '%' || tok.token || '%')
+        or exists (select 1 from unnest((v.g).specializations) as spec(value) where lower(spec.value) ilike '%' || tok.token || '%')
+      )
+    )
+  ),
+  strict_count as (select count(*)::bigint as c from strict),
+  or_fallback as (
+    select v.g
+    from visible v
+    where exists (
+      select 1
+      from unnest(tokens) as tok(token)
+      where (
+        v.full_name ilike '%' || tok.token || '%'
+        or (v.g).bio ilike '%' || tok.token || '%'
+        or (v.g).base_city ilike '%' || tok.token || '%'
+        or exists (select 1 from unnest((v.g).languages) as lang(value) where lower(lang.value) ilike '%' || tok.token || '%')
+        or exists (select 1 from unnest((v.g).specializations) as spec(value) where lower(spec.value) ilike '%' || tok.token || '%')
+      )
+    )
+  ),
+  result as (
+    select (s.g).*, false::boolean as is_partial_match
+    from strict s
+    where (select c from strict_count) > 0
+    union all
+    select (o.g).*, true::boolean as is_partial_match
+    from or_fallback o
+    where (select c from strict_count) = 0
+  )
+  select r.* from result r order by r.created_at desc;
+end;
+$function$;
+
+-- DROP cleared grants; restore EXECUTE to the same roles as before.
+grant execute on function public.search_guides(text, text[], text, boolean) to anon, authenticated, service_role;


### PR DESCRIPTION
## What
Two pre-existing bugs broke the public guide surface; both surfaced once the catalog had real, slugged, approved guides.

### Bug 1 — `/guides/[slug]` returned 404
`getGuideBySlug` embeds `profiles` from `guide_profiles` via `user_id`. After a `guide_templates` table was added with an FK also targeting `guide_profiles.user_id`, PostgREST could no longer disambiguate the relationship and returned `PGRST201`, which the query swallowed into `notFound()`.
- Fix: name the FK in the embed — `profiles:user_id!guide_profiles_user_id_fkey(...)`.

### Bug 2 — `/guides` index showed "нет гидов"
The `search_guides` RPC errored `42804` (return type mismatch at column 33). Its return type is the view `guide_search_result_row`, frozen to an older `guide_profiles` shape; a later `display_name` column made `select g.*, is_partial_match` overrun the view.
- Fix (migration `20260617120000`): drop+recreate the view to mirror current `guide_profiles`, recreate the function verbatim, re-grant. **Already applied to the hosted DB via the management API**; the migration file is included here so repo history matches prod.

### Also: anon-safe guide identity
Anonymous visitors cannot read `profiles` (RLS), so the embed returns null. `mapGuideRow` now falls back to `guide_profiles.display_name` (anon-readable, already selected) — fixes empty names on both `/guides` and `/guides/[slug]`.

## Verification
- typecheck clean · lint:ratchet pass · full suite 790/790 pass (pre-commit hook)
- Verified live against the hosted API as anon: RPC now returns all approved guides; the disambiguated embed resolves.

## Note
`guide_search_result_row` remains a frozen view — if `guide_profiles` columns change again, re-run the migration. Out of scope to refactor here.