### PR TITLE
fix(listings): render route separators as → not ->

### DIFF
--- a/src/components/listing-detail/ExcursionShapeDetail.tsx
+++ b/src/components/listing-detail/ExcursionShapeDetail.tsx
@@ -17,6 +17,7 @@ import type {
   ListingTariffRow,
 } from "@/lib/supabase/types";
 import { maskPii } from "@/lib/pii/mask";
+import { arrowizeRoute } from "@/lib/utils";
 
 import { formatExcursionPriceFrom } from "./excursion-price";
 
@@ -66,7 +67,7 @@ interface Props {
 export function ExcursionShapeDetail({ listing, photos, schedule, tariffs, guide }: Props) {
   const description = maskPii(listing.description);
   const idea = maskPii(listing.idea);
-  const routeText = maskPii(listing.route);
+  const routeText = arrowizeRoute(maskPii(listing.route));
   const theme = maskPii(listing.theme);
   const audience = maskPii(listing.audience);
   const facts = maskPii(listing.facts);

--- a/src/lib/utils.test.ts
+++ b/src/lib/utils.test.ts
@@ -1,0 +1,15 @@
+import { describe, expect, it } from "vitest";
+
+import { arrowizeRoute } from "./utils";
+
+describe("arrowizeRoute", () => {
+  it("replaces ASCII arrows with → and normalizes spacing", () => {
+    expect(arrowizeRoute("A -> B -> C")).toBe("A → B → C");
+    expect(arrowizeRoute("A->B")).toBe("A → B");
+  });
+
+  it("returns an empty string for null or undefined", () => {
+    expect(arrowizeRoute(null)).toBe("");
+    expect(arrowizeRoute(undefined)).toBe("");
+  });
+});

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -5,6 +5,11 @@ export function cn(...inputs: ClassValue[]) {
   return twMerge(clsx(inputs));
 }
 
+/** Display route separators as "→" (data may store "->"). Render-layer only. */
+export function arrowizeRoute(text: string | null | undefined): string {
+  return (text ?? "").replace(/\s*->\s*/g, " → ");
+}
+
 export function pluralize(n: number, form1: string, form2: string, form3: string) {
   const mod10 = Math.abs(n) % 10;
   const mod100 = Math.abs(n) % 100;


### PR DESCRIPTION
Route/itinerary text stored with ASCII '->' now renders '→' via a render-layer arrowizeRoute helper (no DB mutation). Applied to listing detail route. Unit-tested.