### PR TITLE
fix(guide): cancel/no-show enabled only in valid booking states

### DIFF
--- a/src/features/bookings/components/booking-detail-screen.tsx
+++ b/src/features/bookings/components/booking-detail-screen.tsx
@@ -886,15 +886,17 @@ function nextStatusForAction(
   }
 
   if (action === "cancel") {
-    if (current === "completed" || current === "cancelled" || current === "no_show") {
-      return null;
+    // Mirror BOOKING_TRANSITIONS: cancellable from DB pending /
+    // awaiting_guide_confirmation (→ "awaiting_confirmation") and confirmed.
+    if (current === "awaiting_confirmation" || current === "confirmed") {
+      return "cancelled";
     }
-    return "cancelled";
+    return null;
   }
 
   if (action === "no_show") {
-    if (current === "completed" || current === "cancelled") return null;
-    return "no_show";
+    // BOOKING_TRANSITIONS allows no_show only from DB "confirmed".
+    return current === "confirmed" ? "no_show" : null;
   }
 
   return null;


### PR DESCRIPTION
The guide booking-detail no-show button was enabled in states the server's booking state-machine rejects (no_show is valid only from confirmed; cancel only from pending/awaiting/confirmed), so clicks silently failed. Aligns the client nextStatusForAction gate with BOOKING_TRANSITIONS — no-show enables only when confirmed, cancel only in cancellable states. Server actions already persisted; this fixes the UI gate. typecheck+lint+tests pass.