### PR TITLE
feat(listings): rating next to booking CTA on listing detail

### DIFF
--- a/src/components/listing-detail/ExcursionShapeDetail.tsx
+++ b/src/components/listing-detail/ExcursionShapeDetail.tsx
@@ -86,11 +86,13 @@ export function ExcursionShapeDetail({ listing, photos, schedule, tariffs, guide
           <p className="text-3xl font-semibold">
             {formatExcursionPriceFrom(listing.price_from_minor, listing.format)}
           </p>
-          <RatingDisplay
-            rating={listing.average_rating}
-            reviewCount={listing.review_count}
-            className="mt-1"
-          />
+          {listing.review_count && listing.review_count > 0 ? (
+            <RatingDisplay
+              rating={listing.average_rating}
+              reviewCount={listing.review_count}
+              className="mt-1"
+            />
+          ) : null}
         </div>
         <ul className="space-y-1 text-sm text-muted-foreground">
           {durationLabel ? <li>Длительность: {durationLabel}</li> : null}

--- a/src/components/listing-detail/ExcursionShapeDetail.tsx
+++ b/src/components/listing-detail/ExcursionShapeDetail.tsx
@@ -5,6 +5,7 @@ import { GuideCard } from "@/components/listing-detail/GuideCard";
 import { PhotoGallery } from "@/components/listing-detail/PhotoGallery";
 import { ScheduleDisplay } from "@/components/listing-detail/ScheduleDisplay";
 import { TariffsList } from "@/components/listing-detail/TariffsList";
+import { RatingDisplay } from "@/components/shared/rating-display";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent } from "@/components/ui/card";
@@ -85,6 +86,11 @@ export function ExcursionShapeDetail({ listing, photos, schedule, tariffs, guide
           <p className="text-3xl font-semibold">
             {formatExcursionPriceFrom(listing.price_from_minor, listing.format)}
           </p>
+          <RatingDisplay
+            rating={listing.average_rating}
+            reviewCount={listing.review_count}
+            className="mt-1"
+          />
         </div>
         <ul className="space-y-1 text-sm text-muted-foreground">
           {durationLabel ? <li>Длительность: {durationLabel}</li> : null}

--- a/src/components/listing-detail/TourShapeDetail.tsx
+++ b/src/components/listing-detail/TourShapeDetail.tsx
@@ -92,11 +92,13 @@ export function TourShapeDetail({
       <div>
         <p className="text-3xl font-semibold">от {formatRubMinor(listing.price_from_minor)} ₽</p>
         <p className="text-sm text-muted-foreground">на человека</p>
-        <RatingDisplay
-          rating={listing.average_rating}
-          reviewCount={listing.review_count}
-          className="mt-1"
-        />
+        {listing.review_count && listing.review_count > 0 ? (
+          <RatingDisplay
+            rating={listing.average_rating}
+            reviewCount={listing.review_count}
+            className="mt-1"
+          />
+        ) : null}
       </div>
       <Button asChild className="w-full">
         <Link href={`/listings/${listing.id}/book`}>Заказать тур</Link>

--- a/src/components/listing-detail/TourShapeDetail.tsx
+++ b/src/components/listing-detail/TourShapeDetail.tsx
@@ -6,6 +6,7 @@ import { PhotoGallery } from "@/components/listing-detail/PhotoGallery";
 import { TariffsList } from "@/components/listing-detail/TariffsList";
 import { TourDeparturesList } from "@/components/listing-detail/TourDeparturesList";
 import { TourItineraryDisplay } from "@/components/listing-detail/TourItineraryDisplay";
+import { RatingDisplay } from "@/components/shared/rating-display";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Separator } from "@/components/ui/separator";
@@ -91,6 +92,11 @@ export function TourShapeDetail({
       <div>
         <p className="text-3xl font-semibold">от {formatRubMinor(listing.price_from_minor)} ₽</p>
         <p className="text-sm text-muted-foreground">на человека</p>
+        <RatingDisplay
+          rating={listing.average_rating}
+          reviewCount={listing.review_count}
+          className="mt-1"
+        />
       </div>
       <Button asChild className="w-full">
         <Link href={`/listings/${listing.id}/book`}>Заказать тур</Link>


### PR DESCRIPTION
Adds the listing rating next to the booking CTA (R-4 conversion), guarded to >0 reviews (no 'Новый гид' on listings). Page was already canon-compliant (sticky rail, mobile bar, CTA hierarchy, doubt-removers). 2 files. Gates green; Sonnet PASS.