### PR TITLE
fix(trust): RatingDisplay + new-but-vetted zero state

### DIFF
--- a/src/components/shared/rating-display.test.tsx
+++ b/src/components/shared/rating-display.test.tsx
@@ -1,0 +1,31 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import { RatingDisplay } from "./rating-display";
+
+describe("RatingDisplay", () => {
+  it("shows the 'Новый гид' chip and no star when there are no reviews", () => {
+    const { container } = render(<RatingDisplay rating={0} reviewCount={0} />);
+
+    expect(screen.getByText("Новый гид")).toBeInTheDocument();
+    expect(container.querySelector("svg")).toBeNull();
+    expect(container.textContent).not.toContain("0.0");
+    expect(container.textContent).not.toContain("★");
+  });
+
+  it("adds the verified marker for a new but vetted guide", () => {
+    render(<RatingDisplay rating={null} reviewCount={null} verified />);
+
+    expect(screen.getByText("Новый гид")).toBeInTheDocument();
+    expect(screen.getByText("Проверен")).toBeInTheDocument();
+  });
+
+  it("renders the star, rating and review count when reviews exist", () => {
+    const { container } = render(<RatingDisplay rating={4.7} reviewCount={3} />);
+
+    expect(container.querySelector("svg")).not.toBeNull();
+    expect(container.textContent).toContain("4.7");
+    expect(container.textContent).toContain("3 отзыва");
+    expect(screen.queryByText("Новый гид")).not.toBeInTheDocument();
+  });
+});

--- a/src/components/shared/rating-display.tsx
+++ b/src/components/shared/rating-display.tsx
@@ -1,23 +1,39 @@
-import { Star } from "lucide-react";
+import { Star, BadgeCheck } from "lucide-react";
+
+import { cn, pluralize } from "@/lib/utils";
 
 type RatingDisplayProps = {
-  rating: number;
-  reviewCount?: number;
+  rating?: number | null;
+  reviewCount?: number | null;
+  verified?: boolean;
   className?: string;
 };
 
-export function RatingDisplay({ rating, reviewCount, className }: RatingDisplayProps) {
-  if (rating === 0 || reviewCount === 0) {
-    return <div className={className ?? "text-sm text-ink-2"}>нет отзывов</div>;
-  }
-
-  return (
-    <div className={className ?? "flex items-center gap-2 text-sm text-ink-2"}>
-      <span className="flex items-center gap-1 font-semibold text-ink">
-        <Star className="size-4 fill-primary text-primary" />
-        {rating.toFixed(1)}
+/** Zero-review → "Новый гид" chip (+ optional verified), NEVER "★0/0.0". >0 → amber star + rating + count. */
+export function RatingDisplay({ rating, reviewCount, verified, className }: RatingDisplayProps) {
+  const count = reviewCount ?? 0;
+  if (count <= 0) {
+    return (
+      <span className={cn("inline-flex items-center gap-1.5 text-[12.5px] font-medium", className)}>
+        <span className="inline-flex items-center rounded-full bg-surface-low px-2 py-0.5 text-on-surface-muted">
+          Новый гид
+        </span>
+        {verified ? (
+          <span className="inline-flex items-center gap-1 text-success">
+            <BadgeCheck className="size-3.5" />
+            Проверен
+          </span>
+        ) : null}
       </span>
-      {typeof reviewCount === "number" ? <span>· {reviewCount} отзывов</span> : null}
-    </div>
+    );
+  }
+  return (
+    <span className={cn("inline-flex items-center gap-1 text-[12.5px] text-on-surface-muted", className)}>
+      <Star className="size-3.5 fill-current text-gold" />
+      <span className="font-medium text-on-surface">{(rating ?? 0).toFixed(1)}</span>
+      <span>
+        · {count} {pluralize(count, "отзыв", "отзыва", "отзывов")}
+      </span>
+    </span>
   );
 }

--- a/src/components/shared/tour-card.tsx
+++ b/src/components/shared/tour-card.tsx
@@ -46,7 +46,7 @@ export function TourCard({
         <div className="mt-3 grid gap-1.5 text-sm text-primary-foreground/80">
           <span>
             {guide}
-            {rating !== undefined ? ` · ${rating} ★` : null}
+            {rating !== undefined && rating > 0 ? ` · ${rating} ★` : null}
           </span>
         </div>
 

--- a/src/features/guide/components/public/guide-profile-screen.tsx
+++ b/src/features/guide/components/public/guide-profile-screen.tsx
@@ -1,5 +1,6 @@
 import Image from "next/image";
 
+import { RatingDisplay } from "@/components/shared/rating-display";
 import { TourCard } from "@/components/shared/tour-card";
 import type { PublicGuideProfile } from "@/data/public-guides/types";
 import { GuidePhotoGrid } from "./guide-photo-grid";
@@ -101,10 +102,8 @@ export function GuideProfileScreen({ guide, listings, reviews, photos = [] }: Pr
                 {guide.headline}
               </p>
 
-              <div className="mb-6 flex flex-wrap gap-2">
-                <span className="inline-flex items-center rounded-full bg-surface-low px-3.5 py-1.5 text-[0.8125rem] text-muted-foreground">
-                  {rating.toFixed(1)} / 5 · {totalReviews} отзывов
-                </span>
+              <div className="mb-6 flex flex-wrap items-center gap-2">
+                <RatingDisplay rating={rating} reviewCount={totalReviews} verified />
                 <span className="inline-flex items-center rounded-full bg-surface-low px-3.5 py-1.5 text-[0.8125rem] text-muted-foreground">
                   {guide.yearsExperience} лет опыта
                 </span>
@@ -113,19 +112,19 @@ export function GuideProfileScreen({ guide, listings, reviews, photos = [] }: Pr
               <div className="mb-7 grid w-fit grid-cols-3 gap-8 border-b border-outline-variant pb-7">
                 <div className="flex flex-col">
                   <strong className="font-sans text-[2rem] font-semibold leading-[1] tabular-nums text-foreground">
-                    {rating.toFixed(1)}
+                    {totalReviews === 0 ? "—" : rating.toFixed(1)}
                   </strong>
                   <span className="mt-1 text-[0.8125rem] text-muted-foreground">рейтинг</span>
                 </div>
                 <div className="flex flex-col">
                   <strong className="font-sans text-[2rem] font-semibold leading-[1] tabular-nums text-foreground">
-                    {totalReviews}
+                    {totalReviews === 0 ? "—" : totalReviews}
                   </strong>
                   <span className="mt-1 text-[0.8125rem] text-muted-foreground">поездок</span>
                 </div>
                 <div className="flex flex-col">
                   <strong className="font-sans text-[2rem] font-semibold leading-[1] tabular-nums text-foreground">
-                    {guide.yearsExperience}
+                    {guide.yearsExperience > 0 ? guide.yearsExperience : "—"}
                   </strong>
                   <span className="mt-1 text-[0.8125rem] text-muted-foreground">лет опыта</span>
                 </div>

--- a/src/features/guide/components/public/public-guides-grid.tsx
+++ b/src/features/guide/components/public/public-guides-grid.tsx
@@ -6,6 +6,7 @@ import { useRouter } from "next/navigation";
 import { Search } from "lucide-react";
 
 import { ProfileAvatar } from "@/components/profile-avatar";
+import { RatingDisplay } from "@/components/shared/rating-display";
 import { Input } from "@/components/ui/input";
 import { INTEREST_CHIPS } from "@/data/interests";
 import type { GuideRecord } from "@/data/supabase/queries";
@@ -157,9 +158,7 @@ export function PublicGuidesGrid({
                   {guide.bio}
                 </p>
 
-                <p className="text-[0.8125rem] text-on-surface-muted">
-                  <span className="text-amber-500">★</span> {guide.rating} · {guide.reviewCount} отзывов
-                </p>
+                <RatingDisplay rating={guide.rating} reviewCount={guide.reviewCount} />
                 {guide.listingCount != null && (
                   <p className="text-[0.8125rem] text-on-surface-muted">
                     {pluralizeExcursions(guide.listingCount)}


### PR DESCRIPTION
Zero-review guides no longer render as zero-STAR guides (★0/0.0/0 поездок). New RatingDisplay primitive: 0 reviews → 'Новый гид' chip; >0 → star+rating+count. Wired into guides grid, guide profile (+ guarded stat block), embedded TourCard. Listing cards already guarded. 802 tests; Sonnet PASS.