### PR TITLE
Immersive visitor & guide request-detail views + edit/withdraw bid

### DIFF
--- a/src/app/(site)/requests/[requestId]/page.tsx
+++ b/src/app/(site)/requests/[requestId]/page.tsx
@@ -18,6 +18,7 @@ import { viewerRoleForRequest } from "@/lib/auth/viewer-role-for-request";
 import { cityImage } from "@/lib/city-image";
 import { createSupabaseServerClient } from "@/lib/supabase/server";
 import { isRequestMember } from "@/lib/supabase/request-members";
+import { getBiddingGuidesForRequest, type BiddingGuide } from "@/lib/supabase/requests-public";
 import { hasSupabaseEnv } from "@/lib/env";
 import { getOffersForRequest } from "@/lib/supabase/offers";
 import type { QaThread } from "@/lib/supabase/qa-threads";
@@ -411,11 +412,22 @@ export default async function RequestDetailPage({
     ownerId,
   });
 
+  let biddingGuides: BiddingGuide[] = [];
+  if (hasSupabaseEnv()) {
+    try {
+      const sb = await createSupabaseServerClient();
+      biddingGuides = await getBiddingGuidesForRequest(sb, requestId);
+    } catch {
+      // non-fatal — teaser simply renders nothing
+    }
+  }
+
   return (
     <RequestDetailScreen
       viewerRole={viewerRole === "admin" ? "admin" : "public"}
       requestId={requestId}
       viewModel={viewModel}
+      biddingGuides={biddingGuides}
     />
   );
 }

--- a/src/app/(site)/requests/[requestId]/page.tsx
+++ b/src/app/(site)/requests/[requestId]/page.tsx
@@ -248,6 +248,7 @@ async function getGuideDetailData(requestId: string, guideId: string | null) {
   let isApproved = false;
   let existingOfferId: string | null = null;
   let offerMeta: OfferMeta | null = null;
+  let existingOffer: GuideOfferRow | null = null;
 
   if (guideId) {
     const { data: profile } = await supabase
@@ -259,11 +260,12 @@ async function getGuideDetailData(requestId: string, guideId: string | null) {
 
     const { data: offer } = await supabase
       .from("guide_offers")
-      .select("id, starts_at, capacity, price_minor, message")
+      .select("*")
       .eq("guide_id", guideId)
       .eq("request_id", requestId)
       .maybeSingle();
     existingOfferId = (offer?.id as string | undefined) ?? null;
+    existingOffer = (offer as GuideOfferRow | null) ?? null;
     offerMeta = offer
       ? {
           starts_at: offer.starts_at as string | null,
@@ -290,6 +292,7 @@ async function getGuideDetailData(requestId: string, guideId: string | null) {
     isApproved,
     existingOfferId,
     offerMeta,
+    existingOffer,
     competingOffers,
     viewsCount,
   };
@@ -399,6 +402,7 @@ export default async function RequestDetailPage({
         isApproved={guideData.isApproved}
         existingOfferId={guideData.existingOfferId}
         offerMeta={guideData.offerMeta}
+        existingOffer={guideData.existingOffer}
         competingOffers={guideData.competingOffers}
         viewsCount={guideData.viewsCount}
       />

--- a/src/components/shared/bidding-guides-teaser.test.tsx
+++ b/src/components/shared/bidding-guides-teaser.test.tsx
@@ -1,0 +1,52 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import type { BiddingGuide } from "@/lib/supabase/requests-public";
+
+import { BiddingGuidesTeaser } from "./bidding-guides-teaser";
+
+const guides: BiddingGuide[] = [
+  {
+    user_id: "g1",
+    full_name: "Тамара Кикнадзе",
+    avatar_url: null,
+    average_rating: 4.9,
+    review_count: 42,
+    slug: "tamara",
+  },
+  {
+    user_id: "g2",
+    full_name: "Георгий Беридзе",
+    avatar_url: null,
+    average_rating: 4.7,
+    review_count: 18,
+    slug: "georgiy",
+  },
+  {
+    user_id: "g3",
+    full_name: "Нино Гелашвили",
+    avatar_url: null,
+    average_rating: 5,
+    review_count: 7,
+    slug: "nino",
+  },
+];
+
+describe("BiddingGuidesTeaser", () => {
+  it("renders the bidding guides with the count line and ratings", () => {
+    render(<BiddingGuidesTeaser guides={guides} />);
+
+    for (const guide of guides) {
+      expect(screen.getByText(guide.full_name as string)).toBeInTheDocument();
+    }
+
+    expect(screen.getByText(/проверенных гида/)).toBeInTheDocument();
+    expect(screen.getByText(/4\.9/)).toBeInTheDocument();
+  });
+
+  it("renders nothing when there are no bidding guides", () => {
+    const { container } = render(<BiddingGuidesTeaser guides={[]} />);
+
+    expect(container.firstChild).toBeNull();
+  });
+});

--- a/src/components/shared/bidding-guides-teaser.tsx
+++ b/src/components/shared/bidding-guides-teaser.tsx
@@ -1,0 +1,88 @@
+import { BadgeCheck, Star } from "lucide-react";
+
+import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
+import type { BiddingGuide } from "@/lib/supabase/requests-public";
+import { pluralize } from "@/lib/utils";
+
+function initialsFromName(fullName: string | null): string {
+  if (!fullName) {
+    return "Г";
+  }
+
+  const initials = fullName
+    .trim()
+    .split(/\s+/)
+    .slice(0, 2)
+    .map((word) => word.charAt(0))
+    .join("")
+    .toUpperCase();
+
+  return initials || "Г";
+}
+
+/**
+ * Visitor social-proof row: read-only mini cards for the verified guides already
+ * bidding on the request. Renders nothing when no one has bid (zero fabrication).
+ */
+export function BiddingGuidesTeaser({ guides }: { guides: BiddingGuide[] }) {
+  if (guides.length === 0) {
+    return null;
+  }
+
+  const n = guides.length;
+
+  return (
+    <section className="flex flex-col gap-3">
+      <div className="text-[11.5px] font-semibold uppercase tracking-[0.06em] text-on-surface-muted">
+        ВАШИ ПРОВОДНИКИ
+      </div>
+      <p className="text-[15px] font-medium text-on-surface">
+        {n} {pluralize(n, "проверенный гид", "проверенных гида", "проверенных гидов")} уже
+        предлагают программу
+      </p>
+      <div className="flex flex-wrap gap-3">
+        {guides.map((guide) => (
+          <div
+            key={guide.user_id}
+            className="flex items-center gap-3 rounded-[14px] border border-border bg-surface-lowest px-4 py-3"
+          >
+            <Avatar className="size-10">
+              <AvatarImage src={guide.avatar_url ?? undefined} alt={guide.full_name ?? "Гид"} />
+              <AvatarFallback className="bg-surface-low font-semibold text-on-surface-muted">
+                {initialsFromName(guide.full_name)}
+              </AvatarFallback>
+            </Avatar>
+            <div className="flex flex-col gap-0.5">
+              <div className="flex items-center gap-2">
+                <span className="text-[14px] font-semibold text-on-surface">
+                  {guide.full_name ?? "Гид"}
+                </span>
+                <span className="inline-flex items-center gap-1 text-[12px] font-medium text-success">
+                  <BadgeCheck className="size-3.5" />
+                  Проверен
+                </span>
+              </div>
+              {guide.average_rating != null || guide.review_count != null ? (
+                <span className="inline-flex items-center gap-1 text-[12.5px] text-on-surface-muted">
+                  {guide.average_rating != null ? (
+                    <>
+                      <Star className="size-3.5 fill-current text-gold" />
+                      {guide.average_rating}
+                    </>
+                  ) : null}
+                  {guide.average_rating != null && guide.review_count != null ? " · " : null}
+                  {guide.review_count != null ? (
+                    <>
+                      {guide.review_count}{" "}
+                      {pluralize(guide.review_count, "отзыв", "отзыва", "отзывов")}
+                    </>
+                  ) : null}
+                </span>
+              ) : null}
+            </div>
+          </div>
+        ))}
+      </div>
+    </section>
+  );
+}

--- a/src/components/shared/request-facts-panel.tsx
+++ b/src/components/shared/request-facts-panel.tsx
@@ -1,0 +1,104 @@
+import { CalendarDays, Clock, Eye, Users, Wallet } from "lucide-react";
+
+import { Badge } from "@/components/ui/badge";
+import { cn } from "@/lib/utils";
+
+type RequestFactsPanelProps = {
+  dateLabel: string;
+  flexible: boolean;
+  timeLabel?: string;
+  groupLabel: string;
+  budgetLabel: string;
+  formatLabel?: string;
+  interests?: string[];
+  viewsLabel: string;
+  competingLabel: string;
+  className?: string;
+};
+
+/**
+ * Guide-side constraints panel: the request facts a guide weighs before bidding.
+ * Mirrors the white-glass styling of the visitor-facing TripPanel.
+ */
+export function RequestFactsPanel({
+  dateLabel,
+  flexible,
+  timeLabel,
+  groupLabel,
+  budgetLabel,
+  formatLabel,
+  interests,
+  viewsLabel,
+  competingLabel,
+  className,
+}: RequestFactsPanelProps) {
+  return (
+    <div
+      className={cn(
+        "w-full overflow-hidden rounded-[16px] border border-border bg-glass shadow-glass backdrop-blur-[12px] md:w-[334px]",
+        className,
+      )}
+    >
+      <div className="px-[22px] py-5">
+        <div className="mb-3 text-[11.5px] font-semibold uppercase tracking-[0.06em] text-on-surface-muted">
+          Запрос
+        </div>
+        <div className="flex flex-col gap-[11px]">
+          <div className="flex items-center gap-[11px]">
+            <CalendarDays className="size-[17px] shrink-0 text-primary" strokeWidth={1.7} />
+            <span className="text-[14.5px] font-medium text-on-surface">{dateLabel}</span>
+            <span className="text-[13px] text-on-surface-muted">
+              {flexible ? "· гибкие даты" : "· точная дата"}
+            </span>
+          </div>
+          {timeLabel ? (
+            <div className="flex items-center gap-[11px]">
+              <Clock className="size-[17px] shrink-0 text-primary" strokeWidth={1.7} />
+              <span className="text-[14.5px] font-medium text-on-surface">{timeLabel}</span>
+            </div>
+          ) : null}
+          <div className="flex items-center gap-[11px]">
+            <Users className="size-[17px] shrink-0 text-primary" strokeWidth={1.7} />
+            <span className="text-[14.5px] font-medium text-on-surface">{groupLabel}</span>
+          </div>
+          <div className="flex items-center gap-[11px]">
+            <Wallet className="size-[17px] shrink-0 text-primary" strokeWidth={1.7} />
+            <span className="text-[14.5px] font-medium text-on-surface">{budgetLabel}</span>
+          </div>
+        </div>
+        {formatLabel ? (
+          <div className="mt-3">
+            <Badge variant="secondary">{formatLabel}</Badge>
+          </div>
+        ) : null}
+        {interests?.length ? (
+          <div className="mt-3 flex flex-wrap gap-2">
+            {interests.map((interest) => (
+              <span
+                key={interest}
+                className="rounded-full bg-surface-low px-3 py-1 text-[12.5px] text-ink-2"
+              >
+                {interest}
+              </span>
+            ))}
+          </div>
+        ) : null}
+      </div>
+
+      <div className="h-px bg-border" />
+
+      <div className="px-[22px] py-[18px]">
+        <div className="flex items-center gap-5">
+          <span className="flex items-center gap-[7px] text-[13px] text-on-surface-muted">
+            <Eye className="size-[17px] shrink-0 text-primary" strokeWidth={1.7} />
+            {viewsLabel}
+          </span>
+          <span className="flex items-center gap-[7px] text-[13px] text-on-surface-muted">
+            <Users className="size-[17px] shrink-0 text-primary" strokeWidth={1.7} />
+            {competingLabel}
+          </span>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/shared/trip-panel.tsx
+++ b/src/components/shared/trip-panel.tsx
@@ -1,3 +1,4 @@
+import type { ReactNode } from "react";
 import { CalendarDays, Clock } from "lucide-react";
 
 import { AvatarStack, type AvatarStackMember } from "@/components/shared/avatar-stack";
@@ -17,6 +18,8 @@ type TripPanelProps = {
   /** Real joined members (open_request_members). No fabricated avatars. */
   members?: readonly AvatarStackMember[];
   joinedLabel?: string;
+  /** Optional footer slot (e.g. visitor price + Join CTA). */
+  footer?: ReactNode;
   className?: string;
 };
 
@@ -34,6 +37,7 @@ export function TripPanel({
   remainingLabel,
   members = [],
   joinedLabel,
+  footer,
   className,
 }: TripPanelProps) {
   const showAvailability = seatsTotal != null;
@@ -110,6 +114,10 @@ export function TripPanel({
             ) : null}
           </div>
         </>
+      ) : null}
+
+      {footer ? (
+        <div className="border-t border-border px-[22px] py-[18px]">{footer}</div>
       ) : null}
     </div>
   );

--- a/src/features/guide/components/requests/bid-form-panel.tsx
+++ b/src/features/guide/components/requests/bid-form-panel.tsx
@@ -9,10 +9,11 @@ import { Lock, X } from "lucide-react";
 
 import { Button } from "@/components/ui/button";
 import { INTEREST_CHIPS } from "@/data/interests";
+import { kopecksToRub } from "@/data/money";
 import type { RequestRecord } from "@/data/supabase/queries";
-import { submitOfferAction } from "@/features/guide/offer-actions";
+import { submitOfferAction, editOfferAction } from "@/features/guide/offer-actions";
 import type { SubmitOfferResult } from "@/features/guide/offer-action-types";
-import type { GuideTemplateRow } from "@/lib/supabase/types";
+import type { GuideOfferRow, GuideTemplateRow } from "@/lib/supabase/types";
 import { useGuideCatalog } from "./use-guide-catalog";
 
 type RouteStop = { photoId: string; locationName: string; photoUrl: string; sortOrder: number };
@@ -70,23 +71,36 @@ function ProposedBadge() {
 interface BidFormPanelProps {
   requestId: string;
   request: RequestRecord;
+  editOffer?: GuideOfferRow;
   onClose: () => void;
   onSuccess?: () => void;
 }
 
+const mskParts = (iso: string | null | undefined) => {
+  if (!iso) return null;
+  const t = new Date(iso).getTime();
+  if (Number.isNaN(t)) return null;
+  const m = new Date(t + 3 * 60 * 60 * 1000).toISOString();
+  return { date: m.slice(0, 10), time: m.slice(11, 16) };
+};
+
 export function BidFormPanel({
   requestId,
   request,
+  editOffer,
   onClose,
   onSuccess,
 }: BidFormPanelProps) {
+  const isEdit = !!editOffer;
   const [serverError, setServerError] = React.useState<string | null>(null);
   const [submitted, setSubmitted] = React.useState(false);
   const submitInFlight = React.useRef(false);
   const { guidePhotos, guideTemplates, guideVerificationStatus } = useGuideCatalog();
   const [selectedExcursion, setSelectedExcursion] = React.useState<GuideTemplateRow | null>(null);
   const [excursionPickerOpen, setExcursionPickerOpen] = React.useState(false);
-  const [routeStops, setRouteStops] = React.useState<RouteStop[]>([]);
+  const [routeStops, setRouteStops] = React.useState<RouteStop[]>(
+    Array.isArray(editOffer?.route_stops) ? (editOffer.route_stops as RouteStop[]) : [],
+  );
   const [activeCatalogRouteTab, setActiveCatalogRouteTab] = React.useState<CatalogRouteTab>("catalog");
 
   const travelerDate = request.startsOn ? request.startsOn.slice(0, 10) : "";
@@ -103,14 +117,22 @@ export function BidFormPanel({
   } = useForm<OfferFormValues>({
     resolver: zodResolver(offerFormSchema),
     defaultValues: {
-      price_total: request.budgetRub > 0 ? request.budgetRub * travelerCount : undefined,
-      price_per_person: request.budgetRub > 0 ? request.budgetRub : undefined,
-      message: "",
-      valid_until: getDefaultValidUntil(),
-      excursion_date: travelerDate || undefined,
-      excursion_start_time: request.startTime ?? undefined,
-      excursion_end_time: request.endTime ?? undefined,
-      headcount: travelerCount,
+      price_total: editOffer
+        ? Math.round(kopecksToRub(editOffer.price_minor))
+        : request.budgetRub > 0
+          ? request.budgetRub * travelerCount
+          : undefined,
+      price_per_person: editOffer && editOffer.capacity
+        ? Math.round(kopecksToRub(editOffer.price_minor) / editOffer.capacity)
+        : request.budgetRub > 0
+          ? request.budgetRub
+          : undefined,
+      message: editOffer?.message ?? "",
+      valid_until: editOffer?.expires_at ? editOffer.expires_at.slice(0, 10) : getDefaultValidUntil(),
+      excursion_date: mskParts(editOffer?.starts_at)?.date ?? (travelerDate || undefined),
+      excursion_start_time: mskParts(editOffer?.starts_at)?.time ?? (request.startTime ?? undefined),
+      excursion_end_time: mskParts(editOffer?.ends_at)?.time ?? (request.endTime ?? undefined),
+      headcount: editOffer?.capacity ?? travelerCount,
     },
   });
 
@@ -204,7 +226,9 @@ export function BidFormPanel({
           }
         }
 
-        const result: SubmitOfferResult = await submitOfferAction(requestId, fd);
+        const result: SubmitOfferResult = isEdit && editOffer
+          ? await editOfferAction(editOffer.id, requestId, fd)
+          : await submitOfferAction(requestId, fd);
         if ("ok" in result && result.ok === true) {
           setSubmitted(true);
           onSuccess?.();
@@ -215,7 +239,7 @@ export function BidFormPanel({
         submitInFlight.current = false;
       }
     },
-    [requestId, onSuccess, routeStops, submitted, guideVerificationStatus],
+    [requestId, onSuccess, routeStops, submitted, guideVerificationStatus, isEdit, editOffer],
   );
 
   return (
@@ -235,7 +259,7 @@ export function BidFormPanel({
         <div className="flex items-center justify-between border-b border-border/60 px-6 py-4">
           <div>
             <h2 className="font-sans text-base font-semibold text-foreground">
-              Сделать предложение
+              {isEdit ? "Редактировать предложение" : "Сделать предложение"}
             </h2>
             <p className="mt-0.5 text-sm text-muted-foreground">
               {request.destination} · {request.dateLabel} · {travelerCount} чел.
@@ -593,7 +617,17 @@ export function BidFormPanel({
             disabled={isSubmitting || submitted}
             className={submitted ? "border border-success/30 bg-success/10 text-success w-full" : "w-full"}
           >
-            {submitted ? "Отправлено" : isSubmitting ? "Отправляем…" : "Отправить предложение"}
+            {submitted
+              ? isEdit
+                ? "Сохранено"
+                : "Отправлено"
+              : isSubmitting
+                ? isEdit
+                  ? "Сохраняем…"
+                  : "Отправляем…"
+                : isEdit
+                  ? "Сохранить изменения"
+                  : "Отправить предложение"}
           </Button>
         </form>
       </div>

--- a/src/features/guide/offer-actions.test.ts
+++ b/src/features/guide/offer-actions.test.ts
@@ -12,7 +12,14 @@ vi.mock("@/lib/supabase/server", () => ({
   createSupabaseServerClient: createSupabaseServerClientMock,
 }));
 
-import { checkOfferAgainstLocks, submitOfferAction } from "@/features/guide/offer-actions";
+vi.mock("next/cache", () => ({ revalidatePath: vi.fn() }));
+
+import {
+  checkOfferAgainstLocks,
+  submitOfferAction,
+  withdrawOfferAction,
+  editOfferAction,
+} from "@/features/guide/offer-actions";
 
 const baseRequest = {
   date_locked: true,
@@ -107,5 +114,75 @@ describe("submitOfferAction", () => {
     expect(result).toEqual({ error: "Доступно после верификации" });
     expect(from).toHaveBeenCalledWith("guide_profiles");
     expect(eq).toHaveBeenCalledWith("user_id", "guide-1");
+  });
+});
+
+describe("withdrawOfferAction", () => {
+  it("sets a pending owned offer to withdrawn", async () => {
+    const maybeSingle = vi.fn().mockResolvedValue({
+      data: { id: "offer-1", guide_id: "guide-1", status: "pending", request_id: "req-1" },
+    });
+    const selectEq = vi.fn().mockReturnValue({ maybeSingle });
+    const select = vi.fn().mockReturnValue({ eq: selectEq });
+    const selectChain = { select };
+
+    const update = vi.fn().mockReturnValue({
+      eq: vi.fn().mockReturnValue({
+        eq: vi.fn().mockResolvedValue({ error: null }),
+      }),
+    });
+    const updateChain = { update };
+
+    const from = vi
+      .fn()
+      .mockReturnValueOnce(selectChain)
+      .mockReturnValueOnce(updateChain);
+
+    createSupabaseServerClientMock.mockResolvedValue({
+      auth: {
+        getUser: vi.fn().mockResolvedValue({
+          data: { user: { id: "guide-1" } },
+          error: null,
+        }),
+      },
+      from,
+    });
+
+    const result = await withdrawOfferAction("offer-1", "req-1");
+
+    expect(result).toEqual({ ok: true });
+    expect(update).toHaveBeenCalledWith(
+      expect.objectContaining({ status: "withdrawn" }),
+    );
+  });
+});
+
+describe("editOfferAction", () => {
+  it("rejects when the offer is not pending", async () => {
+    const maybeSingle = vi.fn().mockResolvedValue({
+      data: { id: "offer-1", guide_id: "guide-1", status: "accepted", request_id: "req-1" },
+    });
+    const selectEq = vi.fn().mockReturnValue({ maybeSingle });
+    const select = vi.fn().mockReturnValue({ eq: selectEq });
+    const from = vi.fn().mockReturnValue({ select });
+
+    createSupabaseServerClientMock.mockResolvedValue({
+      auth: {
+        getUser: vi.fn().mockResolvedValue({
+          data: { user: { id: "guide-1" } },
+          error: null,
+        }),
+      },
+      from,
+    });
+
+    const fd = new FormData();
+    fd.set("price_total", "5000");
+    fd.set("message", "обновлённое предложение достаточной длины");
+    fd.set("valid_until", "2027-01-01");
+
+    const res = await editOfferAction("offer-1", "req-1", fd);
+
+    expect("error" in res).toBe(true);
   });
 });

--- a/src/features/guide/offer-actions.ts
+++ b/src/features/guide/offer-actions.ts
@@ -1,5 +1,7 @@
 "use server";
 
+import { revalidatePath } from "next/cache";
+import { rubToKopecks } from "@/data/money";
 import { createSupabaseServerClient } from "@/lib/supabase/server";
 import { notifyNewOffer } from "@/lib/notifications/triggers";
 import { getOrCreateThread } from "@/lib/supabase/conversations";
@@ -209,4 +211,154 @@ export async function submitOfferAction(
   }
 
   return { ok: true };
+}
+
+export async function withdrawOfferAction(
+  offerId: string,
+  requestId: string,
+): Promise<{ ok: true } | { error: string }> {
+  try {
+    const guideId = await getCurrentUserId();
+    const supabase = await createSupabaseServerClient();
+
+    const { data: offer } = await supabase
+      .from("guide_offers")
+      .select("id, guide_id, status, request_id")
+      .eq("id", offerId)
+      .maybeSingle();
+
+    if (!offer) return { error: "Предложение не найдено." };
+    if (offer.guide_id !== guideId) return { error: "Это не ваше предложение." };
+    if (offer.status !== "pending") return { error: "Можно отозвать только активное предложение." };
+
+    const { error } = await supabase
+      .from("guide_offers")
+      .update({ status: "withdrawn" })
+      .eq("id", offerId)
+      .eq("guide_id", guideId);
+
+    if (error) return { error: error.message };
+
+    revalidatePath(`/requests/${requestId}`);
+    revalidatePath("/guide/inbox");
+    return { ok: true };
+  } catch (err) {
+    const msg = typeof (err as { message?: unknown }).message === "string"
+      ? (err as { message: string }).message
+      : "Не удалось отозвать предложение.";
+    return { error: msg };
+  }
+}
+
+export async function editOfferAction(
+  offerId: string,
+  requestId: string,
+  formData: FormData,
+): Promise<SubmitOfferResult> {
+  try {
+    const guideId = await getCurrentUserId();
+    const supabase = await createSupabaseServerClient();
+
+    const { data: offer } = await supabase
+      .from("guide_offers")
+      .select("id, guide_id, status, request_id")
+      .eq("id", offerId)
+      .maybeSingle();
+
+    if (!offer) return { error: "Предложение не найдено." };
+    if (offer.guide_id !== guideId) return { error: "Это не ваше предложение." };
+    if (offer.status !== "pending") return { error: "Можно редактировать только активное предложение." };
+
+    let route_stops: unknown[] = [];
+    try {
+      const routeStopsRaw = formData.get("route_stops");
+      if (routeStopsRaw && typeof routeStopsRaw === "string") route_stops = JSON.parse(routeStopsRaw) as unknown[];
+    } catch {
+      // malformed JSON — treat as empty
+    }
+    const durationRaw = formData.get("route_duration_minutes");
+    const route_duration_minutes = durationRaw && String(durationRaw) !== "" ? Number(durationRaw) : undefined;
+
+    const startsAtRaw = formData.get("starts_at");
+    const endsAtRaw = formData.get("ends_at");
+    const starts_at = startsAtRaw && typeof startsAtRaw === "string" ? startsAtRaw : undefined;
+    const ends_at = endsAtRaw && typeof endsAtRaw === "string" ? endsAtRaw : undefined;
+
+    let inclusions: string[] = [];
+    try {
+      const inclusionsRaw = formData.get("inclusions");
+      if (inclusionsRaw && typeof inclusionsRaw === "string") {
+        const parsedInc = JSON.parse(inclusionsRaw) as unknown;
+        if (Array.isArray(parsedInc)) {
+          inclusions = parsedInc
+            .filter((v): v is string => typeof v === "string")
+            .map((v) => v.trim())
+            .filter((v) => v.length > 0);
+        }
+      }
+    } catch {
+      // malformed JSON — treat as empty
+    }
+
+    const capacityRaw = formData.get("capacity");
+    const capacity =
+      capacityRaw && String(capacityRaw) !== "" ? Number(capacityRaw) : undefined;
+
+    const raw = {
+      request_id: requestId,
+      price_total: Number(formData.get("price_total")),
+      message: String(formData.get("message") ?? ""),
+      valid_until: String(formData.get("valid_until") ?? ""),
+      route_stops,
+      route_duration_minutes,
+      starts_at,
+      ends_at,
+      inclusions,
+      capacity,
+    };
+
+    const parsed = createOfferInputSchema.safeParse(raw);
+    if (!parsed.success) return { error: parsed.error.issues[0]?.message ?? "Ошибка валидации." };
+
+    const { data: requestRow } = await supabase
+      .from("traveler_requests")
+      .select("traveler_id, date_locked, time_locked, starts_on, start_time, end_time, date_flexibility")
+      .eq("id", requestId)
+      .maybeSingle();
+    if (!requestRow) return { error: "Заявка не найдена." };
+
+    const lockCheck = await checkOfferAgainstLocks({
+      startsAt: parsed.data.starts_at ?? undefined,
+      endsAt: parsed.data.ends_at ?? undefined,
+      request: { ...requestRow, date_locked: requestRow.date_flexibility === "few_days" ? false : requestRow.date_locked },
+    });
+    if ("error" in lockCheck) return { error: lockCheck.error };
+
+    const { error } = await supabase
+      .from("guide_offers")
+      .update({
+        price_minor: rubToKopecks(parsed.data.price_total),
+        message: parsed.data.message,
+        expires_at: new Date(parsed.data.valid_until).toISOString(),
+        capacity: parsed.data.capacity,
+        inclusions: parsed.data.inclusions,
+        route_stops: parsed.data.route_stops,
+        route_duration_minutes: parsed.data.route_duration_minutes ?? null,
+        starts_at: parsed.data.starts_at ?? null,
+        ends_at: parsed.data.ends_at ?? null,
+      })
+      .eq("id", offerId)
+      .eq("guide_id", guideId);
+    if (error) return { error: error.message };
+
+    revalidatePath(`/requests/${requestId}`);
+    revalidatePath("/guide/inbox");
+    return { ok: true };
+  } catch (err) {
+    if (err instanceof Error && err.message.startsWith("NEXT_")) throw err;
+    const msg = typeof (err as { message?: unknown }).message === "string"
+      ? (err as { message: string }).message
+      : "Не удалось обновить предложение.";
+    return { error: msg };
+  }
 }

--- a/src/features/requests/components/request-detail-screen.test.tsx
+++ b/src/features/requests/components/request-detail-screen.test.tsx
@@ -274,12 +274,12 @@ describe("RequestDetailScreen", () => {
       />,
     );
 
-    expect(screen.getAllByText("Элиста")).toHaveLength(1);
-    expect(screen.getByText("Сборная группа")).toBeInTheDocument();
-    expect(screen.getAllByText("Присоединиться к группе")).toHaveLength(2);
+    expect(screen.getByRole("heading", { name: "Элиста" })).toBeInTheDocument();
+    expect(screen.getAllByText("Присоединиться к группе").length).toBeGreaterThanOrEqual(1);
     expect(screen.getByText("Кто едет")).toBeInTheDocument();
     expect(screen.getByText("Как это работает")).toBeInTheDocument();
 
+    expect(screen.queryByText("Сборная группа")).not.toBeInTheDocument();
     expect(screen.queryByText(/мест занято/i)).not.toBeInTheDocument();
     expect(screen.queryByText(/Стоимость на человека/i)).not.toBeInTheDocument();
     expect(screen.queryByText(/О маршруте/i)).not.toBeInTheDocument();

--- a/src/features/requests/components/request-detail-screen.test.tsx
+++ b/src/features/requests/components/request-detail-screen.test.tsx
@@ -275,7 +275,7 @@ describe("RequestDetailScreen", () => {
     );
 
     expect(screen.getByRole("heading", { name: "Элиста" })).toBeInTheDocument();
-    expect(screen.getAllByText("Присоединиться к группе").length).toBeGreaterThanOrEqual(1);
+    expect(screen.getAllByText("Присоединиться к группе")).toHaveLength(2);
     expect(screen.getByText("Кто едет")).toBeInTheDocument();
     expect(screen.getByText("Как это работает")).toBeInTheDocument();
 
@@ -334,5 +334,30 @@ describe("RequestDetailScreen", () => {
     expect(refresh).toHaveBeenCalledOnce();
     expect(screen.queryByTestId("guide-qa-panel")).not.toBeInTheDocument();
     expect(screen.queryByText("Q&A for pending")).not.toBeInTheDocument();
+  });
+
+  it("renders guide edit and withdraw controls for an existing pending offer", () => {
+    const validOfferId = "d2000000-0000-4000-8000-000000000099";
+    render(
+      <RequestDetailScreen
+        viewerRole="guide"
+        request={guideRequest}
+        isApproved
+        existingOfferId={validOfferId}
+        existingOffer={{ ...offer, id: validOfferId }}
+        offerMeta={{
+          starts_at: offer.starts_at ?? null,
+          capacity: offer.capacity ?? null,
+          price_minor: offer.price_minor ?? null,
+          message: offer.message ?? null,
+        }}
+        competingOffers={0}
+        viewsCount={0}
+      />,
+    );
+
+    expect(screen.getByRole("button", { name: "Редактировать" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Отозвать" })).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "Сделать предложение" })).not.toBeInTheDocument();
   });
 });

--- a/src/features/requests/components/request-detail-screen.tsx
+++ b/src/features/requests/components/request-detail-screen.tsx
@@ -2,7 +2,6 @@
 
 import type { ReactNode } from "react";
 import * as React from "react";
-import Image from "next/image";
 import Link from "next/link";
 import { useRouter } from "next/navigation";
 import {
@@ -11,11 +10,8 @@ import {
   Check,
   ChevronDown,
   Clock,
-  Clock3,
   Eye,
-  ListChecks,
   LogIn,
-  UserPlus,
   Users,
   Wallet,
 } from "lucide-react";
@@ -27,7 +23,6 @@ import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { INTEREST_CHIPS } from "@/data/interests";
 import { kopecksToRub } from "@/data/money";
 import type { RequestRecord } from "@/data/supabase/queries";
-import { getTheme } from "@/data/themes";
 import type { TravelerRequestRecord } from "@/data/traveler-request/types";
 import { BidFormPanel } from "@/features/guide/components/requests/bid-form-panel-lazy";
 import { GuideOfferQaPanel } from "@/features/guide/components/requests/guide-offer-qa-panel";
@@ -37,6 +32,7 @@ import { CancelRequestButton } from "@/features/traveler/components/requests/can
 import { MarkOffersRead } from "@/features/traveler/components/requests/mark-offers-read";
 import { OfferCard } from "@/features/traveler/components/requests/offer-card";
 import { AcceptOfferButton } from "@/features/traveler/components/requests/accept-offer-button";
+import { BiddingGuidesTeaser } from "@/components/shared/bidding-guides-teaser";
 import { ImmersiveHero } from "@/components/shared/immersive-hero";
 import { TripPanel } from "@/components/shared/trip-panel";
 import { GuideOfferCard, type GuideCardInfo } from "@/components/shared/guide-offer-card";
@@ -45,6 +41,7 @@ import { TravelerRequestStatusBadge } from "@/features/traveler/components/reque
 import { formatTimeRange } from "@/lib/dates";
 import { BADGE_CLASS } from "@/lib/styles";
 import type { QaThread } from "@/lib/supabase/qa-threads";
+import type { BiddingGuide } from "@/lib/supabase/requests-public";
 import type { GuideOfferRow, TravelerRequestRow } from "@/lib/supabase/types";
 import { cn, pluralize } from "@/lib/utils";
 
@@ -89,6 +86,7 @@ type RequestDetailScreenProps =
       viewerRole: "public";
       requestId: string;
       viewModel: PublicRequestDetailViewModel;
+      biddingGuides?: BiddingGuide[];
     }
   | {
       viewerRole: "owner";
@@ -115,6 +113,7 @@ type RequestDetailScreenProps =
       viewerRole: "admin";
       requestId?: string;
       viewModel?: PublicRequestDetailViewModel;
+      biddingGuides?: BiddingGuide[];
     };
 
 const INTEREST_LABEL_BY_ID: Record<string, string> = Object.fromEntries(
@@ -216,26 +215,6 @@ function JoinCta({
   );
 }
 
-function ThemeChips({ themes }: { themes: string[] }) {
-  if (themes.length === 0) return null;
-
-  return (
-    <div className="mb-4 flex flex-wrap gap-2">
-      {themes.map((theme) => {
-        const themeData = getTheme(theme);
-        return (
-          <span
-            key={theme}
-            className="inline-flex rounded-full bg-surface-low px-3.5 py-1.5 text-[0.84rem] font-medium text-foreground"
-          >
-            {themeData?.label ?? theme}
-          </span>
-        );
-      })}
-    </div>
-  );
-}
-
 function AvatarGroupVisual({ children }: { children: ReactNode }) {
   return <div className="flex -space-x-2.5">{children}</div>;
 }
@@ -259,181 +238,116 @@ function MemberAvatars({ members }: { members: PublicRequestDetailViewModel["mem
   );
 }
 
-function DecisionCard({
-  requestId,
-  viewModel,
-}: {
-  requestId: string;
-  viewModel: PublicRequestDetailViewModel;
-}) {
-  const price = formatPublicPrice(viewModel.pricePerPersonRub);
-
-  return (
-    <aside className="lg:sticky lg:top-[108px]">
-      <div className="rounded-[22px] border border-border bg-surface-high p-6 shadow-glass">
-        <div className="font-display text-[2rem] font-bold leading-none tracking-[-0.02em] text-foreground">
-          {price}{" "}
-          {viewModel.pricePerPersonRub ? (
-            <small className="text-base font-medium text-muted-foreground">/ с человека</small>
-          ) : null}
-        </div>
-        <p className="mt-3 text-sm leading-[1.55] text-muted-foreground">
-          Добор открыт: группа сейчас {viewModel.memberCount}{" "}
-          {pluralize(viewModel.memberCount, "человек", "человека", "человек")}. Финальную цену предложат гиды.
-        </p>
-        <div className="mt-5 hidden lg:block">
-          <JoinCta requestId={requestId} joinState={viewModel.joinState} />
-        </div>
-        <div className="mt-4 flex items-center gap-2 border-t border-border pt-4 text-[0.84rem] text-muted-foreground">
-          <Eye className="size-4 text-primary" aria-hidden="true" />
-          Гиды уже видят этот запрос
-        </div>
-      </div>
-    </aside>
-  );
-}
-
 function PublicDetailBranch({
   requestId,
   viewModel,
+  biddingGuides,
 }: {
   requestId: string;
   viewModel: PublicRequestDetailViewModel;
+  biddingGuides: BiddingGuide[];
 }) {
   const price = formatPublicPrice(viewModel.pricePerPersonRub);
   const hasAbout = viewModel.notes.trim().length > 0;
 
   return (
-    <div className="bg-surface pb-24 lg:pb-0">
-      <section className="relative h-[240px] overflow-hidden bg-foreground md:h-[300px]">
-        <Image
-          src={viewModel.cityImageUrl}
-          alt={viewModel.title}
-          width={1800}
-          height={600}
-          priority
-          sizes="100vw"
-          className="h-[240px] w-full object-cover md:h-[300px]"
-        />
-        <div
-          className="absolute inset-0 bg-gradient-to-b from-foreground/10 via-transparent to-foreground/80"
-          aria-hidden="true"
-        />
-        <div className="absolute inset-x-0 bottom-0 z-[2]">
-          <div className="mx-auto w-full max-w-page px-[clamp(20px,4vw,48px)] pb-6">
-            <span className="inline-flex items-center gap-2 rounded-full border border-primary-foreground/20 bg-primary-foreground/15 px-3.5 py-1.5 text-[0.82rem] font-medium text-primary-foreground backdrop-blur-[8px]">
-              <span className="size-2 rounded-full bg-success shadow-[0_0_0_3px_rgba(127,227,182,0.25)]" aria-hidden="true" />
-              Сборная группа
-            </span>
-            <h1 className="mt-3 font-display text-[clamp(2.1rem,5vw,2.9rem)] font-bold leading-[1.05] tracking-[-0.02em] text-primary-foreground">
-              {viewModel.title}
-            </h1>
-            <p className="mt-1 text-sm text-primary-foreground/80">{viewModel.regionLabel}</p>
-          </div>
-        </div>
-      </section>
-
-      <div className="mx-auto grid w-full max-w-page grid-cols-1 gap-8 px-[clamp(20px,4vw,48px)] py-8 lg:grid-cols-[minmax(0,1fr)_380px] lg:items-start lg:gap-9 lg:pb-24">
-        <main>
-          <div className="mb-8 flex flex-wrap gap-2.5">
-            <span className="inline-flex items-center gap-2 rounded-xl border border-border bg-surface-high px-3.5 py-2 text-sm font-medium text-foreground shadow-sm">
-              <CalendarDays className="size-4 text-primary" aria-hidden="true" />
-              {viewModel.dateLabel}
-            </span>
-            {viewModel.timeLabel ? (
-              <span className="inline-flex items-center gap-2 rounded-xl border border-border bg-surface-high px-3.5 py-2 text-sm font-medium text-foreground shadow-sm">
-                <Clock3 className="size-4 text-primary" aria-hidden="true" />
-                {viewModel.timeLabel}
-              </span>
-            ) : null}
-            {viewModel.datesFlexible ? (
-              <span className="inline-flex items-center gap-2 rounded-xl border border-primary/20 bg-primary/10 px-3.5 py-2 text-sm font-medium text-primary shadow-sm">
-                <ListChecks className="size-4" aria-hidden="true" />
-                Гибкие даты
-              </span>
-            ) : null}
-          </div>
-
-          <section className="mb-8">
-            <h2 className="mb-3.5 text-[0.8rem] font-semibold uppercase tracking-[0.08em] text-muted-foreground">
-              Кто едет
-            </h2>
-            <div className="rounded-[22px] border border-border bg-surface-high p-6 shadow-sm">
-              <div className="flex flex-wrap items-center justify-between gap-4">
-                <p className="text-[1.2rem] font-semibold text-foreground">
-                  В группе сейчас {viewModel.memberCount}{" "}
-                  {pluralize(viewModel.memberCount, "человек", "человека", "человек")}
-                </p>
-                <MemberAvatars members={viewModel.members} />
+    <>
+      <ImmersiveHero
+        className="-mt-nav-h"
+        imageUrl={viewModel.cityImageUrl}
+        breadcrumb={[{ label: "Поездки" }, { label: viewModel.regionLabel }, { label: viewModel.title }]}
+        title={viewModel.title}
+        intro={hasAbout ? viewModel.notes : undefined}
+      >
+        <TripPanel
+          dateLabel={viewModel.dateLabel}
+          timeLabel={viewModel.timeLabel}
+          footer={
+            <div className="flex flex-col gap-3">
+              <div className="font-display text-[26px] font-bold leading-none tracking-[-0.02em] text-on-surface">
+                {price}
+                {viewModel.pricePerPersonRub ? (
+                  <span className="ml-1 text-[15px] font-medium text-on-surface-muted">/ с человека</span>
+                ) : null}
               </div>
-              <p className="mt-3.5 text-sm text-muted-foreground">
-                Организатор — <b className="font-semibold text-foreground">{viewModel.organizerName}</b>
+              <p className="text-[13px] leading-[1.5] text-on-surface-muted">
+                Добор открыт: в группе сейчас {viewModel.memberCount}{" "}
+                {pluralize(viewModel.memberCount, "человек", "человека", "человек")}. Финальную цену предложат гиды.
               </p>
-              <div className="mt-3.5 inline-flex items-center gap-1.5 text-[0.84rem] font-medium text-primary">
-                <UserPlus className="size-4" aria-hidden="true" />
-                Группа открыта — можно присоединиться
+              <div className="hidden lg:block">
+                <JoinCta requestId={requestId} joinState={viewModel.joinState} />
               </div>
             </div>
-          </section>
+          }
+        />
+      </ImmersiveHero>
 
-          {hasAbout ? (
-            <section className="mb-8">
-              <h2 className="mb-3.5 text-[0.8rem] font-semibold uppercase tracking-[0.08em] text-muted-foreground">
-                О поездке
-              </h2>
-              <ThemeChips themes={viewModel.themes} />
-              <p className="max-w-[60ch] text-[0.97rem] leading-[1.7] text-foreground/85">{viewModel.notes}</p>
-            </section>
-          ) : null}
-
-          <section className="mb-8">
-            <h2 className="mb-3.5 text-[0.8rem] font-semibold uppercase tracking-[0.08em] text-muted-foreground">
-              Как это работает
-            </h2>
-            <div className="grid gap-3.5 sm:grid-cols-3">
-              {["Присоединяешься к группе", "Гиды предлагают условия и цену", "Группа подтверждает бронь"].map(
-                (step, index) => (
-                  <div key={step} className="rounded-2xl border border-border bg-surface-high p-4 shadow-sm">
-                    <div className="mb-2.5 flex size-7 items-center justify-center rounded-full bg-primary/10 text-sm font-bold text-primary">
-                      {index + 1}
-                    </div>
-                    <p className="text-sm leading-[1.45] text-foreground">{step}</p>
-                  </div>
-                ),
-              )}
+      <div className="mx-auto w-full max-w-page px-5 pb-32 md:px-8">
+        {/* Кто едет — preserve member social proof */}
+        <section className="flex flex-col gap-4 pt-[54px]">
+          <div className="text-[11.5px] font-semibold uppercase tracking-[0.14em] text-primary">Кто едет</div>
+          <div className="rounded-[16px] border border-border bg-surface-lowest p-6">
+            <div className="flex flex-wrap items-center justify-between gap-4">
+              <p className="text-[20px] font-semibold text-on-surface">
+                В группе сейчас {viewModel.memberCount}{" "}
+                {pluralize(viewModel.memberCount, "человек", "человека", "человек")}
+              </p>
+              <MemberAvatars members={viewModel.members} />
             </div>
-          </section>
+            <p className="mt-3 text-sm text-on-surface-muted">
+              Организатор — <b className="font-semibold text-on-surface">{viewModel.organizerName}</b>
+            </p>
+          </div>
+        </section>
 
-          <section>
-            <div className="border-t border-border">
-              {faqItems.map((item) => (
-                <details key={item.question} className="group border-b border-border">
-                  <summary className="flex cursor-pointer list-none items-center justify-between gap-4 py-4 text-left text-[0.97rem] font-medium text-foreground marker:hidden">
-                    {item.question}
-                    <ChevronDown className="size-4 text-muted-foreground transition-transform group-open:rotate-180" aria-hidden="true" />
-                  </summary>
-                  <p className="pb-4 text-sm leading-[1.6] text-muted-foreground">{item.answer}</p>
-                </details>
-              ))}
-            </div>
-          </section>
-        </main>
+        {/* Social-proof teaser — renders nothing if no real bidders */}
+        <div className="pt-[54px]">
+          <BiddingGuidesTeaser guides={biddingGuides} />
+        </div>
 
-        <DecisionCard requestId={requestId} viewModel={viewModel} />
+        {/* Как это работает + off-platform reassurance */}
+        <section className="flex flex-col gap-4 pt-[54px]">
+          <div className="text-[11.5px] font-semibold uppercase tracking-[0.14em] text-primary">Как это работает</div>
+          <div className="grid gap-3.5 sm:grid-cols-3">
+            {["Присоединяешься к группе", "Гиды предлагают условия и цену", "Группа подтверждает бронь"].map((step, index) => (
+              <div key={step} className="rounded-[16px] border border-border bg-surface-lowest p-4">
+                <div className="mb-2.5 flex size-7 items-center justify-center rounded-full bg-primary/10 text-sm font-bold text-primary">{index + 1}</div>
+                <p className="text-sm leading-[1.45] text-on-surface">{step}</p>
+              </div>
+            ))}
+          </div>
+          <p className="text-[13.5px] text-on-surface-muted">Договорённость и оплата — напрямую с гидом.</p>
+        </section>
+
+        {/* FAQ */}
+        <section className="pt-[54px]">
+          <div className="border-t border-border">
+            {faqItems.map((item) => (
+              <details key={item.question} className="group border-b border-border">
+                <summary className="flex cursor-pointer list-none items-center justify-between gap-4 py-4 text-left text-[0.97rem] font-medium text-on-surface marker:hidden">
+                  {item.question}
+                  <ChevronDown className="size-4 text-on-surface-muted transition-transform group-open:rotate-180" aria-hidden="true" />
+                </summary>
+                <p className="pb-4 text-sm leading-[1.6] text-on-surface-muted">{item.answer}</p>
+              </details>
+            ))}
+          </div>
+        </section>
       </div>
 
-      <div className="fixed inset-x-0 bottom-0 z-50 flex items-center gap-3 border-t border-border bg-surface-high px-4 py-3 shadow-[0_-6px_24px_rgba(10,40,28,0.10)] lg:hidden">
-        <div className="shrink-0 font-display text-lg font-bold text-foreground">
+      {/* Mobile sticky join bar — preserved */}
+      <div className="fixed inset-x-0 bottom-0 z-50 flex items-center gap-3 border-t border-border bg-surface-lowest px-4 py-3 shadow-glass lg:hidden">
+        <div className="shrink-0 font-display text-lg font-bold text-on-surface">
           {price}
           {viewModel.pricePerPersonRub ? (
-            <small className="block text-xs font-medium text-muted-foreground">с человека</small>
+            <small className="block text-xs font-medium text-on-surface-muted">с человека</small>
           ) : null}
         </div>
         <div className="min-w-0 flex-1">
           <JoinCta requestId={requestId} joinState={viewModel.joinState} compact />
         </div>
       </div>
-    </div>
+    </>
   );
 }
 
@@ -1072,14 +986,26 @@ function GuideDetailBranch({
 export function RequestDetailScreen(props: RequestDetailScreenProps) {
   switch (props.viewerRole) {
     case "public":
-      return <PublicDetailBranch requestId={props.requestId} viewModel={props.viewModel} />;
+      return (
+        <PublicDetailBranch
+          requestId={props.requestId}
+          viewModel={props.viewModel}
+          biddingGuides={props.biddingGuides ?? []}
+        />
+      );
     case "owner":
       return <OwnerDetailBranch {...props} />;
     case "guide":
       return <GuideDetailBranch {...props} />;
     case "admin":
       if (props.requestId && props.viewModel) {
-        return <PublicDetailBranch requestId={props.requestId} viewModel={props.viewModel} />;
+        return (
+          <PublicDetailBranch
+            requestId={props.requestId}
+            viewModel={props.viewModel}
+            biddingGuides={props.biddingGuides ?? []}
+          />
+        );
       }
       return null;
   }

--- a/src/features/requests/components/request-detail-screen.tsx
+++ b/src/features/requests/components/request-detail-screen.tsx
@@ -10,7 +10,6 @@ import {
   Check,
   ChevronDown,
   Clock,
-  Eye,
   LogIn,
   Users,
   Wallet,
@@ -19,7 +18,6 @@ import {
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
-import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { INTEREST_CHIPS } from "@/data/interests";
 import { kopecksToRub } from "@/data/money";
 import type { RequestRecord } from "@/data/supabase/queries";
@@ -34,10 +32,13 @@ import { OfferCard } from "@/features/traveler/components/requests/offer-card";
 import { AcceptOfferButton } from "@/features/traveler/components/requests/accept-offer-button";
 import { BiddingGuidesTeaser } from "@/components/shared/bidding-guides-teaser";
 import { ImmersiveHero } from "@/components/shared/immersive-hero";
+import { RequestFactsPanel } from "@/components/shared/request-facts-panel";
 import { TripPanel } from "@/components/shared/trip-panel";
 import { GuideOfferCard, type GuideCardInfo } from "@/components/shared/guide-offer-card";
 import { StickyActionBar } from "@/components/shared/sticky-action-bar";
 import { TravelerRequestStatusBadge } from "@/features/traveler/components/requests/traveler-request-status";
+import { withdrawOfferAction } from "@/features/guide/offer-actions";
+import { cityImage } from "@/lib/city-image";
 import { formatTimeRange } from "@/lib/dates";
 import { BADGE_CLASS } from "@/lib/styles";
 import type { QaThread } from "@/lib/supabase/qa-threads";
@@ -106,6 +107,7 @@ type RequestDetailScreenProps =
       isApproved: boolean;
       existingOfferId: string | null;
       offerMeta?: OfferMeta | null;
+      existingOffer?: GuideOfferRow | null;
       competingOffers: number;
       viewsCount: number;
     }
@@ -143,12 +145,6 @@ const avatarFallbackClassNames = [
 
 const UUID_RE =
   /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
-
-const chipBase = "inline-flex items-center rounded-full px-2.5 py-0.5 text-xs font-medium";
-const assemblyChip = `${chipBase} bg-sky-100 text-sky-700`;
-const privateChip = `${chipBase} bg-purple-100 text-purple-700`;
-const flexibleChip = `${chipBase} bg-emerald-100 text-emerald-700`;
-const exactChip = `${chipBase} bg-rose-100 text-rose-700`;
 
 function formatPublicPrice(pricePerPersonRub: number | null): string {
   if (!pricePerPersonRub) return "Цена уточняется";
@@ -777,209 +773,136 @@ function GuideDetailBranch({
   isApproved,
   existingOfferId,
   offerMeta,
+  existingOffer,
   competingOffers,
   viewsCount,
 }: Extract<RequestDetailScreenProps, { viewerRole: "guide" }>) {
   const router = useRouter();
   const [panelOpen, setPanelOpen] = React.useState(false);
   const [offerId, setOfferId] = React.useState<string | null>(existingOfferId);
+  const [editMode, setEditMode] = React.useState(false);
+  const [withdrawing, setWithdrawing] = React.useState(false);
 
   React.useEffect(() => {
     setOfferId(existingOfferId);
   }, [existingOfferId]);
 
-  const interestsLabel = request.interests
-    .map((s) => INTEREST_LABEL_BY_ID[s] ?? s)
-    .join(" · ");
   const validOfferId = offerId && UUID_RE.test(offerId) ? offerId : null;
   const hasFlexibleDates =
     request.dateFlexibility === "few_days" || request.date_locked === false;
 
   return (
-    <div className="space-y-6">
-      <Link
-        href="/guide/inbox"
-        className="inline-flex items-center gap-1.5 text-sm text-muted-foreground hover:text-foreground"
+    <>
+      <ImmersiveHero
+        className="-mt-nav-h"
+        imageUrl={cityImage(request.destination)}
+        breadcrumb={[{ label: "Запросы" }, { label: request.destination }]}
+        title={request.destination}
+        intro={request.description || undefined}
       >
-        <ArrowLeft className="size-4" />
-        Назад к запросам
-      </Link>
+        <RequestFactsPanel
+          dateLabel={request.dateLabel}
+          flexible={hasFlexibleDates}
+          timeLabel={formatTimeRange(request.startTime, request.endTime) || undefined}
+          groupLabel={`${request.groupSize} ${pluralize(request.groupSize, "человек", "человека", "человек")}`}
+          budgetLabel={request.budgetLabel}
+          formatLabel={request.mode === "assembly" ? "Сборная группа" : "Своя группа"}
+          interests={request.interests.map((s) => INTEREST_LABEL_BY_ID[s] ?? s)}
+          viewsLabel={formatViewsLabel(viewsCount)}
+          competingLabel={formatCompetingOffersLabel(competingOffers, validOfferId !== null)}
+        />
+      </ImmersiveHero>
 
-      <Card className="border-border/70 bg-card/90">
-        <CardHeader className="space-y-2">
-          <div className="flex items-start gap-3">
-            <div
-              className="flex h-12 w-12 shrink-0 items-center justify-center rounded-full bg-gradient-to-br from-primary/30 to-primary/10 text-primary text-base font-bold"
-              aria-hidden="true"
-            >
-              {request.requesterInitials}
+      <div className="mx-auto w-full max-w-page px-5 pb-24 md:px-8">
+        <div className="flex items-center gap-2 pt-[54px]">
+          <div className="flex size-11 shrink-0 items-center justify-center rounded-full bg-primary/12 text-base font-bold text-primary" aria-hidden="true">
+            {request.requesterInitials}
+          </div>
+          <div>
+            <p className="text-[15px] font-semibold text-on-surface">{request.requesterName}</p>
+            <p className="text-[13px] text-on-surface-muted">Запрос от {formatDateTime(request.createdAt)}</p>
+          </div>
+        </div>
+
+        <div className="pt-7">
+          {/* ACTION ZONE — three states */}
+          {!isApproved ? (
+            <div className="flex flex-wrap items-center gap-2">
+              <Button variant="default" size="default" disabled>Доступно после верификации</Button>
+              <Link href="/guide/profile#verification" className="text-xs text-primary underline-offset-2 hover:underline">
+                Пройти верификацию →
+              </Link>
             </div>
-            <div className="flex-1 min-w-0">
-              <CardTitle className="text-lg">{request.requesterName}</CardTitle>
-              <p className="mt-1 text-sm text-muted-foreground">
-                в{" "}
-                <span className="font-medium text-foreground">
-                  {request.destination}
+          ) : validOfferId ? (
+            <div className="flex flex-col gap-4 rounded-[16px] border border-primary/25 bg-primary/5 p-5">
+              <div className="flex items-center justify-between gap-3">
+                <p className="text-[11px] font-semibold uppercase tracking-wider text-primary/70">Ваш отклик</p>
+                <span className="inline-flex items-center gap-1.5 rounded-full bg-primary/10 px-3 py-1 text-xs font-semibold text-primary">
+                  <Check className="size-3.5" aria-hidden="true" /> Предложение отправлено
                 </span>
-              </p>
-            </div>
-            <p className="text-xs text-muted-foreground shrink-0">
-              {formatDateTime(request.createdAt)}
-            </p>
-          </div>
-        </CardHeader>
-
-        <CardContent className="space-y-5">
-          <p className="text-[11px] font-semibold uppercase tracking-wider text-muted-foreground/70">
-            Запрос путешественника
-          </p>
-
-          {interestsLabel ? (
-            <div>
-              <span className="inline-flex items-center gap-1.5 whitespace-normal rounded-full bg-primary/10 px-2.5 py-1 font-sans text-[11px] font-semibold tracking-[0.02em] text-primary">
-                {interestsLabel}
-              </span>
-            </div>
-          ) : null}
-
-          <div className="flex flex-wrap gap-2">
-            <span className={request.mode === "assembly" ? assemblyChip : privateChip}>
-              {request.mode === "assembly" ? "Сборная группа" : "Своя группа"}
-            </span>
-            <span className={hasFlexibleDates ? flexibleChip : exactChip}>
-              {hasFlexibleDates ? "Гибкие даты" : "Точная дата"}
-            </span>
-          </div>
-
-          <div className="space-y-1.5">
-            <p className="text-sm">
-              <span className="font-medium text-foreground">Даты:</span>{" "}
-              <span className="text-muted-foreground">{request.dateLabel}</span>
-              {formatTimeRange(request.startTime, request.endTime) && (
-                <>
-                  {" · "}
-                  <span className="font-medium text-foreground">Время:</span>{" "}
-                  <span className="text-muted-foreground">
-                    {formatTimeRange(request.startTime, request.endTime)}
-                  </span>
-                </>
-              )}
-            </p>
-            <p className="text-sm">
-              <span className="font-medium text-foreground">Бюджет:</span>{" "}
-              <span className="text-muted-foreground">
-                {request.budgetLabel} · {request.groupSize} чел.
-              </span>
-            </p>
-          </div>
-
-          <div className="border-t border-border/50 pt-4">
-            <p className="text-xs font-semibold uppercase tracking-wider text-muted-foreground/70">
-              Описание
-            </p>
-            {request.description ? (
-              <p className="mt-2 whitespace-pre-line text-sm text-muted-foreground">
-                {request.description}
-              </p>
-            ) : (
-              <p className="mt-2 text-sm italic text-muted-foreground/60">
-                Путешественник не оставил описание.
-              </p>
-            )}
-          </div>
-
-          <div
-            className="flex flex-col gap-1.5 rounded-md border border-border/50 bg-muted/30 px-3 py-2 text-xs text-muted-foreground"
-            aria-live="polite"
-          >
-            <div className="flex items-center gap-2">
-              <Eye className="size-3.5 shrink-0" aria-hidden="true" />
-              <span>{formatViewsLabel(viewsCount)}</span>
-            </div>
-            <div className="flex items-center gap-2">
-              <Users className="size-3.5 shrink-0" aria-hidden="true" />
-              <span>{formatCompetingOffersLabel(competingOffers, validOfferId !== null)}</span>
-            </div>
-          </div>
-
-          {validOfferId ? (
-            <div className="rounded-lg border border-primary/25 bg-primary/5 p-4 space-y-3">
-              <p className="text-[11px] font-semibold uppercase tracking-wider text-primary/70">
-                Ваш отклик
-              </p>
-              <span className="inline-flex items-center gap-1.5 rounded-full bg-primary/10 px-3 py-1 font-sans text-xs font-semibold tracking-[0.02em] text-primary">
-                ✓ Предложение отправлено
-              </span>
-              {offerMeta &&
-                (offerMeta.starts_at != null ||
-                  offerMeta.capacity != null ||
-                  offerMeta.price_minor != null ||
-                  offerMeta.message != null) ? (
-                <div className="space-y-2">
-                  <p className="text-sm text-foreground/80">
-                    {offerMeta.starts_at
-                      ? new Date(offerMeta.starts_at).toLocaleDateString("ru-RU", {
-                          day: "numeric",
-                          month: "long",
-                        })
-                      : ""}
+              </div>
+              {offerMeta && (offerMeta.starts_at != null || offerMeta.capacity != null || offerMeta.price_minor != null || offerMeta.message != null) ? (
+                <div className="flex flex-col gap-2">
+                  <p className="text-sm text-on-surface/80">
+                    {offerMeta.starts_at ? new Date(offerMeta.starts_at).toLocaleDateString("ru-RU", { day: "numeric", month: "long" }) : ""}
                     {offerMeta.capacity != null ? ` · ${offerMeta.capacity} чел.` : ""}
-                    {offerMeta.price_minor != null
-                      ? ` · ${Math.round(
-                          kopecksToRub(offerMeta.price_minor) / (offerMeta.capacity ?? 1),
-                        ).toLocaleString("ru-RU")} ₽/чел.`
-                      : ""}
+                    {offerMeta.price_minor != null ? ` · ${Math.round(kopecksToRub(offerMeta.price_minor) / (offerMeta.capacity ?? 1)).toLocaleString("ru-RU")} ₽/чел.` : ""}
                   </p>
                   {offerMeta.message ? (
-                    <div className="rounded-md border border-primary/15 bg-background/70 p-3">
-                      <p className="mb-1 text-xs font-medium text-primary/60">
-                        Сообщение путешественнику
-                      </p>
-                      <p className="text-sm whitespace-pre-line">{offerMeta.message}</p>
+                    <div className="rounded-[12px] border border-primary/15 bg-surface-lowest p-3">
+                      <p className="mb-1 text-xs font-medium text-primary/60">Сообщение путешественнику</p>
+                      <p className="whitespace-pre-line text-sm text-on-surface">{offerMeta.message}</p>
                     </div>
                   ) : null}
                 </div>
               ) : null}
+              <div className="flex flex-wrap gap-2">
+                <Button
+                  variant="default"
+                  size="default"
+                  disabled={!existingOffer}
+                  onClick={() => { setEditMode(true); setPanelOpen(true); }}
+                >
+                  Редактировать
+                </Button>
+                <Button
+                  variant="outline"
+                  size="default"
+                  disabled={withdrawing}
+                  onClick={async () => {
+                    if (!window.confirm("Отозвать предложение? Путешественник больше его не увидит.")) return;
+                    setWithdrawing(true);
+                    const res = await withdrawOfferAction(validOfferId, request.id);
+                    setWithdrawing(false);
+                    if ("ok" in res) { setOfferId(null); router.refresh(); }
+                    else window.alert(res.error);
+                  }}
+                >
+                  {withdrawing ? "Отзываем…" : "Отозвать"}
+                </Button>
+              </div>
               <div className="border-t border-primary/15 pt-3">
                 <GuideOfferQaPanel offerId={validOfferId} />
               </div>
             </div>
-          ) : isApproved ? (
-            <Button
-              variant="default"
-              size="default"
-              onClick={() => setPanelOpen(true)}
-            >
+          ) : (
+            <Button variant="default" size="default" onClick={() => { setEditMode(false); setPanelOpen(true); }}>
               Сделать предложение
             </Button>
-          ) : (
-            <div className="flex flex-wrap items-center gap-2">
-              <Button variant="default" size="default" disabled>
-                Доступно после верификации
-              </Button>
-              <Link
-                href="/guide/profile#verification"
-                className="text-xs text-primary underline-offset-2 hover:underline"
-              >
-                Пройти верификацию →
-              </Link>
-            </div>
           )}
-        </CardContent>
-      </Card>
+        </div>
+      </div>
 
       {panelOpen ? (
         <BidFormPanel
           requestId={request.id}
           request={request}
-          onClose={() => setPanelOpen(false)}
-          onSuccess={() => {
-            setPanelOpen(false);
-            router.refresh();
-          }}
+          editOffer={editMode ? existingOffer ?? undefined : undefined}
+          onClose={() => { setPanelOpen(false); setEditMode(false); }}
+          onSuccess={() => { setPanelOpen(false); setEditMode(false); router.refresh(); }}
         />
       ) : null}
-    </div>
+    </>
   );
 }
 

--- a/src/lib/supabase/database.types.ts
+++ b/src/lib/supabase/database.types.ts
@@ -3196,6 +3196,17 @@ export type Database = {
         Args: { p_listing_id: string }
         Returns: undefined
       }
+      get_bidding_guides_for_request: {
+        Args: { p_request_id: string }
+        Returns: {
+          user_id: string
+          full_name: string | null
+          avatar_url: string | null
+          average_rating: number | null
+          review_count: number | null
+          slug: string | null
+        }[]
+      }
       guide_offer_exists_for_counter: {
         Args: { p_guide_id: string; p_request_id: string }
         Returns: boolean

--- a/src/lib/supabase/requests-public.ts
+++ b/src/lib/supabase/requests-public.ts
@@ -1,0 +1,29 @@
+import type { SupabaseClient } from "@supabase/supabase-js";
+
+export type BiddingGuide = {
+  user_id: string;
+  full_name: string | null;
+  avatar_url: string | null;
+  average_rating: number | null;
+  review_count: number | null;
+  slug: string | null;
+};
+
+/**
+ * Privacy-scoped social proof for the public visitor view. Returns the approved
+ * guides with a live bid on an OPEN request (the RPC enforces the open_to_join
+ * gate). Never throws — returns [] on any error so it can never block the page.
+ */
+export async function getBiddingGuidesForRequest(
+  supabase: SupabaseClient,
+  requestId: string,
+): Promise<BiddingGuide[]> {
+  try {
+    const { data } = await supabase.rpc("get_bidding_guides_for_request", {
+      p_request_id: requestId,
+    });
+    return (data ?? []) as BiddingGuide[];
+  } catch {
+    return [];
+  }
+}

--- a/supabase/migrations/20260618140000_bidding_guides_rpc.sql
+++ b/supabase/migrations/20260618140000_bidding_guides_rpc.sql
@@ -1,0 +1,26 @@
+-- Read-only, privacy-scoped social proof for the public visitor view: which
+-- approved guides have a live (pending) bid on an OPEN/сборная request.
+-- Returns only already-public profile fields; no offer contents. SECURITY DEFINER
+-- because non-owners are RLS-blocked from reading guide_offers directly.
+create or replace function public.get_bidding_guides_for_request(p_request_id uuid)
+returns table (
+  user_id uuid, full_name text, avatar_url text,
+  average_rating numeric, review_count integer, slug text
+)
+language sql stable security definer set search_path = public
+as $$
+  select distinct on (gp.user_id)
+    gp.user_id, p.full_name, p.avatar_url, gp.average_rating, gp.review_count, gp.slug
+  from public.guide_offers o
+  join public.guide_profiles gp on gp.user_id = o.guide_id
+  left join public.profiles p on p.id = gp.user_id
+  join public.traveler_requests tr on tr.id = o.request_id
+  where o.request_id = p_request_id
+    and o.status = 'pending'::public.offer_status
+    and gp.verification_status = 'approved'
+    and tr.open_to_join = true
+  order by gp.user_id, gp.average_rating desc nulls last;
+$$;
+
+revoke all on function public.get_bidding_guides_for_request(uuid) from public;
+grant execute on function public.get_bidding_guides_for_request(uuid) to anon, authenticated;

--- a/supabase/rollbacks/20260618140000_bidding_guides_rpc.sql
+++ b/supabase/rollbacks/20260618140000_bidding_guides_rpc.sql
@@ -1,0 +1,1 @@
+drop function if exists public.get_bidding_guides_for_request(uuid);


### PR DESCRIPTION
Brings the **public visitor** and **guide** branches of `/requests/[requestId]` up to the immersive owner-view quality (navy/amber/Onest, ImmersiveHero + glass panels), persona-tuned.

## What's in
- **Data layer**: privacy-scoped read-only RPC `get_bidding_guides_for_request` (open/сборная requests only, no offer contents) + typed wrapper (returns `[]` on any error — never blocks the page); guide `editOfferAction` + `withdrawOfferAction` server actions (ownership + pending guards, defense-in-depth).
- **Primitives**: `TripPanel` footer slot, `BiddingGuidesTeaser` (renders nothing when there are no real bidders — zero fabrication), `RequestFactsPanel`.
- **Visitor branch**: immersive hero + trip panel (price + Join CTA), social-proof teaser of real bidding guides, "Кто едет", "Как это работает" + off-platform-pay line, FAQ; mobile sticky Join preserved.
- **Guide branch**: immersive hero + request-facts panel; action zone with **Редактировать** / **Отозвать** for an existing bid, verification gate + Q&A preserved.

## Verification
- `bun run typecheck` · `bun run lint` · `bun run test:run` (799) · `bun run build` — all green locally.
- Each workstream independently reviewed (spec compliance, ownership security, zero fabrication, no scope creep).

## Note
The teaser is RPC-tolerant: until `supabase/migrations/20260618140000_bidding_guides_rpc.sql` is applied, the teaser simply renders nothing and every page still works.