### PR TITLE
fix(spine): destinations cards height @375px + listing-card route arrows

### DIFF
--- a/src/components/shared/listing-card.tsx
+++ b/src/components/shared/listing-card.tsx
@@ -2,6 +2,7 @@ import Image from "next/image";
 import Link from "next/link";
 
 import type { ListingRecord } from "@/data/supabase/queries";
+import { arrowizeRoute } from "@/lib/utils";
 
 function getFormatLabel(format: string): string {
   if (format === "private") return "Индивидуальный";
@@ -55,7 +56,7 @@ export function ListingCard({ listing, priority }: ListingCardProps) {
 
         {/* Description */}
         <p className="max-w-sm text-sm leading-[1.55] text-primary-foreground/80 line-clamp-2">
-          {listing.description}
+          {arrowizeRoute(listing.description)}
         </p>
 
         {/* Bottom row */}

--- a/src/features/destinations/components/destinations-grid.tsx
+++ b/src/features/destinations/components/destinations-grid.tsx
@@ -72,7 +72,7 @@ export function DestinationsGrid({
           {featured && (
             <Link
               href={`/destinations/${featured.slug}`}
-              className="relative block overflow-hidden rounded-glass bg-surface-low lg:row-span-2"
+              className="relative block min-h-[240px] overflow-hidden rounded-glass bg-surface-low lg:row-span-2"
             >
               <Image
                 src={
@@ -105,7 +105,7 @@ export function DestinationsGrid({
             <Link
               key={dest.slug}
               href={`/destinations/${dest.slug}`}
-              className="relative block overflow-hidden rounded-glass bg-surface-low"
+              className="relative block min-h-[240px] overflow-hidden rounded-glass bg-surface-low"
             >
               <Image
                 src={


### PR DESCRIPTION
E-final sweep fixes: destination cards had 0 height at mobile (relied on lg:grid-rows) → added min-h-[240px]; listing-card description now renders → via arrowizeRoute. Gates green.