### PR TITLE
fix(search): slug listing links + zero-results lead CTA

### DIFF
--- a/src/app/(site)/search/page.tsx
+++ b/src/app/(site)/search/page.tsx
@@ -92,11 +92,19 @@ export default async function SearchPage({
         </Suspense>
         <ListingGrid listings={listings} />
         {listings.length === 0 ? (
-          <div className="mt-12 flex flex-col items-center gap-4 text-center">
-            <p className="text-muted-foreground">Ничего не найдено по вашему запросу</p>
-            <Button asChild variant="secondary">
-              <Link href="/search">Сбросить фильтры</Link>
-            </Button>
+          <div className="mt-12 flex flex-col items-center gap-3 text-center">
+            <p className="text-on-surface-muted">Ничего не нашли по вашему запросу</p>
+            <p className="max-w-[420px] text-sm text-on-surface-muted">
+              Опубликуйте запрос — местные гиды предложат варианты под вашу поездку.
+            </p>
+            <div className="mt-1 flex flex-wrap items-center justify-center gap-2">
+              <Button asChild>
+                <Link href="/">Опубликовать запрос</Link>
+              </Button>
+              <Button asChild variant="outline">
+                <Link href="/search">Сбросить фильтры</Link>
+              </Button>
+            </div>
           </div>
         ) : null}
       </div>

--- a/src/components/traveler/ListingCard.tsx
+++ b/src/components/traveler/ListingCard.tsx
@@ -35,6 +35,7 @@ interface Props {
   listing: Pick<
     ListingRow,
     | "id"
+    | "slug"
     | "title"
     | "region"
     | "city"
@@ -53,7 +54,7 @@ export function ListingCard({ listing }: Props) {
   return (
     <Link
       className="group block rounded-glass focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
-      href={`/listings/${listing.id}`}
+      href={`/listings/${listing.slug ?? listing.id}`}
     >
       <Card className="h-full gap-0 py-0 transition-shadow group-hover:shadow-md">
         <div


### PR DESCRIPTION
Listing cards link to /listings/{slug} (was UUID); empty search shows a primary 'Опубликовать запрос' lead CTA + secondary reset. Gates green; Sonnet PASS.