### PR TITLE
fix(dates): timezone-pinned formatters to resolve hydration #418

### DIFF
--- a/src/features/messaging/components/conversation-list.tsx
+++ b/src/features/messaging/components/conversation-list.tsx
@@ -4,28 +4,20 @@ import { useQuery } from "@tanstack/react-query";
 import Link from "next/link";
 
 import { Avatar, AvatarFallback } from "@/components/ui/avatar";
+import { formatRussianDate, formatRussianTime } from "@/lib/dates";
 import type { UserThreadSummary } from "@/lib/supabase/conversations";
+
+const moscowDayKey = new Intl.DateTimeFormat("en-CA", { timeZone: "Europe/Moscow" });
 
 function formatThreadTimestamp(timestamp: string | null) {
   if (!timestamp) {
     return "Без сообщений";
   }
 
-  const date = new Date(timestamp);
-  const now = new Date();
-  const isSameDay = date.toDateString() === now.toDateString();
+  const isSameDay =
+    moscowDayKey.format(new Date(timestamp)) === moscowDayKey.format(new Date());
 
-  if (isSameDay) {
-    return date.toLocaleTimeString("ru-RU", {
-      hour: "2-digit",
-      minute: "2-digit",
-    });
-  }
-
-  return date.toLocaleDateString("ru-RU", {
-    day: "numeric",
-    month: "short",
-  });
+  return isSameDay ? formatRussianTime(timestamp) : formatRussianDate(timestamp);
 }
 
 async function fetchThreads() {

--- a/src/features/messaging/components/message-bubble.tsx
+++ b/src/features/messaging/components/message-bubble.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
+import { formatRussianTime } from "@/lib/dates";
 import type { GuideOfferRow, MessageRow } from "@/lib/supabase/types";
 
 import { OfferCard } from "./OfferCard";
@@ -8,13 +9,6 @@ import {
   SystemEventMessage,
   type SystemEventPayload,
 } from "./SystemEventMessage";
-
-function formatTime(timestamp: string) {
-  return new Date(timestamp).toLocaleTimeString("ru-RU", {
-    hour: "2-digit",
-    minute: "2-digit",
-  });
-}
 
 function getInitials(senderName: string) {
   return (
@@ -215,7 +209,7 @@ function UserBubble({
               {isOwn ? "Вы" : senderName}
             </p>
             <time className="text-xs text-muted-foreground" dateTime={timestamp}>
-              {formatTime(timestamp)}
+              {formatRussianTime(timestamp)}
             </time>
           </div>
         </div>

--- a/src/features/requests/components/request-detail-screen.test.tsx
+++ b/src/features/requests/components/request-detail-screen.test.tsx
@@ -308,7 +308,7 @@ describe("RequestDetailScreen", () => {
 
     expect(badgeTexts).toEqual([
       "Сборная группа",
-      "10 июня 2026",
+      "10 июня",
       "±пара дней",
       "—",
       "2 из 5 чел.",

--- a/src/features/requests/components/request-detail-screen.tsx
+++ b/src/features/requests/components/request-detail-screen.tsx
@@ -39,7 +39,7 @@ import { StickyActionBar } from "@/components/shared/sticky-action-bar";
 import { TravelerRequestStatusBadge } from "@/features/traveler/components/requests/traveler-request-status";
 import { withdrawOfferAction } from "@/features/guide/offer-actions";
 import { cityImage } from "@/lib/city-image";
-import { formatTimeRange } from "@/lib/dates";
+import { formatRussianDate, formatRussianDateTime, formatTimeRange } from "@/lib/dates";
 import { BADGE_CLASS } from "@/lib/styles";
 import type { QaThread } from "@/lib/supabase/qa-threads";
 import type { BiddingGuide } from "@/lib/supabase/requests-public";
@@ -356,32 +356,10 @@ function formatRub(amount: number) {
   }).format(amount);
 }
 
-function formatDate(iso: string) {
-  const d = new Date(iso);
-  if (Number.isNaN(d.getTime())) return iso;
-  const monthDay = d.toLocaleDateString("ru-RU", { day: "numeric", month: "long" });
-  return `${monthDay} ${d.getFullYear()}`;
-}
-
-function formatPublishedAt(iso: string) {
-  const d = new Date(iso);
-  if (Number.isNaN(d.getTime())) return "";
-  const date = d.toLocaleDateString("ru-RU", {
-    day: "numeric",
-    month: "long",
-    year: "numeric",
-  });
-  const time = d.toLocaleTimeString("ru-RU", {
-    hour: "2-digit",
-    minute: "2-digit",
-  });
-  return `Опубликован ${date}, ${time}`;
-}
-
 function TravelerRequestSummary({ record }: { record: TravelerRequestRecord }) {
   const request = record.request;
 
-  const dateLabel = formatDate(request.startDate);
+  const dateLabel = formatRussianDate(request.startDate);
   const timeLabel = request.startTime
     ? request.endTime
       ? `${request.startTime} – ${request.endTime}`
@@ -405,7 +383,7 @@ function TravelerRequestSummary({ record }: { record: TravelerRequestRecord }) {
       ? "Бюджет не указан"
       : `${formatRub(request.budgetPerPersonRub)} на чел.`;
 
-  const publishedAt = formatPublishedAt(record.createdAt);
+  const publishedAt = `Опубликован ${formatRussianDateTime(record.createdAt)}`;
   const interests = request.interests ?? [];
 
   return (
@@ -730,17 +708,6 @@ function OwnerDetailBranch({
   );
 }
 
-function formatDateTime(value: string): string {
-  const date = new Date(value);
-  if (Number.isNaN(date.getTime())) return value;
-  return date.toLocaleString("ru-RU", {
-    month: "short",
-    day: "2-digit",
-    hour: "2-digit",
-    minute: "2-digit",
-  });
-}
-
 function formatViewsLabel(count: number): string {
   if (count <= 0) return "Вы первый, кто открыл этот запрос";
   const mod10 = count % 10;
@@ -820,7 +787,7 @@ function GuideDetailBranch({
           </div>
           <div>
             <p className="text-[15px] font-semibold text-on-surface">{request.requesterName}</p>
-            <p className="text-[13px] text-on-surface-muted">Запрос от {formatDateTime(request.createdAt)}</p>
+            <p className="text-[13px] text-on-surface-muted">Запрос от {formatRussianDateTime(request.createdAt)}</p>
           </div>
         </div>
 
@@ -844,7 +811,7 @@ function GuideDetailBranch({
               {offerMeta && (offerMeta.starts_at != null || offerMeta.capacity != null || offerMeta.price_minor != null || offerMeta.message != null) ? (
                 <div className="flex flex-col gap-2">
                   <p className="text-sm text-on-surface/80">
-                    {offerMeta.starts_at ? new Date(offerMeta.starts_at).toLocaleDateString("ru-RU", { day: "numeric", month: "long" }) : ""}
+                    {offerMeta.starts_at ? formatRussianDate(offerMeta.starts_at) : ""}
                     {offerMeta.capacity != null ? ` · ${offerMeta.capacity} чел.` : ""}
                     {offerMeta.price_minor != null ? ` · ${Math.round(kopecksToRub(offerMeta.price_minor) / (offerMeta.capacity ?? 1)).toLocaleString("ru-RU")} ₽/чел.` : ""}
                   </p>

--- a/src/features/traveler/components/requests/traveler-requests-screen.tsx
+++ b/src/features/traveler/components/requests/traveler-requests-screen.tsx
@@ -4,6 +4,7 @@ import Link from 'next/link'
 import { useState, type ReactNode } from 'react'
 
 import { Button } from '@/components/ui/button'
+import { formatRussianDate, formatRussianDateTime } from '@/lib/dates'
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs'
 import {
   RequestCardFinal,
@@ -66,28 +67,15 @@ function sortByPriority(
 }
 
 function formatDateRange(startsOn: string, endsOn?: string | null): string {
-  const start = new Date(startsOn)
-  if (Number.isNaN(start.getTime())) return startsOn
-  const opts: Intl.DateTimeFormatOptions = { day: 'numeric', month: 'short' }
-  const s = start.toLocaleDateString('ru-RU', opts)
-  if (!endsOn || endsOn === startsOn) return s
-  const end = new Date(endsOn)
-  if (Number.isNaN(end.getTime())) return s
-  return `${s} – ${end.toLocaleDateString('ru-RU', opts)}`
+  const start = formatRussianDate(startsOn)
+  if (!endsOn || endsOn === startsOn) return start
+  return `${start} — ${formatRussianDate(endsOn)}`
 }
 
 function formatPrice(budgetMinor: number | null): string {
   if (budgetMinor == null) return 'По договоренности'
   const rub = budgetMinor / 100
   return `${new Intl.NumberFormat('ru-RU').format(rub)} ₽ / чел`
-}
-
-function formatPublishedAt(iso: string): string {
-  const d = new Date(iso)
-  if (Number.isNaN(d.getTime())) return ''
-  const date = d.toLocaleDateString('ru-RU', { day: 'numeric', month: 'short' })
-  const time = d.toLocaleTimeString('ru-RU', { hour: '2-digit', minute: '2-digit' })
-  return `${date}, ${time}`
 }
 
 function mapRequestToCard(request: TravelerRequestSummary): RequestCardFinalProps {
@@ -109,7 +97,7 @@ function mapRequestToCard(request: TravelerRequestSummary): RequestCardFinalProp
     groupPrice: request.budget_minor != null
       ? `~${new Intl.NumberFormat('ru-RU').format(Math.round(request.budget_minor * request.participants_count / 100))} ₽ за группу`
       : undefined,
-    publishedAt: request.created_at ? formatPublishedAt(request.created_at) : undefined,
+    publishedAt: request.created_at ? formatRussianDateTime(request.created_at) : undefined,
     unreadOfferCount: request.unread_offer_count,
   }
 }

--- a/src/lib/dates.ts
+++ b/src/lib/dates.ts
@@ -78,6 +78,42 @@ export function todayMoscowISODate(): string {
 }
 
 /**
+ * Format an ISO timestamp/date as a Russian "day month" string, pinned to Moscow TZ.
+ * Pinning the timeZone keeps SSR (UTC) and client output identical — avoids hydration #418.
+ */
+export function formatRussianDate(iso: string): string {
+  return new Intl.DateTimeFormat("ru-RU", {
+    day: "numeric",
+    month: "long",
+    timeZone: MOSCOW_TZ,
+  }).format(new Date(iso));
+}
+
+/**
+ * Format an ISO timestamp as a Russian "day month, HH:MM" string, pinned to Moscow TZ.
+ */
+export function formatRussianDateTime(iso: string): string {
+  return new Intl.DateTimeFormat("ru-RU", {
+    day: "numeric",
+    month: "long",
+    hour: "2-digit",
+    minute: "2-digit",
+    timeZone: MOSCOW_TZ,
+  }).format(new Date(iso));
+}
+
+/**
+ * Format an ISO timestamp as a Russian "HH:MM" time string, pinned to Moscow TZ.
+ */
+export function formatRussianTime(iso: string): string {
+  return new Intl.DateTimeFormat("ru-RU", {
+    hour: "2-digit",
+    minute: "2-digit",
+    timeZone: MOSCOW_TZ,
+  }).format(new Date(iso));
+}
+
+/**
  * Format a duration in minutes as a human-readable Russian string.
  * Examples:
  *   formatDurationMinutes(0)  → ""


### PR DESCRIPTION
Adds Europe/Moscow + ru-RU pinned date/time formatters to src/lib/dates.ts and replaces unpinned toLocale* calls in request-detail, messaging (bubble + conversation list), and traveler-requests. Server (UTC) and client now render identical date strings, eliminating React hydration #418. No suppressHydrationWarning/mounted-guards. Note: compact dates (no year) — confirm at final sweep.