### PR TITLE
fix(admin): replace undefined booking-badge classes with Badge

### DIFF
--- a/src/app/(protected)/admin/guides/[id]/page.tsx
+++ b/src/app/(protected)/admin/guides/[id]/page.tsx
@@ -28,16 +28,18 @@ function formatDateTime(value: string) {
   });
 }
 
-function verificationBadgeClass(status: string) {
+function verificationBadgeVariant(
+  status: string,
+): "default" | "secondary" | "destructive" | "outline" {
   switch (status) {
     case "approved":
-      return "booking-badge booking-badge--completed";
+      return "default";
     case "rejected":
-      return "booking-badge booking-badge--cancelled";
+      return "destructive";
     case "submitted":
-      return "booking-badge booking-badge--pending";
+      return "secondary";
     default:
-      return "booking-badge booking-badge--pending";
+      return "outline";
   }
 }
 
@@ -124,9 +126,9 @@ export default async function AdminGuideDetailPage({
               <span>{detail.account?.email ?? "Email не указан"}</span>
               <span>{detail.profile.regions.join(", ") || "Регионы не указаны"}</span>
               <span>{detail.profile.languages.join(", ") || "Языки не указаны"}</span>
-              <span className={verificationBadgeClass(detail.profile.verification_status)}>
+              <Badge variant={verificationBadgeVariant(detail.profile.verification_status)}>
                 {verificationLabel(detail.profile.verification_status)}
-              </span>
+              </Badge>
             </div>
           </div>
         </div>

--- a/src/app/(protected)/admin/guides/page.tsx
+++ b/src/app/(protected)/admin/guides/page.tsx
@@ -2,6 +2,7 @@ import type { Metadata } from "next";
 import Link from "next/link";
 import { revalidatePath } from "next/cache";
 
+import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import {
   ensureOpenModerationCase,
@@ -29,16 +30,18 @@ function formatDateTime(value: string) {
   });
 }
 
-function verificationBadgeClass(status: string) {
+function verificationBadgeVariant(
+  status: string,
+): "default" | "secondary" | "destructive" | "outline" {
   switch (status) {
     case "approved":
-      return "booking-badge booking-badge--completed";
+      return "default";
     case "rejected":
-      return "booking-badge booking-badge--cancelled";
+      return "destructive";
     case "submitted":
-      return "booking-badge booking-badge--pending";
+      return "secondary";
     default:
-      return "booking-badge booking-badge--pending";
+      return "outline";
   }
 }
 
@@ -192,13 +195,13 @@ export default async function AdminGuidesPage({
                       {item.profile.regions.join(", ") || "—"}
                     </td>
                     <td className="px-4 py-4">
-                      <span
-                        className={verificationBadgeClass(
+                      <Badge
+                        variant={verificationBadgeVariant(
                           item.profile.verification_status,
                         )}
                       >
                         {verificationLabel(item.profile.verification_status)}
-                      </span>
+                      </Badge>
                     </td>
                     <td className="px-4 py-4 text-muted-foreground">
                       {formatDateTime(item.profile.updated_at)}

--- a/src/app/(protected)/admin/listings/page.tsx
+++ b/src/app/(protected)/admin/listings/page.tsx
@@ -2,6 +2,7 @@ import type { Metadata } from "next";
 import Link from "next/link";
 import { revalidatePath } from "next/cache";
 
+import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import {
   ensureOpenModerationCase,
@@ -36,17 +37,19 @@ function formatPrice(value: number, currency: string) {
   }).format(value / 100);
 }
 
-function statusBadgeClass(status: string) {
+function statusBadgeVariant(
+  status: string,
+): "default" | "secondary" | "destructive" | "outline" {
   switch (status) {
     case "published":
-      return "booking-badge booking-badge--confirmed";
+      return "default";
     case "rejected":
-      return "booking-badge booking-badge--cancelled";
+      return "destructive";
     case "open":
     case "pending_review":
-      return "booking-badge booking-badge--pending";
+      return "secondary";
     default:
-      return "booking-badge booking-badge--pending";
+      return "outline";
   }
 }
 
@@ -165,9 +168,9 @@ export default async function AdminListingsPage() {
                       {formatPrice(row.listing.price_from_minor, row.listing.currency)}
                     </td>
                     <td className="px-4 py-4">
-                      <span className={statusBadgeClass(displayStatus)}>
+                      <Badge variant={statusBadgeVariant(displayStatus)}>
                         {listingStatusLabel(displayStatus)}
-                      </span>
+                      </Badge>
                     </td>
                     <td className="px-4 py-4 text-muted-foreground">
                       {formatDateTime(row.listing.created_at)}


### PR DESCRIPTION
Admin status pills used undefined booking-badge* classes (no styling). Now use shadcn <Badge variant> with semantic mapping (approved→default, rejected→destructive, pending→secondary). 3 files. Gates green; Sonnet PASS.