### PR TITLE
feat(cabinet): shared ListRow + ConfirmDialog primitives

### DIFF
--- a/src/components/shared/confirm-dialog.test.tsx
+++ b/src/components/shared/confirm-dialog.test.tsx
@@ -1,0 +1,66 @@
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import * as React from "react";
+import { describe, expect, it } from "vitest";
+
+import { useConfirm, type ConfirmOptions } from "./confirm-dialog";
+
+function Harness({ options }: { options: ConfirmOptions }) {
+  const { confirm, ConfirmDialog } = useConfirm();
+  const [result, setResult] = React.useState<string>("pending");
+
+  return (
+    <div>
+      <button
+        type="button"
+        onClick={() => {
+          void confirm(options).then((value) => setResult(String(value)));
+        }}
+      >
+        Открыть
+      </button>
+      <span data-testid="result">{result}</span>
+      {ConfirmDialog}
+    </div>
+  );
+}
+
+describe("useConfirm", () => {
+  it("shows the title and description, resolves true on confirm", async () => {
+    render(
+      <Harness
+        options={{
+          title: "Удалить заявку?",
+          description: "Это действие нельзя отменить.",
+          confirmText: "Удалить",
+          destructive: true,
+        }}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Открыть" }));
+
+    expect(await screen.findByText("Удалить заявку?")).toBeInTheDocument();
+    expect(screen.getByText("Это действие нельзя отменить.")).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: "Удалить" }));
+
+    await waitFor(() => {
+      expect(screen.getByTestId("result")).toHaveTextContent("true");
+    });
+  });
+
+  it("resolves false on cancel and uses Russian default labels", async () => {
+    render(<Harness options={{ title: "Подтвердите действие" }} />);
+
+    fireEvent.click(screen.getByRole("button", { name: "Открыть" }));
+
+    expect(await screen.findByText("Подтвердите действие")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Подтвердить" })).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: "Отмена" }));
+
+    await waitFor(() => {
+      expect(screen.getByTestId("result")).toHaveTextContent("false");
+    });
+  });
+});

--- a/src/components/shared/confirm-dialog.tsx
+++ b/src/components/shared/confirm-dialog.tsx
@@ -1,0 +1,110 @@
+"use client";
+
+import * as React from "react";
+
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from "@/components/ui/alert-dialog";
+import { buttonVariants } from "@/components/ui/button";
+
+export type ConfirmOptions = {
+  title: string;
+  description?: React.ReactNode;
+  confirmText?: string;
+  cancelText?: string;
+  destructive?: boolean;
+};
+
+type ControlledConfirmDialogProps = ConfirmOptions & {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  onConfirm: () => void;
+};
+
+/** Controlled canon confirm dialog. Prefer the {@link useConfirm} hook for imperative flows. */
+export function ConfirmDialog({
+  open,
+  onOpenChange,
+  onConfirm,
+  title,
+  description,
+  confirmText = "Подтвердить",
+  cancelText = "Отмена",
+  destructive = false,
+}: ControlledConfirmDialogProps) {
+  return (
+    <AlertDialog open={open} onOpenChange={onOpenChange}>
+      <AlertDialogContent>
+        <AlertDialogHeader>
+          <AlertDialogTitle>{title}</AlertDialogTitle>
+          {description ? (
+            <AlertDialogDescription>{description}</AlertDialogDescription>
+          ) : null}
+        </AlertDialogHeader>
+        <AlertDialogFooter>
+          <AlertDialogCancel>{cancelText}</AlertDialogCancel>
+          <AlertDialogAction
+            className={
+              destructive ? buttonVariants({ variant: "destructive" }) : undefined
+            }
+            onClick={onConfirm}
+          >
+            {confirmText}
+          </AlertDialogAction>
+        </AlertDialogFooter>
+      </AlertDialogContent>
+    </AlertDialog>
+  );
+}
+
+/** Imperative confirm — replacement for window.confirm. Render `ConfirmDialog` once in the tree. */
+export function useConfirm(): {
+  confirm: (opts: ConfirmOptions) => Promise<boolean>;
+  ConfirmDialog: React.ReactNode;
+} {
+  const [open, setOpen] = React.useState(false);
+  const [options, setOptions] = React.useState<ConfirmOptions | null>(null);
+  const resolverRef = React.useRef<((value: boolean) => void) | null>(null);
+
+  const settle = React.useCallback((value: boolean) => {
+    const resolve = resolverRef.current;
+    resolverRef.current = null;
+    setOpen(false);
+    resolve?.(value);
+  }, []);
+
+  const confirm = React.useCallback((opts: ConfirmOptions) => {
+    setOptions(opts);
+    setOpen(true);
+    return new Promise<boolean>((resolve) => {
+      resolverRef.current = resolve;
+    });
+  }, []);
+
+  const handleOpenChange = React.useCallback(
+    (next: boolean) => {
+      if (!next) {
+        settle(false);
+      }
+    },
+    [settle],
+  );
+
+  const dialog = options ? (
+    <ConfirmDialog
+      {...options}
+      open={open}
+      onOpenChange={handleOpenChange}
+      onConfirm={() => settle(true)}
+    />
+  ) : null;
+
+  return { confirm, ConfirmDialog: dialog };
+}

--- a/src/components/shared/list-row.test.tsx
+++ b/src/components/shared/list-row.test.tsx
@@ -1,0 +1,52 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+import { Badge } from "@/components/ui/badge";
+import { ListRow } from "./list-row";
+
+describe("ListRow", () => {
+  it("renders title, subtitle and badge", () => {
+    render(
+      <ListRow
+        title="Экскурсия по Казани"
+        subtitle="12 июня · 4 человека"
+        badge={<Badge>Активна</Badge>}
+      />,
+    );
+
+    expect(screen.getByText("Экскурсия по Казани")).toBeInTheDocument();
+    expect(screen.getByText("12 июня · 4 человека")).toBeInTheDocument();
+    expect(screen.getByText("Активна")).toBeInTheDocument();
+  });
+
+  it("renders a link covering the row when href is set", () => {
+    render(<ListRow href="/requests/abc" title="Заявка" />);
+
+    expect(screen.getByRole("link", { name: "Заявка" })).toHaveAttribute(
+      "href",
+      "/requests/abc",
+    );
+  });
+
+  it("does not bubble action clicks to the row", () => {
+    const onRow = vi.fn();
+    const onAction = vi.fn();
+
+    render(
+      <ListRow
+        title="Заявка"
+        onClick={onRow}
+        actions={
+          <button type="button" onClick={onAction}>
+            Отменить
+          </button>
+        }
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Отменить" }));
+
+    expect(onAction).toHaveBeenCalledTimes(1);
+    expect(onRow).not.toHaveBeenCalled();
+  });
+});

--- a/src/components/shared/list-row.tsx
+++ b/src/components/shared/list-row.tsx
@@ -1,0 +1,88 @@
+import * as React from "react";
+import Link from "next/link";
+
+import { cn } from "@/lib/utils";
+
+export type ListRowProps = {
+  href?: string;
+  leading?: React.ReactNode;
+  title: React.ReactNode;
+  subtitle?: React.ReactNode;
+  badge?: React.ReactNode;
+  actions?: React.ReactNode;
+  onClick?: () => void;
+  className?: string;
+};
+
+const baseClasses =
+  "flex min-h-[44px] flex-wrap items-center gap-3 rounded-[12px] border border-border bg-card p-4 text-left text-sm";
+const interactiveClasses =
+  "transition-colors hover:bg-muted focus-visible:outline-none focus-visible:ring-3 focus-visible:ring-ring/40";
+
+/** Presentational cabinet row: leading | title/subtitle | badge | actions. */
+export function ListRow({
+  href,
+  leading,
+  title,
+  subtitle,
+  badge,
+  actions,
+  onClick,
+  className,
+}: ListRowProps) {
+  const inner = (
+    <>
+      {leading ? <div className="flex shrink-0 items-center">{leading}</div> : null}
+      <div className="min-w-0 flex-1">
+        <div className="truncate font-medium text-foreground">{title}</div>
+        {subtitle ? (
+          <div className="truncate text-sm text-muted-foreground">{subtitle}</div>
+        ) : null}
+      </div>
+      {badge ? <div className="shrink-0">{badge}</div> : null}
+      {actions ? (
+        <div
+          className="flex shrink-0 items-center gap-2"
+          onClick={(event) => {
+            event.stopPropagation();
+          }}
+        >
+          {actions}
+        </div>
+      ) : null}
+    </>
+  );
+
+  if (href) {
+    return (
+      <Link
+        href={href}
+        className={cn(baseClasses, interactiveClasses, className)}
+        onClick={onClick}
+      >
+        {inner}
+      </Link>
+    );
+  }
+
+  if (onClick) {
+    return (
+      <div
+        role="button"
+        tabIndex={0}
+        className={cn(baseClasses, interactiveClasses, "w-full cursor-pointer", className)}
+        onClick={onClick}
+        onKeyDown={(event) => {
+          if (event.key === "Enter" || event.key === " ") {
+            event.preventDefault();
+            onClick();
+          }
+        }}
+      >
+        {inner}
+      </div>
+    );
+  }
+
+  return <div className={cn(baseClasses, className)}>{inner}</div>;
+}


### PR DESCRIPTION
Two reusable cabinet primitives for the redesign:
- ListRow: consistent presentational cabinet row (leading/title/subtitle/badge/actions, optional href makes the whole row a link, actions stop propagation, min-h-44px, canon styling).
- useConfirm()/ConfirmDialog: AlertDialog-based confirm to replace native window.confirm (Russian labels, destructive variant, a11y title, resolves true/false).

Build-only — no consumer pages changed (those adopt these in later tasks). typecheck+lint+824 tests pass.