### PR TITLE
feat(nav): canonical navigation source of truth + global header/drawer

### DIFF
--- a/src/components/shared/site-header.test.tsx
+++ b/src/components/shared/site-header.test.tsx
@@ -136,7 +136,7 @@ describe("SiteHeader desktop account menu", () => {
 
     await openAccountMenu();
 
-    expect(await screen.findByText("Мой профиль")).toBeInTheDocument();
+    expect(await screen.findByText("Профиль")).toBeInTheDocument();
     expect(screen.getByText("Помощь")).toBeInTheDocument();
     expect(screen.getByText("Выйти")).toBeInTheDocument();
   });
@@ -161,12 +161,12 @@ describe("SiteHeader desktop account menu", () => {
     requestSubmit.mockRestore();
   });
 
-  it("hides «Настройки» in the desktop header dropdown for both travellers and guides (settings merged into profile)", async () => {
+  it("shows «Настройки» for guides but not travellers in the desktop header dropdown", async () => {
     const { unmount } = renderAuthenticatedHeader("traveler");
 
     await openAccountMenu();
 
-    expect(await screen.findByText("Мой профиль")).toBeInTheDocument();
+    expect(await screen.findByText("Профиль")).toBeInTheDocument();
     expect(screen.queryByText("Настройки")).not.toBeInTheDocument();
 
     unmount();
@@ -174,27 +174,27 @@ describe("SiteHeader desktop account menu", () => {
 
     await openAccountMenu();
 
-    expect(await screen.findByText("Мой профиль")).toBeInTheDocument();
-    expect(screen.queryByText("Настройки")).not.toBeInTheDocument();
+    expect(await screen.findByText("Профиль")).toBeInTheDocument();
+    expect(screen.getByText("Настройки")).toBeInTheDocument();
   });
 
-  it("«Мой профиль» for traveler links to /account", async () => {
+  it("«Профиль» for traveler links to /account", async () => {
     renderAuthenticatedHeader("traveler");
 
     await openAccountMenu();
 
-    expect(await screen.findByRole("menuitem", { name: "Мой профиль" })).toHaveAttribute(
+    expect(await screen.findByRole("menuitem", { name: "Профиль" })).toHaveAttribute(
       "href",
       "/account",
     );
   });
 
-  it("«Мой профиль» for guide links to /guide/profile", async () => {
+  it("«Профиль» for guide links to /guide/profile", async () => {
     renderAuthenticatedHeader("guide");
 
     await openAccountMenu();
 
-    expect(await screen.findByRole("menuitem", { name: "Мой профиль" })).toHaveAttribute(
+    expect(await screen.findByRole("menuitem", { name: "Профиль" })).toHaveAttribute(
       "href",
       "/guide/profile",
     );

--- a/src/components/shared/site-header.tsx
+++ b/src/components/shared/site-header.tsx
@@ -31,32 +31,17 @@ import { COPY } from "@/lib/copy";
 import { resolveDisplayName } from "@/lib/profile/resolve-display-name";
 import { cn } from "@/lib/utils";
 import { UserAccountDrawer } from "@/components/shared/user-account-drawer";
+import { accountMenu, headerPrimary, isNavActive, type NavItem } from "@/lib/navigation";
 
-const navLinks = [
-  { href: "/requests", label: "Запросы" },
-  { href: "/destinations", label: "Направления" },
-  { href: "/guides", label: "Гиды" },
-] as const;
-
-const travelerNavLinks = [
-  { href: "/trips", label: "Мои запросы" },
-  { href: "/requests", label: "Открытые группы" },
-  { href: "/listings", label: "Готовые экскурсии" },
-  { href: "/destinations", label: "Направления" },
-] as const;
-
-const guideNavLinks = [
-  { href: "/guide", label: "Запросы" },
-  { href: "/guide/listings", label: "Мои экскурсии" },
-] as const;
-
-const publicNavLinks = [
-  { href: "/requests", label: "Открытые группы" },
-  { href: "/listings", label: "Готовые экскурсии" },
-  { href: "/guides", label: "Гиды" },
-  { href: "/how-it-works", label: "Как это работает" },
-] as const;
-
+function resolveActiveHref(pathname: string, items: readonly NavItem[]): string | null {
+  let best: string | null = null;
+  for (const item of items) {
+    if (isNavActive(pathname, item) && (best === null || item.href.length > best.length)) {
+      best = item.href;
+    }
+  }
+  return best;
+}
 
 const roleLabels: Record<AppRole, string> = {
   traveler: "Путешественник",
@@ -91,12 +76,31 @@ export function SiteHeader({
   const [drawerOpen, setDrawerOpen] = React.useState(false);
   const logoutFormRef = React.useRef<HTMLFormElement>(null);
 
-  const profileHref = role === "guide" ? "/guide/profile" : "/account";
   const primaryCtaHref = role === "guide" ? "/requests" : "/";
   const primaryCtaLabel = role === "guide" ? "Смотреть запросы" : "Создать запрос";
   const accountLabel = fullName?.trim().split(/\s+/)[0] || (role ? roleLabels[role] : "Аккаунт");
   const messagesLabel =
     unreadCount > 0 ? `Сообщения, непрочитанных: ${unreadCount}` : "Сообщения";
+
+  const primaryItems: readonly NavItem[] = !isAuthenticated
+    ? headerPrimary.anon
+    : role === "guide"
+      ? headerPrimary.guide
+      : role === "admin"
+        ? headerPrimary.admin
+        : role === "traveler"
+          ? headerPrimary.traveler
+          : headerPrimary.anon;
+  const activeHref = resolveActiveHref(pathname, primaryItems);
+
+  const accountItems: readonly NavItem[] =
+    role === "guide"
+      ? accountMenu.guide
+      : role === "admin"
+        ? accountMenu.admin
+        : role === "traveler"
+          ? accountMenu.traveler
+          : [];
 
   return (
     <>
@@ -110,42 +114,24 @@ export function SiteHeader({
         </Link>
 
         <ul className="m-0 flex list-none items-center justify-self-center gap-8 p-0 max-md:hidden" role="list">
-          {(isAuthenticated && role === "guide"
-            ? guideNavLinks
-            : isAuthenticated && role === "traveler"
-              ? travelerNavLinks
-              : isAuthenticated
-                ? navLinks
-                : publicNavLinks).map(
-            (link) => {
-              const isHashLink = link.href.includes("#");
-              let isActive: boolean;
-              if (link.href === "/guide") {
-                isActive = pathname === "/guide" ||
-                  pathname.startsWith("/guide/inbox") ||
-                  pathname.startsWith("/guide/bookings");
-              } else if (isHashLink) {
-                isActive = pathname === "/";
-              } else {
-                isActive = pathname === link.href || pathname.startsWith(`${link.href}/`);
-              }
+          {primaryItems.map((item) => {
+            const isActive = item.href === activeHref;
 
-              return (
-                <li key={link.href}>
-                  <Link
-                    href={link.href}
-                    className={cn(
-                      "relative text-sm font-medium text-muted-foreground transition-colors hover:text-primary",
-                      isActive && "text-primary",
-                    )}
-                    aria-current={isActive ? "page" : undefined}
-                  >
-                    {link.label}
-                  </Link>
-                </li>
-              );
-            },
-          )}
+            return (
+              <li key={item.href}>
+                <Link
+                  href={item.href}
+                  className={cn(
+                    "relative text-sm font-medium text-muted-foreground transition-colors hover:text-primary",
+                    isActive && "text-primary",
+                  )}
+                  aria-current={isActive ? "page" : undefined}
+                >
+                  {item.label}
+                </Link>
+              </li>
+            );
+          })}
         </ul>
 
         <div className="flex items-center justify-self-end gap-2">
@@ -168,19 +154,11 @@ export function SiteHeader({
               <DropdownMenuContent align="end">
                 <DropdownMenuLabel>{accountLabel}</DropdownMenuLabel>
                 <DropdownMenuSeparator />
-                <DropdownMenuItem asChild>
-                  <Link href={profileHref}>Мой профиль</Link>
-                </DropdownMenuItem>
-                {role === "guide" && (
-                  <>
-                    <DropdownMenuItem asChild>
-                      <Link href="/guide/calendar">Календарь</Link>
-                    </DropdownMenuItem>
-                  </>
-                )}
-                <DropdownMenuItem asChild>
-                  <Link href="/help">Помощь</Link>
-                </DropdownMenuItem>
+                {accountItems.map((item) => (
+                  <DropdownMenuItem asChild key={item.href}>
+                    <Link href={item.href}>{item.label}</Link>
+                  </DropdownMenuItem>
+                ))}
                 <DropdownMenuItem
                   onSelect={(event) => {
                     // Radix closes (and unmounts) the menu on select, which
@@ -280,36 +258,20 @@ export function SiteHeader({
                 </SheetDescription>
               </SheetHeader>
               <nav className="flex flex-col gap-1 px-2 pb-4" aria-label="Мобильная навигация">
-                {(isAuthenticated && role === "guide"
-                ? guideNavLinks
-                : isAuthenticated && role === "traveler"
-                  ? travelerNavLinks
-                  : isAuthenticated
-                    ? navLinks
-                    : publicNavLinks).map((link) => {
-                  const isHashLink = link.href.includes("#");
-                  let isActive: boolean;
-                  if (link.href === "/guide") {
-                    isActive = pathname === "/guide" ||
-                      pathname.startsWith("/guide/inbox") ||
-                      pathname.startsWith("/guide/bookings");
-                  } else if (isHashLink) {
-                    isActive = pathname === "/";
-                  } else {
-                    isActive = pathname === link.href || pathname.startsWith(`${link.href}/`);
-                  }
+                {primaryItems.map((item) => {
+                  const isActive = item.href === activeHref;
 
                   return (
-                    <SheetClose asChild key={link.href}>
+                    <SheetClose asChild key={item.href}>
                       <Link
-                        href={link.href}
+                        href={item.href}
                         className={cn(
                           "w-full rounded-md px-3 py-3 text-base font-medium text-muted-foreground transition-colors hover:bg-surface-high hover:text-primary",
                           isActive && "bg-surface-high text-primary",
                         )}
                         aria-current={isActive ? "page" : undefined}
                       >
-                        {link.label}
+                        {item.label}
                       </Link>
                     </SheetClose>
                   );

--- a/src/components/shared/user-account-drawer.test.tsx
+++ b/src/components/shared/user-account-drawer.test.tsx
@@ -19,7 +19,7 @@ describe("UserAccountDrawer", () => {
     ).toBeInTheDocument();
   });
 
-  it("hides «Настройки» for travellers (settings merged into profile)", () => {
+  it("hides «Настройки» for travellers (guides-only setting)", () => {
     render(
       <UserAccountDrawer
         open
@@ -30,10 +30,10 @@ describe("UserAccountDrawer", () => {
     );
 
     expect(screen.queryByText("Настройки")).not.toBeInTheDocument();
-    expect(screen.getByText("Мой профиль")).toBeInTheDocument();
+    expect(screen.getByText("Профиль")).toBeInTheDocument();
   });
 
-  it("hides «Настройки» for guides too (settings merged into profile)", () => {
+  it("shows «Настройки» for guides", () => {
     render(
       <UserAccountDrawer
         open
@@ -43,8 +43,8 @@ describe("UserAccountDrawer", () => {
       />,
     );
 
-    expect(screen.queryByText("Настройки")).not.toBeInTheDocument();
-    expect(screen.getByText("Мой профиль")).toBeInTheDocument();
+    expect(screen.getByText("Настройки")).toBeInTheDocument();
+    expect(screen.getByText("Профиль")).toBeInTheDocument();
   });
 
   it("links guides to the traveler experience", () => {

--- a/src/components/shared/user-account-drawer.tsx
+++ b/src/components/shared/user-account-drawer.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import Link from "next/link";
-import { ArrowLeftRight, Calendar, HelpCircle, LogOut, Map, User } from "lucide-react";
+import { ArrowLeftRight, LogOut } from "lucide-react";
 
 import {
   Sheet,
@@ -12,6 +12,7 @@ import {
 } from "@/components/ui/sheet";
 import { ProfileAvatar } from "@/components/profile-avatar";
 import type { AppRole } from "@/lib/auth/types";
+import { accountMenu, type NavItem } from "@/lib/navigation";
 
 const roleLabels: Record<AppRole, string> = {
   traveler: "Путешественник",
@@ -37,7 +38,14 @@ export function UserAccountDrawer({
   role,
 }: UserAccountDrawerProps) {
   const displayName = fullName?.trim().split(/\s+/)[0] || email || "Гость";
-  const profileHref = role === "guide" ? "/guide/profile" : "/account";
+  const accountItems: readonly NavItem[] =
+    role === "guide"
+      ? accountMenu.guide
+      : role === "admin"
+        ? accountMenu.admin
+        : role === "traveler"
+          ? accountMenu.traveler
+          : [];
   const roleSwitch =
     role === "guide"
       ? { href: "/trips", label: "Переключиться на путешественника" }
@@ -78,55 +86,30 @@ export function UserAccountDrawer({
         </SheetHeader>
 
         <nav className="flex flex-col px-3 pt-3 flex-1" aria-label="Меню аккаунта">
-          <Link
-            href={profileHref}
-            onClick={closeAndNavigate}
-            className="flex min-h-[44px] items-center gap-3 rounded-lg px-3 py-2.5 text-sm font-medium text-foreground hover:bg-surface-high transition-colors"
-          >
-            <User className="size-[18px] shrink-0 text-muted-foreground" aria-hidden="true" />
-            Мой профиль
-          </Link>
+          {accountItems.map((item) => {
+            const Icon = item.icon;
+            return (
+              <Link
+                key={item.href}
+                href={item.href}
+                onClick={closeAndNavigate}
+                className="flex min-h-[44px] items-center gap-3 rounded-lg px-3 py-2.5 text-sm font-medium text-foreground hover:bg-surface-high transition-colors"
+              >
+                <Icon className="size-[18px] shrink-0 text-muted-foreground" aria-hidden="true" />
+                {item.label}
+              </Link>
+            );
+          })}
           {roleSwitch ? (
-            <>
-              <Link
-                href={roleSwitch.href}
-                onClick={closeAndNavigate}
-                className="flex min-h-[44px] items-center gap-3 rounded-lg px-3 py-2.5 text-sm font-medium text-foreground hover:bg-surface-high transition-colors"
-              >
-                <ArrowLeftRight className="size-[18px] shrink-0 text-muted-foreground" aria-hidden="true" />
-                {roleSwitch.label}
-              </Link>
-              <div className="h-px bg-border my-2" />
-            </>
+            <Link
+              href={roleSwitch.href}
+              onClick={closeAndNavigate}
+              className="flex min-h-[44px] items-center gap-3 rounded-lg px-3 py-2.5 text-sm font-medium text-foreground hover:bg-surface-high transition-colors"
+            >
+              <ArrowLeftRight className="size-[18px] shrink-0 text-muted-foreground" aria-hidden="true" />
+              {roleSwitch.label}
+            </Link>
           ) : null}
-          {role === "guide" && (
-            <>
-              <Link
-                href="/guide/listings"
-                onClick={closeAndNavigate}
-                className="flex min-h-[44px] items-center gap-3 rounded-lg px-3 py-2.5 text-sm font-medium text-foreground hover:bg-surface-high transition-colors"
-              >
-                <Map className="size-[18px] shrink-0 text-muted-foreground" aria-hidden="true" />
-                Мои экскурсии
-              </Link>
-              <Link
-                href="/guide/calendar"
-                onClick={closeAndNavigate}
-                className="flex min-h-[44px] items-center gap-3 rounded-lg px-3 py-2.5 text-sm font-medium text-foreground hover:bg-surface-high transition-colors"
-              >
-                <Calendar className="size-[18px] shrink-0 text-muted-foreground" aria-hidden="true" />
-                Календарь
-              </Link>
-            </>
-          )}
-          <Link
-            href="/help"
-            onClick={closeAndNavigate}
-            className="flex min-h-[44px] items-center gap-3 rounded-lg px-3 py-2.5 text-sm font-medium text-foreground hover:bg-surface-high transition-colors"
-          >
-            <HelpCircle className="size-[18px] shrink-0 text-muted-foreground" aria-hidden="true" />
-            Помощь и поддержка
-          </Link>
 
           <div className="h-px bg-border my-2" />
 

--- a/src/lib/navigation.ts
+++ b/src/lib/navigation.ts
@@ -1,0 +1,86 @@
+import type { LucideIcon } from "lucide-react";
+import {
+  Users, Compass, UserSearch, Map, Search, Route, BadgeCheck, ShieldCheck,
+  Briefcase, HelpCircle, LogIn, ClipboardList, Luggage, Heart, MessageSquare,
+  Bell, Gift, User, Inbox, BookCheck, Star, Calendar, Settings,
+  BarChart3, UserCheck, Flag, CalendarCheck, ScrollText,
+} from "lucide-react";
+
+export type NavItem = {
+  href: string;
+  label: string;
+  shortLabel?: string;
+  icon: LucideIcon;
+  activePrefixes?: readonly string[];
+  external?: boolean;
+};
+
+export const ROUTES = {
+  requests:     { href: "/requests",     label: "Открытые группы",   icon: Users },
+  listings:     { href: "/listings",     label: "Готовые экскурсии", icon: Compass },
+  guides:       { href: "/guides",       label: "Гиды",              icon: UserSearch },
+  destinations: { href: "/destinations", label: "Направления",       icon: Map },
+  search:       { href: "/search",       label: "Поиск",             icon: Search },
+  howItWorks:   { href: "/how-it-works", label: "Как это работает",  icon: Route },
+  becomeGuide:  { href: "/become-a-guide", label: "Стать гидом",     icon: BadgeCheck },
+  trust:        { href: "/trust",        label: "Доверие и безопасность", icon: ShieldCheck },
+  forBusiness:  { href: "/for-business", label: "Для бизнеса",       icon: Briefcase },
+  help:         { href: "/help",         label: "Помощь",            icon: HelpCircle },
+  auth:         { href: "/auth",         label: "Войти",             icon: LogIn },
+  trips:        { href: "/trips",        label: "Мои запросы",       icon: ClipboardList },
+  myBookings:   { href: "/bookings",     label: "Поездки",           icon: Luggage },
+  favorites:    { href: "/favorites",    label: "Избранное",         icon: Heart },
+  messages:     { href: "/messages",     label: "Сообщения",         icon: MessageSquare, activePrefixes: ["/messages"] },
+  notifications:{ href: "/notifications",label: "Уведомления",       icon: Bell },
+  referrals:    { href: "/referrals",    label: "Приглашения",       icon: Gift },
+  account:      { href: "/account",      label: "Профиль",           icon: User },
+  guideInbox:   { href: "/guide",          label: "Запросы",         icon: Inbox, activePrefixes: ["/guide/inbox"] },
+  guideListings:{ href: "/guide/listings", label: "Мои экскурсии", shortLabel: "Экскурсии", icon: Compass },
+  guideBookings:{ href: "/guide/bookings", label: "Заказы",          icon: BookCheck },
+  guideReviews: { href: "/guide/reviews",  label: "Отзывы",          icon: Star },
+  guideCalendar:{ href: "/guide/calendar", label: "Календарь",       icon: Calendar },
+  guideProfile: { href: "/guide/profile",  label: "Профиль",         icon: User },
+  guideSettings:{ href: "/guide/settings/contact-visibility", label: "Настройки", icon: Settings },
+  adminDashboard: { href: "/admin/dashboard",  label: "Обзор",        icon: BarChart3 },
+  adminGuides:    { href: "/admin/guides",     label: "Гиды",         icon: UserCheck },
+  adminListings:  { href: "/admin/listings",   label: "Листинги",     icon: ClipboardList },
+  adminModeration:{ href: "/admin/moderation", label: "Модерация",    icon: ShieldCheck },
+  adminDisputes:  { href: "/admin/disputes",   label: "Споры",        icon: Flag },
+  adminBookings:  { href: "/admin/bookings",   label: "Бронирования", shortLabel: "Брони", icon: CalendarCheck },
+  adminAudit:     { href: "/admin/audit",      label: "Аудит",        icon: ScrollText },
+} satisfies Record<string, NavItem>;
+
+const adminBridge: NavItem = { ...ROUTES.adminDashboard, label: "Админка" };
+
+export const headerPrimary = {
+  anon:     [ROUTES.requests, ROUTES.listings, ROUTES.guides, ROUTES.destinations, ROUTES.howItWorks],
+  traveler: [ROUTES.requests, ROUTES.listings, ROUTES.destinations, ROUTES.trips],
+  guide:    [ROUTES.guideInbox, ROUTES.guideListings, ROUTES.guideBookings, ROUTES.guideReviews],
+  admin:    [ROUTES.requests, ROUTES.guides, ROUTES.destinations, adminBridge],
+} as const;
+
+export const accountMenu = {
+  traveler: [ROUTES.account, ROUTES.myBookings, ROUTES.favorites, ROUTES.notifications, ROUTES.referrals, ROUTES.help],
+  guide:    [ROUTES.guideProfile, ROUTES.guideCalendar, ROUTES.guideSettings, ROUTES.help],
+  admin:    [adminBridge, ROUTES.account, ROUTES.help],
+} as const;
+
+export const guideBottomNav = [ROUTES.guideInbox, ROUTES.guideListings, ROUTES.guideBookings, ROUTES.guideReviews] as const;
+export const adminNav = [ROUTES.adminDashboard, ROUTES.adminGuides, ROUTES.adminListings, ROUTES.adminModeration, ROUTES.adminDisputes, ROUTES.adminBookings, ROUTES.adminAudit] as const;
+
+export const footerNav = {
+  about:   [ROUTES.howItWorks, ROUTES.trust, ROUTES.becomeGuide, ROUTES.forBusiness],
+  support: [ROUTES.help,
+            { href: "https://t.me/provodnik_help", label: "Telegram-поддержка", icon: MessageSquare, external: true } as NavItem,
+            { href: "mailto:support@provodnik.app", label: "Email: support@provodnik.app", icon: MessageSquare, external: true } as NavItem],
+  legal:   [
+    { href: "/policies/terms",   label: "Условия использования", icon: ScrollText } as NavItem,
+    { href: "/policies/privacy", label: "Конфиденциальность",    icon: ScrollText } as NavItem,
+    { href: "/policies/cookies", label: "Cookies",               icon: ScrollText } as NavItem,
+  ],
+} as const;
+
+export function isNavActive(pathname: string, item: NavItem): boolean {
+  if (pathname === item.href || pathname.startsWith(`${item.href}/`)) return true;
+  return item.activePrefixes?.some((p) => pathname === p || pathname.startsWith(`${p}/`)) ?? false;
+}


### PR DESCRIPTION
Adds src/lib/navigation.ts as the single source of truth for all navigation (one canonical label per route, role-aware header/account/footer arrays, isNavActive helper). Rewires the global site header (desktop + mobile sheet + avatar dropdown) and the mobile account drawer to consume it.

- Fixes label collisions (one label per destination)
- Guide header now mirrors its 4 work surfaces; admin gets an Админка bridge link
- Traveler cabinet links (Поездки/Избранное/Уведомления/Приглашения) now reachable from the drawer
- Pure label + grouping + source-of-truth refactor: no new/renamed routes, no redirect changes

Verified: typecheck + lint + 819 tests pass locally; build via CI.