### PR TITLE
feat(search): ListHero + canon filter styling

### DIFF
--- a/src/app/(site)/search/page.tsx
+++ b/src/app/(site)/search/page.tsx
@@ -2,6 +2,7 @@ import type { Metadata } from "next";
 import Link from "next/link";
 import { Suspense } from "react";
 
+import { ListHero } from "@/components/shared/list-hero";
 import { FilterBar } from "@/components/traveler/FilterBar";
 import { ListingGrid } from "@/components/traveler/ListingGrid";
 import { Button } from "@/components/ui/button";
@@ -74,11 +75,13 @@ export default async function SearchPage({
     sp.q && sp.region ? `«${sp.q}» в ${sp.region}` : "Все предложения";
 
   return (
-    <section className="pb-20 pt-10">
-      <div className="mx-auto w-full max-w-page px-[clamp(20px,4vw,48px)]">
-        <h1 className="mb-8 font-serif text-3xl font-semibold tracking-tight text-foreground md:text-4xl">
-          {title}
-        </h1>
+    <section className="pb-20">
+      <ListHero
+        imageUrl="/hero-valley.jpg"
+        title={title}
+        intro="Фильтруйте по типу, формату и цене — или опубликуйте запрос, если не нашли."
+      />
+      <div className="mx-auto w-full max-w-page px-[clamp(20px,4vw,48px)] pt-10">
         <Suspense fallback={<Skeleton className="mb-8 h-28 w-full rounded-xl" />}>
           <FilterBar
             currentType={sp.type}

--- a/src/components/traveler/FilterBar.tsx
+++ b/src/components/traveler/FilterBar.tsx
@@ -3,7 +3,6 @@
 import { useCallback, useMemo } from "react";
 import { usePathname, useRouter, useSearchParams } from "next/navigation";
 
-import { Badge } from "@/components/ui/badge";
 import {
   Select,
   SelectContent,
@@ -11,6 +10,19 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@/components/ui/select";
+import { cn } from "@/lib/utils";
+
+const PILL_BASE =
+  "shrink-0 rounded-full px-3.5 py-1.5 text-sm font-medium transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring";
+
+function pillClass(selected: boolean): string {
+  return cn(
+    PILL_BASE,
+    selected
+      ? "bg-primary text-primary-foreground"
+      : "bg-surface-low text-on-surface-muted hover:bg-surface-low/80",
+  );
+}
 
 const TYPE_OPTIONS: { value: string; label: string }[] = [
   { value: "excursion", label: "Экскурсия" },
@@ -84,9 +96,9 @@ export function FilterBar({ currentType, currentFormat, currentSort }: FilterBar
           <button
             type="button"
             onClick={() => navigateWithPatch({ type: undefined })}
-            className="shrink-0 rounded-full focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+            className={pillClass(!currentType)}
           >
-            <Badge variant={!currentType ? "default" : "outline"}>Все</Badge>
+            Все
           </button>
           {TYPE_OPTIONS.map((opt) => {
             const selected = currentType === opt.value;
@@ -95,9 +107,9 @@ export function FilterBar({ currentType, currentFormat, currentSort }: FilterBar
                 key={opt.value}
                 type="button"
                 onClick={() => navigateWithPatch({ type: opt.value })}
-                className="shrink-0 rounded-full focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+                className={pillClass(selected)}
               >
-                <Badge variant={selected ? "default" : "outline"}>{opt.label}</Badge>
+                {opt.label}
               </button>
             );
           })}
@@ -119,9 +131,9 @@ export function FilterBar({ currentType, currentFormat, currentSort }: FilterBar
                 key={opt.value || "any"}
                 type="button"
                 onClick={() => navigateWithPatch({ format: opt.value || undefined })}
-                className="shrink-0 rounded-full focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+                className={pillClass(selected)}
               >
-                <Badge variant={selected ? "default" : "outline"}>{opt.label}</Badge>
+                {opt.label}
               </button>
             );
           })}


### PR DESCRIPTION
Search page gets a ListHero (dynamic title) and token-aligned FilterBar, matching /listings. Functional fixes (slugs/rating/lead-CTA) shipped earlier. 2 files. Gates green; Sonnet PASS.