### PR TITLE
feat(guide): real guide stats (bookings/reviews/listings)

### DIFF
--- a/src/app/(protected)/guide/stats/page.tsx
+++ b/src/app/(protected)/guide/stats/page.tsx
@@ -1,14 +1,116 @@
 import type { Metadata } from "next";
+import { redirect } from "next/navigation";
+
+import { Badge } from "@/components/ui/badge";
+import { Card, CardContent } from "@/components/ui/card";
+import { createSupabaseServerClient } from "@/lib/supabase/server";
 
 export const metadata: Metadata = {
   title: "Статистика",
 };
 
-export default function GuideStatsPage() {
+type Stat = {
+  label: string;
+  value: string;
+  helper: string;
+};
+
+export default async function GuideStatsPage() {
+  let stats: Stat[] | null = null;
+
+  try {
+    const supabase = await createSupabaseServerClient();
+    const {
+      data: { user },
+    } = await supabase.auth.getUser();
+
+    if (!user) {
+      redirect("/auth?next=/guide/stats");
+    }
+
+    const guideId = user.id;
+
+    const [completedBookings, publishedReviews, activeListings] = await Promise.all([
+      supabase
+        .from("bookings")
+        .select("id", { count: "exact", head: true })
+        .eq("guide_id", guideId)
+        .eq("status", "completed"),
+      supabase
+        .from("reviews")
+        .select("rating")
+        .eq("guide_id", guideId)
+        .eq("status", "published"),
+      supabase
+        .from("listings")
+        .select("id", { count: "exact", head: true })
+        .eq("guide_id", guideId)
+        .eq("status", "published"),
+    ]);
+
+    const ratings = (publishedReviews.data ?? []).map((r) => r.rating);
+    const reviewCount = ratings.length;
+    const averageRating =
+      reviewCount > 0
+        ? (ratings.reduce((sum, value) => sum + value, 0) / reviewCount).toFixed(1)
+        : "—";
+
+    stats = [
+      {
+        label: "Завершённые экскурсии",
+        value: String(completedBookings.count ?? 0),
+        helper: "Проведённые брони",
+      },
+      {
+        label: "Средняя оценка",
+        value: averageRating,
+        helper: "По опубликованным отзывам",
+      },
+      {
+        label: "Отзывов",
+        value: String(reviewCount),
+        helper: "Опубликованных",
+      },
+      {
+        label: "Активных экскурсий",
+        value: String(activeListings.count ?? 0),
+        helper: "Опубликованные объявления",
+      },
+    ];
+  } catch {
+    return (
+      <div className="space-y-4">
+        <Badge variant="outline">Кабинет гида</Badge>
+        <h1 className="text-3xl font-semibold tracking-tight text-foreground">Статистика</h1>
+        <p className="text-sm text-muted-foreground">
+          Раздел временно недоступен. Напишите в поддержку.
+        </p>
+      </div>
+    );
+  }
+
   return (
-    <div className="p-6">
-      <h1 className="text-2xl font-semibold">Статистика</h1>
-      <p className="mt-2 text-muted-foreground">Скоро здесь будут ваши показатели.</p>
+    <div className="space-y-6">
+      <div className="space-y-2">
+        <Badge variant="outline">Кабинет гида</Badge>
+        <h1 className="text-3xl font-semibold tracking-tight text-foreground">Статистика</h1>
+        <p className="text-sm text-muted-foreground">
+          Ключевые показатели по вашим экскурсиям, бронированиям и отзывам.
+        </p>
+      </div>
+      <div className="grid grid-cols-2 gap-4 lg:grid-cols-4">
+        {stats.map((stat) => (
+          <Card key={stat.label} size="sm">
+            <CardContent className="space-y-1">
+              <p className="text-xs text-muted-foreground">{stat.label}</p>
+              <p className="text-3xl font-semibold tracking-tight text-foreground">
+                {stat.value}
+              </p>
+              <p className="text-xs text-muted-foreground">{stat.helper}</p>
+            </CardContent>
+          </Card>
+        ))}
+      </div>
     </div>
   );
 }


### PR DESCRIPTION
Replaced the /guide/stats 'coming soon' placeholder with real read-only metrics for the authed guide: completed bookings, avg rating (— at 0 reviews), review count, active listings. No DB change. Gates green; Sonnet PASS.