### PR TITLE
fix(guides): correct PostgREST embed disambiguation syntax

### DIFF
--- a/src/data/supabase/queries.ts
+++ b/src/data/supabase/queries.ts
@@ -816,7 +816,7 @@ export async function getGuideBySlug(
   try {
     const { data, error } = await client
       .from("guide_profiles")
-      .select("*, profiles:user_id!guide_profiles_user_id_fkey(id, full_name, avatar_url)")
+      .select("*, profiles!guide_profiles_user_id_fkey(id, full_name, avatar_url)")
       .eq("slug", slug)
       .maybeSingle();
 


### PR DESCRIPTION
Follow-up to #127. The embed used profiles:user_id!guide_profiles_user_id_fkey, which fails at runtime with PGRST200 (the unit tests and typecheck do not exercise the live PostgREST API, so this slipped through). Correct form, verified against the live API, is profiles!guide_profiles_user_id_fkey. One-line change in getGuideBySlug. Full suite 790/790 green.