### PR TITLE
feat(analytics): funnel events (request/bid/accept/confirm)

### DIFF
--- a/src/app/(protected)/guide/bookings/[bookingId]/actions.ts
+++ b/src/app/(protected)/guide/bookings/[bookingId]/actions.ts
@@ -4,6 +4,7 @@ import { revealTravelerName, revealTravelerPhone, type BookingRecord } from "@/d
 import { transitionBooking, type BookingStatus } from "@/lib/bookings/state-machine";
 import { createSupabaseAdminClient } from "@/lib/supabase/admin";
 import { createSupabaseServerClient } from "@/lib/supabase/server";
+import { logFunnelEvent } from "@/lib/analytics/marketplace-events";
 
 export type ConfirmBookingResult =
   | { ok: true; status: BookingStatus }
@@ -59,7 +60,23 @@ async function transitionAction(
 export async function confirmBookingAction(
   bookingId: string,
 ): Promise<ConfirmBookingResult> {
-  return transitionAction(bookingId, "confirmed", "Не удалось подтвердить бронирование");
+  const auth = await assertGuideOwns(bookingId);
+  if (!auth.ok) return auth;
+  try {
+    const updated = await transitionBooking(bookingId, "confirmed", auth.userId);
+    await logFunnelEvent({
+      event_type: "booking_confirmed",
+      scope: "booking",
+      booking_id: bookingId,
+      actor_id: auth.userId,
+      summary: "Бронирование подтверждено",
+    });
+    return { ok: true, status: updated.status };
+  } catch (error) {
+    const message =
+      error instanceof Error ? error.message : "Не удалось подтвердить бронирование";
+    return { ok: false, error: message };
+  }
 }
 
 export async function confirmBooking(

--- a/src/features/guide/offer-actions.ts
+++ b/src/features/guide/offer-actions.ts
@@ -10,6 +10,7 @@ import {
   hasGuideOffered,
   createOfferInputSchema,
 } from "@/lib/supabase/offers";
+import { logFunnelEvent } from "@/lib/analytics/marketplace-events";
 import type { SubmitOfferResult } from "@/features/guide/offer-action-types";
 
 export type { SubmitOfferResult } from "@/features/guide/offer-action-types";
@@ -179,6 +180,14 @@ export async function submitOfferAction(
     }
 
     const offer = await createGuideOffer(parsed.data, guideId);
+
+    await logFunnelEvent({
+      event_type: "bid_placed",
+      scope: "request",
+      request_id: requestId,
+      actor_id: guideId,
+      summary: "Гид отправил предложение",
+    });
 
     try {
       await notifyNewOffer(requestId, offer.id);

--- a/src/features/requests/create-request-actions.ts
+++ b/src/features/requests/create-request-actions.ts
@@ -9,6 +9,7 @@ import { createTravelerRequest, type CreateRequestInput } from "@/lib/supabase/r
 import { createSupabaseServerClient } from "@/lib/supabase/server";
 import { hasSupabaseEnv } from "@/lib/env";
 import { notifyGuidesNewRequest } from "@/lib/notifications/triggers";
+import { logFunnelEvent } from "@/lib/analytics/marketplace-events";
 
 export type CreateRequestState = {
   error: string | null;
@@ -124,6 +125,15 @@ export async function createRequestAction(
   } catch {
     // notification errors are non-fatal — traveler redirect proceeds
   }
+
+  await logFunnelEvent({
+    event_type: "request_created",
+    scope: "request",
+    request_id: requestId,
+    actor_id: travelerId,
+    summary: "Заявка создана",
+    payload: { mode: input.mode },
+  });
 
   redirect(`/requests/${requestId}?created=1&mode=${input.mode}`);
 }

--- a/src/features/requests/owner-request-actions.ts
+++ b/src/features/requests/owner-request-actions.ts
@@ -11,6 +11,7 @@ import { buildAuthLoginRedirect } from "@/lib/auth/safe-redirect";
 import { createSupabaseServerClient } from "@/lib/supabase/server";
 import { markOffersReadForRequest } from "@/lib/supabase/offers";
 import { createNotification } from "@/lib/notifications/create-notification";
+import { logFunnelEvent } from "@/lib/analytics/marketplace-events";
 
 export type AcceptOfferActionState = {
   error: string | null;
@@ -147,6 +148,14 @@ export async function acceptOfferAction(
   } catch {
     // Notification delivery must not block booking creation.
   }
+
+  await logFunnelEvent({
+    event_type: "offer_accepted",
+    scope: "booking",
+    booking_id: booking.id,
+    actor_id: user.id,
+    summary: "Путешественник принял предложение",
+  });
 
   redirect(`/bookings/${booking.id}`);
 }

--- a/src/lib/analytics/marketplace-events.ts
+++ b/src/lib/analytics/marketplace-events.ts
@@ -1,0 +1,26 @@
+import "server-only";
+
+import { createSupabaseAdminClient } from "@/lib/supabase/admin";
+
+type FunnelEvent =
+  | { event_type: "request_created"; scope: "request"; request_id: string; actor_id?: string | null; summary: string; payload?: Record<string, unknown> }
+  | { event_type: "bid_placed"; scope: "request"; request_id: string; actor_id?: string | null; summary: string; payload?: Record<string, unknown> }
+  | { event_type: "offer_accepted"; scope: "booking"; booking_id: string; actor_id?: string | null; summary: string; payload?: Record<string, unknown> }
+  | { event_type: "booking_confirmed"; scope: "booking"; booking_id: string; actor_id?: string | null; summary: string; payload?: Record<string, unknown> };
+
+export async function logFunnelEvent(e: FunnelEvent): Promise<void> {
+  try {
+    const admin = createSupabaseAdminClient();
+    await admin.from("marketplace_events").insert({
+      scope: e.scope,
+      request_id: "request_id" in e ? e.request_id : null,
+      booking_id: "booking_id" in e ? e.booking_id : null,
+      actor_id: e.actor_id ?? null,
+      event_type: e.event_type,
+      summary: e.summary,
+      payload: e.payload ?? {},
+    });
+  } catch {
+    // best-effort telemetry — never block the action
+  }
+}


### PR DESCRIPTION
Best-effort funnel instrumentation reusing the existing marketplace_events table (admin client, no migration). Events: request_created, bid_placed, offer_accepted, booking_confirmed. Never blocks the underlying action; no PII. Gates green; Sonnet PASS.