### PR TITLE
fix(account): load saved notification prefs + surface save errors + 44px targets

### DIFF
--- a/src/app/(protected)/account/notifications/page.tsx
+++ b/src/app/(protected)/account/notifications/page.tsx
@@ -2,12 +2,13 @@
 
 import Link from "next/link";
 import { notFound } from "next/navigation";
-import { useCallback, useState } from "react";
+import { useCallback, useEffect, useState } from "react";
 
 import {
   NotificationPrefsMatrix,
   type NotificationPrefsMatrixProps,
 } from "@/features/profile/components/NotificationPrefsMatrix";
+import { getPersonalSettings } from "@/features/profile/actions/getPersonalSettings";
 import { updatePersonalSettings } from "@/features/profile/actions/updatePersonalSettings";
 import { flags } from "@/lib/flags";
 
@@ -18,14 +19,34 @@ if (!flags.FEATURE_TR_NOTIFICATIONS) {
 
 export default function NotificationPreferencesPage() {
   const [prefs, setPrefs] = useState<Record<string, unknown>>({});
+  const [isLoading, setIsLoading] = useState(true);
   const [saving, setSaving] = useState(false);
   const [saved, setSaved] = useState(false);
+  const [saveError, setSaveError] = useState(false);
+
+  useEffect(() => {
+    let active = true;
+    (async () => {
+      try {
+        const result = await getPersonalSettings();
+        if (active && result) {
+          setPrefs(result.notificationPrefs);
+        }
+      } finally {
+        if (active) setIsLoading(false);
+      }
+    })();
+    return () => {
+      active = false;
+    };
+  }, []);
 
   const handleChange = useCallback<NotificationPrefsMatrixProps["onChange"]>(
     async (updatedPrefs) => {
       setPrefs(updatedPrefs);
       setSaving(true);
       setSaved(false);
+      setSaveError(false);
       try {
         await updatePersonalSettings({
           locale: "ru",
@@ -33,6 +54,8 @@ export default function NotificationPreferencesPage() {
           notificationPrefs: updatedPrefs,
         });
         setSaved(true);
+      } catch {
+        setSaveError(true);
       } finally {
         setSaving(false);
       }
@@ -59,13 +82,22 @@ export default function NotificationPreferencesPage() {
         </Link>
       </div>
 
-      <NotificationPrefsMatrix prefs={prefs} onChange={handleChange} />
+      {isLoading ? (
+        <p className="text-sm text-muted-foreground">Загрузка настроек…</p>
+      ) : (
+        <NotificationPrefsMatrix prefs={prefs} onChange={handleChange} />
+      )}
 
       {saving && (
         <p className="text-sm text-muted-foreground">Сохранение…</p>
       )}
       {!saving && saved && (
         <p className="text-sm text-success">Настройки сохранены</p>
+      )}
+      {!saving && saveError && (
+        <p className="text-sm text-destructive">
+          Не удалось сохранить. Попробуйте ещё раз.
+        </p>
       )}
     </div>
   );

--- a/src/features/profile/actions/getPersonalSettings.test.ts
+++ b/src/features/profile/actions/getPersonalSettings.test.ts
@@ -1,0 +1,129 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { mockGetUser, mockFrom } = vi.hoisted(() => ({
+  mockGetUser: vi.fn(),
+  mockFrom: vi.fn(),
+}));
+
+vi.mock("@/lib/supabase/server", () => ({
+  createSupabaseServerClient: vi.fn(async () => ({
+    auth: { getUser: mockGetUser },
+    from: mockFrom,
+  })),
+}));
+
+import { getPersonalSettings } from "./getPersonalSettings";
+
+describe("getPersonalSettings", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGetUser.mockResolvedValue({
+      data: { user: { id: "11111111-1111-4111-8111-111111111111" } },
+    });
+  });
+
+  it("returns null when not authed", async () => {
+    mockGetUser.mockResolvedValue({ data: { user: null } });
+
+    const result = await getPersonalSettings();
+
+    expect(result).toBeNull();
+    expect(mockFrom).not.toHaveBeenCalled();
+  });
+
+  it("loads traveler notification prefs from profiles", async () => {
+    const prefs = { "traveler.new_offer.email": false };
+    const roleMaybeSingle = vi.fn().mockResolvedValue({
+      data: { role: "traveler" },
+    });
+    const prefsMaybeSingle = vi.fn().mockResolvedValue({
+      data: { notification_prefs: prefs },
+    });
+
+    mockFrom.mockImplementation((table: string) => {
+      if (table === "profiles") {
+        return {
+          select: vi.fn((cols: string) => ({
+            eq: vi.fn().mockReturnValue({
+              maybeSingle:
+                cols === "role" ? roleMaybeSingle : prefsMaybeSingle,
+            }),
+          })),
+        };
+      }
+      throw new Error(`unexpected table ${table}`);
+    });
+
+    const result = await getPersonalSettings();
+
+    expect(result).toEqual({
+      notificationPrefs: prefs,
+      locale: "ru",
+      preferredCurrency: "RUB",
+    });
+  });
+
+  it("defaults notificationPrefs to {} when the column is null", async () => {
+    const roleMaybeSingle = vi.fn().mockResolvedValue({
+      data: { role: "traveler" },
+    });
+    const prefsMaybeSingle = vi.fn().mockResolvedValue({
+      data: { notification_prefs: null },
+    });
+
+    mockFrom.mockImplementation((table: string) => {
+      if (table === "profiles") {
+        return {
+          select: vi.fn((cols: string) => ({
+            eq: vi.fn().mockReturnValue({
+              maybeSingle:
+                cols === "role" ? roleMaybeSingle : prefsMaybeSingle,
+            }),
+          })),
+        };
+      }
+      throw new Error(`unexpected table ${table}`);
+    });
+
+    const result = await getPersonalSettings();
+
+    expect(result?.notificationPrefs).toEqual({});
+  });
+
+  it("loads guide settings from guide_profiles", async () => {
+    const prefs = { "guide.new_request.telegram": true };
+    const roleMaybeSingle = vi.fn().mockResolvedValue({
+      data: { role: "guide" },
+    });
+    const guideMaybeSingle = vi.fn().mockResolvedValue({
+      data: {
+        notification_prefs: prefs,
+        locale: "en",
+        preferred_currency: "USD",
+      },
+    });
+
+    mockFrom.mockImplementation((table: string) => {
+      if (table === "profiles") {
+        return {
+          select: vi.fn().mockReturnValue({
+            eq: vi.fn().mockReturnValue({ maybeSingle: roleMaybeSingle }),
+          }),
+        };
+      }
+      return {
+        select: vi.fn().mockReturnValue({
+          eq: vi.fn().mockReturnValue({ maybeSingle: guideMaybeSingle }),
+        }),
+      };
+    });
+
+    const result = await getPersonalSettings();
+
+    expect(result).toEqual({
+      notificationPrefs: prefs,
+      locale: "en",
+      preferredCurrency: "USD",
+    });
+  });
+});

--- a/src/features/profile/actions/getPersonalSettings.ts
+++ b/src/features/profile/actions/getPersonalSettings.ts
@@ -1,0 +1,52 @@
+"use server";
+
+import { createSupabaseServerClient } from "@/lib/supabase/server";
+
+export async function getPersonalSettings(): Promise<{
+  notificationPrefs: Record<string, unknown>;
+  locale: string;
+  preferredCurrency: string;
+} | null> {
+  const supabase = await createSupabaseServerClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+  if (!user) return null;
+
+  const { data: profile } = await supabase
+    .from("profiles")
+    .select("role")
+    .eq("id", user.id)
+    .maybeSingle();
+
+  if (profile?.role === "traveler") {
+    const { data: travelerProfile } = await supabase
+      .from("profiles")
+      .select("notification_prefs")
+      .eq("id", user.id)
+      .maybeSingle();
+
+    return {
+      notificationPrefs:
+        (travelerProfile?.notification_prefs as Record<string, unknown> | null) ??
+        {},
+      locale: "ru",
+      preferredCurrency: "RUB",
+    };
+  }
+
+  const { data: guideProfile } = await supabase
+    .from("guide_profiles")
+    .select("notification_prefs, locale, preferred_currency")
+    .eq("user_id", user.id)
+    .maybeSingle();
+
+  if (!guideProfile) return null;
+
+  return {
+    notificationPrefs:
+      (guideProfile.notification_prefs as Record<string, unknown> | null) ?? {},
+    locale: guideProfile.locale ?? "ru",
+    preferredCurrency: guideProfile.preferred_currency ?? "RUB",
+  };
+}

--- a/src/features/profile/components/NotificationPrefsMatrix.tsx
+++ b/src/features/profile/components/NotificationPrefsMatrix.tsx
@@ -113,15 +113,21 @@ export function NotificationPrefsMatrix({
                           checked={Boolean(telegramVal)}
                           onCheckedChange={(next) => onChange({ ...prefs, [telegramKey]: next })}
                           className={cn(
-                            "peer inline-flex h-[1.15rem] w-8 shrink-0 cursor-pointer items-center rounded-full border border-transparent shadow-xs outline-none transition-all focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50 disabled:cursor-not-allowed disabled:opacity-50 data-[state=checked]:bg-primary data-[state=unchecked]:bg-input",
+                            "group inline-flex min-h-[44px] min-w-[44px] cursor-pointer items-center justify-center rounded-md outline-none transition-all focus-visible:ring-[3px] focus-visible:ring-ring/50 disabled:cursor-not-allowed disabled:opacity-50",
                           )}
                           aria-label={`${event.label} — Telegram`}
                         >
-                          <SwitchPrimitive.Thumb
+                          <span
                             className={cn(
-                              "pointer-events-none block size-4 rounded-full bg-background ring-0 transition-transform data-[state=checked]:translate-x-[calc(100%-2px)] data-[state=unchecked]:translate-x-0",
+                              "inline-flex h-[1.15rem] w-8 shrink-0 items-center rounded-full border border-transparent shadow-xs transition-all group-data-[state=checked]:bg-primary group-data-[state=unchecked]:bg-input",
                             )}
-                          />
+                          >
+                            <SwitchPrimitive.Thumb
+                              className={cn(
+                                "pointer-events-none block size-4 rounded-full bg-background ring-0 transition-transform data-[state=checked]:translate-x-[calc(100%-2px)] data-[state=unchecked]:translate-x-0",
+                              )}
+                            />
+                          </span>
                         </SwitchPrimitive.Root>
                       </div>
                     ) : (
@@ -143,15 +149,21 @@ export function NotificationPrefsMatrix({
                         checked={Boolean(emailVal)}
                         onCheckedChange={(next) => onChange({ ...prefs, [emailKey]: next })}
                         className={cn(
-                          "peer inline-flex h-[1.15rem] w-8 shrink-0 cursor-pointer items-center rounded-full border border-transparent shadow-xs outline-none transition-all focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50 disabled:cursor-not-allowed disabled:opacity-50 data-[state=checked]:bg-primary data-[state=unchecked]:bg-input",
+                          "group inline-flex min-h-[44px] min-w-[44px] cursor-pointer items-center justify-center rounded-md outline-none transition-all focus-visible:ring-[3px] focus-visible:ring-ring/50 disabled:cursor-not-allowed disabled:opacity-50",
                         )}
                         aria-label={`${event.label} — Email`}
                       >
-                        <SwitchPrimitive.Thumb
+                        <span
                           className={cn(
-                            "pointer-events-none block size-4 rounded-full bg-background ring-0 transition-transform data-[state=checked]:translate-x-[calc(100%-2px)] data-[state=unchecked]:translate-x-0",
+                            "inline-flex h-[1.15rem] w-8 shrink-0 items-center rounded-full border border-transparent shadow-xs transition-all group-data-[state=checked]:bg-primary group-data-[state=unchecked]:bg-input",
                           )}
-                        />
+                        >
+                          <SwitchPrimitive.Thumb
+                            className={cn(
+                              "pointer-events-none block size-4 rounded-full bg-background ring-0 transition-transform data-[state=checked]:translate-x-[calc(100%-2px)] data-[state=unchecked]:translate-x-0",
+                            )}
+                          />
+                        </span>
                       </SwitchPrimitive.Root>
                     </div>
                   </td>


### PR DESCRIPTION
Notifications page loaded prefs as {} (never the user's saved settings) and swallowed save failures. Added getPersonalSettings loader + load-on-mount, error surfacing, and 44px touch targets. Gates green; Sonnet PASS.