### PR TITLE
fix(form): restore manual /form route + repoint homepage link

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -48,7 +48,6 @@ const nextConfig: NextConfig = {
   },
   async redirects() {
     return [
-      { source: "/form", destination: "/", permanent: true },
       { source: "/tours", destination: "/listings", permanent: true },
       { source: "/requests/new", destination: "/", permanent: true },
       { source: "/traveler/requests/new", destination: "/", permanent: true },

--- a/src/app/(home)/form/page.tsx
+++ b/src/app/(home)/form/page.tsx
@@ -1,0 +1,35 @@
+import type { Metadata } from "next";
+
+import { getActiveGuideDestinations, getHomepageRequests, type DestinationOption, type RequestRecord } from "@/data/supabase/queries";
+import { SiteHeaderServer } from "@/components/shared/site-header-server";
+import { HomePageShell2Classic } from "@/features/homepage-classic/components/homepage-shell2-classic";
+import { createSupabaseServerClient } from "@/lib/supabase/server";
+
+export const metadata: Metadata = {
+  title: "Заполнить заявку — Проводник",
+};
+
+export default async function ManualRequestFormPage() {
+  let destinations: DestinationOption[] = [];
+  let requests: RequestRecord[] = [];
+  try {
+    const supabase = await createSupabaseServerClient();
+    const [destResult, reqResult] = await Promise.all([
+      getActiveGuideDestinations(supabase),
+      getHomepageRequests(supabase),
+    ]);
+    destinations = destResult.data ?? [];
+    requests = reqResult.data ?? [];
+  } catch {
+    // both stay []
+  }
+
+  return (
+    <>
+      <SiteHeaderServer />
+      <main className="pt-nav-h">
+        <HomePageShell2Classic destinations={destinations} requests={requests} />
+      </main>
+    </>
+  );
+}

--- a/src/features/homepage/components/hero-conversation.tsx
+++ b/src/features/homepage/components/hero-conversation.tsx
@@ -259,7 +259,7 @@ export function HeroConversation() {
 
         <p className="mt-6 text-center text-xs text-muted-foreground">
           Предпочитаете заполнить вручную?{" "}
-          <Link href="/" className="font-medium text-primary underline-offset-2 hover:underline">
+          <Link href="/form" className="font-medium text-primary underline-offset-2 hover:underline">
             Обычная форма
           </Link>
         </p>


### PR DESCRIPTION
Restores the deleted /form manual request page (the classic alternative to the conversational /). Removed the /form→/ redirect; homepage 'Обычная форма' link now points to /form. Build shows the /form route. Old styling — canon refactor is a later task.