### PR TITLE
feat(nav): wire bottom-nav/admin-sidebar/footer to canonical nav + fix isNavActive

### DIFF
--- a/src/app/(protected)/admin/admin-sidebar-nav.tsx
+++ b/src/app/(protected)/admin/admin-sidebar-nav.tsx
@@ -3,8 +3,7 @@
 import Link from "next/link";
 import { usePathname } from "next/navigation";
 
-import { BarChart3, CalendarCheck, ClipboardList, Flag, ScrollText, ShieldCheck, UserCheck } from "lucide-react";
-
+import { adminNav, isNavActive, type NavItem } from "@/lib/navigation";
 import { cn } from "@/lib/utils";
 
 type AdminNavCounts = {
@@ -12,76 +11,25 @@ type AdminNavCounts = {
   listings: number;
 };
 
-const adminNavItems = [
-  {
-    href: "/admin/dashboard",
-    label: "Обзор",
-    mobileLabel: "Обзор",
-    icon: BarChart3,
-    countKey: null,
-  },
-  {
-    href: "/admin/guides",
-    label: "Гиды",
-    mobileLabel: "Гиды",
-    icon: UserCheck,
-    countKey: "guides",
-  },
-  {
-    href: "/admin/listings",
-    label: "Листинги",
-    mobileLabel: "Листинги",
-    icon: ClipboardList,
-    countKey: "listings",
-  },
-  {
-    href: "/admin/moderation",
-    label: "Модерация",
-    mobileLabel: "Модерация",
-    icon: ShieldCheck,
-    countKey: null,
-  },
-  {
-    href: "/admin/disputes",
-    label: "Споры",
-    mobileLabel: "Споры",
-    icon: Flag,
-    countKey: null,
-  },
-  {
-    href: "/admin/bookings",
-    label: "Бронирования",
-    mobileLabel: "Брони",
-    icon: CalendarCheck,
-    countKey: null,
-  },
-  {
-    href: "/admin/audit",
-    label: "Аудит",
-    mobileLabel: "Аудит",
-    icon: ScrollText,
-    countKey: null,
-  },
-] as const;
-
-function isActivePath(pathname: string, href: string) {
-  return pathname === href || pathname.startsWith(`${href}/`);
-}
+const countKeyByHref: Record<string, keyof AdminNavCounts> = {
+  "/admin/guides": "guides",
+  "/admin/listings": "listings",
+};
 
 function NavLink({
-  href,
-  label,
-  mobileLabel,
-  icon: Icon,
+  item,
   count,
   active,
-}: (typeof adminNavItems)[number] & {
+}: {
+  item: NavItem;
   active: boolean;
   count?: number;
 }) {
+  const Icon = item.icon;
+
   return (
     <Link
-      href={href}
+      href={item.href}
       aria-current={active ? "page" : undefined}
       className={cn(
         "flex items-center gap-3 rounded-2xl px-4 py-3 text-sm font-medium transition-colors",
@@ -91,8 +39,8 @@ function NavLink({
       )}
     >
       <Icon className="size-[18px] shrink-0" strokeWidth={1.8} />
-      <span className="hidden min-w-0 lg:block">{label}</span>
-      <span className="min-w-0 lg:hidden">{mobileLabel}</span>
+      <span className="hidden min-w-0 lg:block">{item.label}</span>
+      <span className="min-w-0 lg:hidden">{item.shortLabel ?? item.label}</span>
       {typeof count === "number" && count > 0 ? (
         <span className="ml-auto inline-flex min-w-6 items-center justify-center rounded-full bg-brand-light px-2 py-0.5 text-xs font-semibold text-brand">
           {count}
@@ -111,14 +59,17 @@ export function AdminSidebarNav({
 
   return (
     <nav className="space-y-2" aria-label="Admin workspace">
-      {adminNavItems.map((item) => (
-        <NavLink
-          key={item.href}
-          {...item}
-          count={item.countKey ? counts?.[item.countKey] : undefined}
-          active={isActivePath(pathname, item.href)}
-        />
-      ))}
+      {adminNav.map((item: NavItem) => {
+        const countKey = countKeyByHref[item.href];
+        return (
+          <NavLink
+            key={item.href}
+            item={item}
+            count={countKey ? counts?.[countKey] : undefined}
+            active={isNavActive(pathname, item)}
+          />
+        );
+      })}
     </nav>
   );
 }
@@ -135,10 +86,11 @@ export function AdminMobileTabs({
       className="fixed inset-x-3 bottom-3 z-[110] grid grid-cols-7 rounded-[1.5rem] border border-glass-border bg-nav-glass-bg p-1.5 shadow-glass backdrop-blur md:hidden"
       aria-label="Admin workspace mobile"
     >
-      {adminNavItems.map((item) => {
+      {adminNav.map((item: NavItem) => {
         const Icon = item.icon;
-        const active = isActivePath(pathname, item.href);
-        const count = item.countKey ? counts?.[item.countKey] : undefined;
+        const active = isNavActive(pathname, item);
+        const countKey = countKeyByHref[item.href];
+        const count = countKey ? counts?.[countKey] : undefined;
 
         return (
           <Link
@@ -153,7 +105,7 @@ export function AdminMobileTabs({
             )}
           >
             <Icon className="size-4" strokeWidth={1.9} />
-            <span className="truncate">{item.mobileLabel}</span>
+            <span className="truncate">{item.shortLabel ?? item.label}</span>
             {typeof count === "number" && count > 0 ? (
               <span className="inline-flex min-w-5 items-center justify-center rounded-full bg-brand-light px-1.5 py-0.5 text-[10px] font-semibold text-brand">
                 {count}

--- a/src/components/shared/guide-bottom-nav.test.tsx
+++ b/src/components/shared/guide-bottom-nav.test.tsx
@@ -8,11 +8,11 @@ vi.mock("next/navigation", () => ({
 import { GuideBottomNav } from "./guide-bottom-nav";
 
 describe("GuideBottomNav", () => {
-  it("renders Запросы, Экскурсии, Подтверждённые and Отзывы nav items", () => {
+  it("renders Запросы, Экскурсии, Заказы and Отзывы nav items", () => {
     render(<GuideBottomNav />);
     expect(screen.getByRole("link", { name: "Запросы" })).toBeDefined();
     expect(screen.getByRole("link", { name: "Экскурсии" })).toBeDefined();
-    expect(screen.getByRole("link", { name: "Подтверждённые" })).toBeDefined();
+    expect(screen.getByRole("link", { name: "Заказы" })).toBeDefined();
     expect(screen.getByRole("link", { name: "Отзывы" })).toHaveAttribute("href", "/guide/reviews");
   });
 });

--- a/src/components/shared/guide-bottom-nav.tsx
+++ b/src/components/shared/guide-bottom-nav.tsx
@@ -2,16 +2,9 @@
 
 import Link from "next/link";
 import { usePathname } from "next/navigation";
-import { BookCheck, ClipboardList, FileText, Star } from "lucide-react";
 
+import { guideBottomNav, isNavActive, type NavItem } from "@/lib/navigation";
 import { cn } from "@/lib/utils";
-
-const items = [
-  { href: "/guide", label: "Запросы", Icon: FileText },
-  { href: "/guide/listings", label: "Экскурсии", Icon: ClipboardList },
-  { href: "/guide/bookings", label: "Подтверждённые", Icon: BookCheck },
-  { href: "/guide/reviews", label: "Отзывы", Icon: Star },
-] as const;
 
 export function GuideBottomNav() {
   const pathname = usePathname();
@@ -22,23 +15,16 @@ export function GuideBottomNav() {
       style={{ paddingBottom: "env(safe-area-inset-bottom)" }}
     >
       <div className="h-16 grid grid-cols-4">
-        {items.map((item) => {
-          let isActive: boolean;
-          if (item.href === "/guide") {
-            isActive =
-              pathname === "/guide" ||
-              pathname.startsWith("/guide/inbox");
-          } else {
-            isActive =
-              pathname === item.href ||
-              pathname.startsWith(`${item.href}/`);
-          }
+        {guideBottomNav.map((item: NavItem) => {
+          const isActive = isNavActive(pathname, item);
+          const label = item.shortLabel ?? item.label;
+          const Icon = item.icon;
 
           return (
             <Link
               key={item.href}
               href={item.href}
-              aria-label={item.label}
+              aria-label={label}
               aria-current={isActive ? "page" : undefined}
               className={cn(
                 "relative flex flex-col items-center justify-center gap-0.5 min-h-[44px]",
@@ -53,7 +39,7 @@ export function GuideBottomNav() {
               )}
 
               <span className="relative">
-                <item.Icon
+                <Icon
                   size={22}
                   aria-hidden="true"
                   strokeWidth={isActive ? 2.25 : 1.75}
@@ -61,7 +47,7 @@ export function GuideBottomNav() {
               </span>
 
               <span className={cn("text-[11px]", isActive ? "font-bold" : "font-medium")}>
-                {item.label}
+                {label}
               </span>
             </Link>
           );

--- a/src/components/shared/site-footer.tsx
+++ b/src/components/shared/site-footer.tsx
@@ -1,30 +1,13 @@
 import Link from "next/link";
 import { ChevronDown } from "lucide-react";
 
+import { footerNav, type NavItem } from "@/lib/navigation";
+
 const TG_ICON = (
   <svg width="17" height="17" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
     <path d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm4.64 6.8l-1.68 7.92c-.12.56-.46.7-.93.43l-2.6-1.91-1.25 1.21c-.14.14-.26.26-.53.26l.19-2.66 4.84-4.37c.21-.19-.05-.29-.32-.1L7.97 14.37l-2.55-.8c-.55-.17-.56-.55.12-.82l9.95-3.84c.46-.17.86.11.15.89z" />
   </svg>
 );
-
-const projectLinks = [
-  { href: "/trust", label: "О нас" },
-  { href: "/how-it-works", label: "Как это работает" },
-  { href: "/guides", label: "Для гидов" },
-  { href: "/for-business", label: "Для бизнеса" },
-] as const;
-
-const supportLinks = [
-  { href: "/trust", label: "Доверие и безопасность" },
-  { href: "https://t.me/provodnik_help", label: "Telegram-поддержка", external: true },
-  { href: "mailto:support@provodnik.app", label: "Email: support@provodnik.app" },
-] as const;
-
-const policyLinks = [
-  { href: "/policies/terms", label: "Условия использования" },
-  { href: "/policies/privacy", label: "Конфиденциальность" },
-  { href: "/policies/cookies", label: "Cookies" },
-] as const;
 
 const socialLinks = [
   { href: "https://t.me/provodnik_help", label: "Telegram", icon: TG_ICON },
@@ -84,7 +67,7 @@ export function SiteFooter() {
               О проекте
             </p>
             <ul className="m-0 flex list-none flex-col gap-2.5 p-0">
-              {projectLinks.map((link) => (
+              {footerNav.about.map((link) => (
                 <li key={link.label}>
                   <Link href={link.href} className="flex min-h-11 items-center text-sm text-primary-foreground/60 transition-colors hover:text-primary-foreground md:min-h-0">
                     {link.label}
@@ -99,8 +82,8 @@ export function SiteFooter() {
               Поддержка
             </p>
             <ul className="m-0 flex list-none flex-col gap-2.5 p-0">
-              {supportLinks.map((link) =>
-                "external" in link && link.external ? (
+              {footerNav.support.map((link: NavItem) =>
+                link.external ? (
                   <li key={link.label}>
                     <a
                       href={link.href}
@@ -131,7 +114,7 @@ export function SiteFooter() {
                 Правила
               </p>
               <ul className="m-0 flex list-none flex-col gap-2.5 p-0">
-                {policyLinks.map((link) => (
+                {footerNav.legal.map((link) => (
                   <li key={link.label}>
                     <Link href={link.href} className="flex min-h-11 items-center text-sm text-primary-foreground/60 transition-colors hover:text-primary-foreground md:min-h-0">
                       {link.label}

--- a/src/lib/navigation.ts
+++ b/src/lib/navigation.ts
@@ -72,7 +72,7 @@ export const footerNav = {
   about:   [ROUTES.howItWorks, ROUTES.trust, ROUTES.becomeGuide, ROUTES.forBusiness],
   support: [ROUTES.help,
             { href: "https://t.me/provodnik_help", label: "Telegram-поддержка", icon: MessageSquare, external: true } as NavItem,
-            { href: "mailto:support@provodnik.app", label: "Email: support@provodnik.app", icon: MessageSquare, external: true } as NavItem],
+            { href: "mailto:support@provodnik.app", label: "Email: support@provodnik.app", icon: MessageSquare } as NavItem],
   legal:   [
     { href: "/policies/terms",   label: "Условия использования", icon: ScrollText } as NavItem,
     { href: "/policies/privacy", label: "Конфиденциальность",    icon: ScrollText } as NavItem,

--- a/src/lib/navigation.ts
+++ b/src/lib/navigation.ts
@@ -81,6 +81,8 @@ export const footerNav = {
 } as const;
 
 export function isNavActive(pathname: string, item: NavItem): boolean {
-  if (pathname === item.href || pathname.startsWith(`${item.href}/`)) return true;
-  return item.activePrefixes?.some((p) => pathname === p || pathname.startsWith(`${p}/`)) ?? false;
+  if (item.activePrefixes) {
+    return pathname === item.href || item.activePrefixes.some((p) => pathname === p || pathname.startsWith(`${p}/`));
+  }
+  return pathname === item.href || pathname.startsWith(`${item.href}/`);
 }


### PR DESCRIPTION
Wires the remaining nav surfaces to the canonical src/lib/navigation.ts: guide bottom-nav (Запросы/Экскурсии/Заказы/Отзывы), admin sidebar+mobile tabs (Обзор/Гиды/Листинги/Модерация/Споры/Бронирования/Аудит, short 'Брони' on the tab bar), and the footer (single Доверие row, Стать гидом→recruiting, +Помощь, −/guides). Also fixes isNavActive to restrictive activePrefixes (guide inbox no longer lights on /guide/bookings). No new routes.