### PR TITLE
fix(bookings): reveal traveler contact to guide after confirmation

### DIFF
--- a/src/app/(protected)/guide/bookings/[bookingId]/actions.ts
+++ b/src/app/(protected)/guide/bookings/[bookingId]/actions.ts
@@ -1,6 +1,6 @@
 "use server";
 
-import { revealTravelerName, type BookingRecord } from "@/data/supabase/queries";
+import { revealTravelerName, revealTravelerPhone, type BookingRecord } from "@/data/supabase/queries";
 import { transitionBooking, type BookingStatus } from "@/lib/bookings/state-machine";
 import { createSupabaseAdminClient } from "@/lib/supabase/admin";
 import { createSupabaseServerClient } from "@/lib/supabase/server";
@@ -110,16 +110,18 @@ export async function getGuideBookingDetailAction(
   if (booking.guide_id !== user.id) return { ok: false, error: "Нет доступа" };
 
   let travelerName: string | undefined;
+  let travelerPhone: string | null = null;
   try {
     const admin = createSupabaseAdminClient();
     const { data: traveler } = await admin
       .from("profiles")
-      .select("full_name")
+      .select("full_name, phone")
       .eq("id", booking.traveler_id)
       .maybeSingle();
     travelerName = revealTravelerName(traveler?.full_name, booking.status);
+    travelerPhone = revealTravelerPhone(traveler?.phone, booking.status);
   } catch {
-    // admin env not configured — traveler name unavailable
+    // admin env not configured — traveler contact unavailable
   }
 
   return {
@@ -131,6 +133,7 @@ export async function getGuideBookingDetailAction(
       dateLabel: formatDateLabel(booking.starts_at ?? "", booking.ends_at),
       priceRub: Math.round((booking.subtotal_minor ?? 0) / 100),
       travelerName,
+      travelerPhone,
       status: booking.status,
     },
   };

--- a/src/data/supabase/queries.ts
+++ b/src/data/supabase/queries.ts
@@ -128,6 +128,7 @@ export type BookingRecord = {
   priceRub: number;
   guideName?: string;
   travelerName?: string;
+  travelerPhone?: string | null;
   status: string;
 };
 
@@ -355,7 +356,17 @@ export function revealTravelerName(
   bookingStatus: string | null | undefined,
 ): string {
   const trimmed = name?.trim();
-  return bookingStatus === "confirmed" && trimmed ? trimmed : "Путешественник";
+  return (bookingStatus === "confirmed" || bookingStatus === "completed") && trimmed
+    ? trimmed
+    : "Путешественник";
+}
+
+export function revealTravelerPhone(
+  phone: string | null | undefined,
+  bookingStatus: string | null | undefined,
+): string | null {
+  const trimmed = phone?.trim();
+  return (bookingStatus === "confirmed" || bookingStatus === "completed") && trimmed ? trimmed : null;
 }
 
 export function mapRequestRow(

--- a/src/features/bookings/components/booking-detail-screen.test.tsx
+++ b/src/features/bookings/components/booking-detail-screen.test.tsx
@@ -154,7 +154,7 @@ describe("BookingDetailScreen", () => {
     expect(screen.queryByRole("button", { name: "Подтвердить" })).not.toBeInTheDocument();
   });
 
-  it("renders guide controls and traveler contact without traveler review/dispute entry", async () => {
+  it("renders guide controls and revealed traveler contact on a confirmed booking", async () => {
     getGuideBookingDetailAction.mockResolvedValue({
       ok: true,
       booking: {
@@ -164,7 +164,8 @@ describe("BookingDetailScreen", () => {
         dateLabel: "10 июня 2026",
         priceRub: 6000,
         travelerName: "Мария",
-        status: "awaiting_guide_confirmation",
+        travelerPhone: "+79991234567",
+        status: "confirmed",
       },
     });
 
@@ -172,8 +173,10 @@ describe("BookingDetailScreen", () => {
 
     expect(await screen.findByText("Операции по бронированию")).toBeInTheDocument();
     expect(screen.getByRole("button", { name: "Подтвердить" })).toBeInTheDocument();
-    expect(screen.getByText("Путешественник")).toBeInTheDocument();
+    expect(screen.getByText("Свяжитесь с путешественником")).toBeInTheDocument();
     expect(screen.getByText("Мария")).toBeInTheDocument();
+    const phoneLink = screen.getByRole("link", { name: "+79991234567" });
+    expect(phoneLink).toHaveAttribute("href", "tel:+79991234567");
     expect(screen.queryByText(/Оцените поездку/)).not.toBeInTheDocument();
     expect(screen.queryByRole("button", { name: "Открыть спор" })).not.toBeInTheDocument();
   });

--- a/src/features/bookings/components/booking-detail-screen.tsx
+++ b/src/features/bookings/components/booking-detail-screen.tsx
@@ -499,6 +499,8 @@ function GuideBookingDetailView({ bookingId }: { bookingId: string }) {
   const canComplete = Boolean(nextStatusForAction(statusTyped, "complete"));
   const canCancel = Boolean(nextStatusForAction(statusTyped, "cancel"));
   const canNoShow = Boolean(nextStatusForAction(statusTyped, "no_show"));
+  const contactRevealed =
+    record.status === "confirmed" || record.status === "completed";
 
   return (
     <div className="space-y-8">
@@ -612,6 +614,39 @@ function GuideBookingDetailView({ bookingId }: { bookingId: string }) {
         </CardContent>
       </Card>
 
+      {contactRevealed ? (
+        <Card className="border-border/70 bg-card/90">
+          <CardHeader className="space-y-1">
+            <CardTitle>Свяжитесь с путешественником</CardTitle>
+            <p className="text-sm text-muted-foreground">
+              Контакт открыт после подтверждения бронирования.
+            </p>
+          </CardHeader>
+          <CardContent>
+            <div className="flex flex-col gap-[0.3rem]">
+              <p className="font-sans text-base font-semibold text-foreground">
+                {record.travelerName ?? "Путешественник"}
+              </p>
+              {record.travelerPhone ? (
+                <p className="font-sans text-sm text-muted-foreground">
+                  <span className="font-medium">Телефон:</span>{" "}
+                  <a
+                    href={`tel:${record.travelerPhone}`}
+                    className="text-primary no-underline hover:underline"
+                  >
+                    {record.travelerPhone}
+                  </a>
+                </p>
+              ) : (
+                <p className="font-sans text-sm text-muted-foreground">
+                  Контакт появится после подтверждения
+                </p>
+              )}
+            </div>
+          </CardContent>
+        </Card>
+      ) : null}
+
       <Card className="border-border/70 bg-card/90">
         <CardHeader className="space-y-1">
           <CardTitle>Деньги</CardTitle>
@@ -631,11 +666,13 @@ function GuideBookingDetailView({ bookingId }: { bookingId: string }) {
               value={formatStatusLabelForSummary(mapDbStatusToGuideStatus(record.status))}
               helper={record.title}
             />
-            <StatCard
-              label="Путешественник"
-              value={record.travelerName ?? "Путешественник"}
-              helper="Имя раскрывается после подтверждения"
-            />
+            {!contactRevealed ? (
+              <StatCard
+                label="Путешественник"
+                value={record.travelerName ?? "Путешественник"}
+                helper="Имя и контакт раскрываются после подтверждения"
+              />
+            ) : null}
           </div>
         </CardContent>
       </Card>


### PR DESCRIPTION
Fixes the one-directional booking handshake found in the live handoff audit: the guide side of a confirmed/completed booking now reveals the traveler's name + phone (tel: link), mirroring the traveler side. Reveal is gated to confirmed/completed only (no PII pre-confirmation); admin client, no RLS change. typecheck/lint/799 tests/build green; Sonnet review PASS.