### PR TITLE
feat(ui): PageHeader + loading skeleton primitives

### DIFF
--- a/src/components/shared/loading-skeletons.tsx
+++ b/src/components/shared/loading-skeletons.tsx
@@ -1,0 +1,44 @@
+import { Skeleton } from "@/components/ui/skeleton";
+import { cn } from "@/lib/utils";
+
+/** Grid of card skeletons for catalog/list loading. */
+export function CardGridSkeleton({ count = 6, className }: { count?: number; className?: string }) {
+  return (
+    <div className={cn("grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3", className)}>
+      {Array.from({ length: count }).map((_, i) => (
+        <div key={i} className="overflow-hidden rounded-[16px] border border-border">
+          <Skeleton className="h-44 w-full" />
+          <div className="flex flex-col gap-2 p-4">
+            <Skeleton className="h-4 w-3/4" />
+            <Skeleton className="h-3 w-1/2" />
+          </div>
+        </div>
+      ))}
+    </div>
+  );
+}
+
+/** Detail-page skeleton (hero + body rows). */
+export function DetailSkeleton({ className }: { className?: string }) {
+  return (
+    <div className={cn("flex flex-col gap-5", className)}>
+      <Skeleton className="h-64 w-full rounded-[16px]" />
+      <Skeleton className="h-7 w-1/2" />
+      <Skeleton className="h-4 w-full" />
+      <Skeleton className="h-4 w-5/6" />
+    </div>
+  );
+}
+
+/** Single list-row skeleton. */
+export function ListRowSkeleton({ className }: { className?: string }) {
+  return (
+    <div className={cn("flex items-center gap-3 rounded-[12px] border border-border p-4", className)}>
+      <Skeleton className="size-12 shrink-0 rounded-full" />
+      <div className="flex flex-1 flex-col gap-2">
+        <Skeleton className="h-4 w-1/3" />
+        <Skeleton className="h-3 w-1/2" />
+      </div>
+    </div>
+  );
+}

--- a/src/components/shared/page-header.test.tsx
+++ b/src/components/shared/page-header.test.tsx
@@ -1,0 +1,34 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import { PageHeader } from "./page-header";
+
+describe("PageHeader", () => {
+  it("renders the title", () => {
+    render(<PageHeader title="Мои заявки" />);
+
+    expect(screen.getByRole("heading", { name: "Мои заявки" })).toBeInTheDocument();
+  });
+
+  it("renders eyebrow, subtitle and actions when provided", () => {
+    render(
+      <PageHeader
+        eyebrow="Кабинет"
+        title="Мои заявки"
+        subtitle="Здесь собраны ваши запросы."
+        actions={<button type="button">Создать</button>}
+      />,
+    );
+
+    expect(screen.getByText("Кабинет")).toBeInTheDocument();
+    expect(screen.getByText("Здесь собраны ваши запросы.")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Создать" })).toBeInTheDocument();
+  });
+
+  it("omits eyebrow, subtitle and actions when not provided", () => {
+    render(<PageHeader title="Мои заявки" />);
+
+    expect(screen.queryByText("Кабинет")).not.toBeInTheDocument();
+    expect(screen.queryByRole("button")).not.toBeInTheDocument();
+  });
+});

--- a/src/components/shared/page-header.tsx
+++ b/src/components/shared/page-header.tsx
@@ -1,0 +1,28 @@
+import type { ReactNode } from "react";
+import { cn } from "@/lib/utils";
+
+type PageHeaderProps = {
+  eyebrow?: string;
+  title: string;
+  subtitle?: string;
+  actions?: ReactNode;
+  className?: string;
+};
+
+/** Canonical page title block (Onest). Use on non-hero list/cabinet pages. */
+export function PageHeader({ eyebrow, title, subtitle, actions, className }: PageHeaderProps) {
+  return (
+    <div className={cn("flex flex-wrap items-end justify-between gap-4", className)}>
+      <div className="min-w-0">
+        {eyebrow ? (
+          <div className="mb-2 text-[11.5px] font-semibold uppercase tracking-[0.14em] text-primary">{eyebrow}</div>
+        ) : null}
+        <h1 className="text-[30px] font-bold leading-[1.1] tracking-[-0.03em] text-on-surface">{title}</h1>
+        {subtitle ? (
+          <p className="mt-2 max-w-[60ch] text-[15px] leading-[1.5] text-on-surface-muted">{subtitle}</p>
+        ) : null}
+      </div>
+      {actions ? <div className="flex shrink-0 items-center gap-2">{actions}</div> : null}
+    </div>
+  );
+}


### PR DESCRIPTION
Two reusable primitives for the spine rollout: PageHeader (canonical title block) + loading skeletons (CardGrid/Detail/ListRow). Additive, not yet wired. Gates green; Sonnet PASS.