### PR TITLE
fix(destinations): de-duplicate city/region label on cards

### DIFF
--- a/src/features/destinations/components/destination-detail-screen.tsx
+++ b/src/features/destinations/components/destination-detail-screen.tsx
@@ -61,7 +61,9 @@ export function DestinationDetailScreen({
 
         <div className="relative z-[2] mx-auto w-full max-w-page px-[clamp(20px,4vw,48px)] pt-[calc(var(--nav-h)+48px)] pb-14 text-primary-foreground">
           <div className="max-w-[720px]">
-            {destination.region ? (
+            {destination.region &&
+            destination.region.trim().toLowerCase() !==
+              destination.name.trim().toLowerCase() ? (
               <p className="mb-2 font-sans text-[0.6875rem] font-medium uppercase tracking-[0.18em] text-primary-foreground/70">
                 {destination.region}
               </p>

--- a/src/features/destinations/components/destinations-grid.tsx
+++ b/src/features/destinations/components/destinations-grid.tsx
@@ -94,7 +94,9 @@ export function DestinationsGrid({
                 <p className="font-display text-[1.75rem] font-semibold leading-[1.1] text-primary-foreground">
                   {featured.name}
                 </p>
-                <p className="mt-1 text-[0.8125rem] text-primary-foreground/70">{featured.region}</p>
+                {featured.region && normalize(featured.region) !== normalize(featured.name) ? (
+                  <p className="mt-1 text-[0.8125rem] text-primary-foreground/70">{featured.region}</p>
+                ) : null}
               </div>
             </Link>
           )}
@@ -120,7 +122,9 @@ export function DestinationsGrid({
                 <p className="font-display text-[1.25rem] font-semibold leading-[1.1] text-primary-foreground">
                   {dest.name}
                 </p>
-                <p className="mt-1 text-[0.8125rem] text-primary-foreground/70">{dest.region}</p>
+                {dest.region && normalize(dest.region) !== normalize(dest.name) ? (
+                  <p className="mt-1 text-[0.8125rem] text-primary-foreground/70">{dest.region}</p>
+                ) : null}
               </div>
             </Link>
           ))}


### PR DESCRIPTION
Destination cards/hero showed 'Москва Москва' (name + identical region). Region now renders only when it differs from the name (case-insensitive). 2 files.