### PR TITLE
feat(admin): dashboard hierarchy + real hover + content-only skeleton

### DIFF
--- a/src/app/(protected)/admin/dashboard/loading.tsx
+++ b/src/app/(protected)/admin/dashboard/loading.tsx
@@ -1,60 +1,28 @@
-const queueSlots = Array.from({ length: 4 });
+import { Skeleton } from "@/components/ui/skeleton";
 
 export default function Loading() {
   return (
-    <div className="space-y-8" role="status" aria-busy="true" aria-live="polite">
+    <div className="space-y-10" role="status" aria-busy="true" aria-live="polite">
       <span className="sr-only">Загрузка панели администратора</span>
 
       <div className="space-y-3">
-        <div className="h-3 w-28 rounded-full bg-muted/70 animate-pulse" />
-        <div className="h-9 w-full max-w-xl rounded-2xl bg-muted/70 animate-pulse" />
-        <div className="h-5 w-full max-w-3xl rounded-full bg-muted/60 animate-pulse" />
+        <Skeleton className="h-3 w-40 rounded-full" />
+        <Skeleton className="h-8 w-44 rounded-xl" />
+        <Skeleton className="h-5 w-full max-w-md rounded-full" />
       </div>
 
-      <div className="grid grid-cols-1 lg:grid-cols-[240px_minmax(0,1fr)] gap-8 mt-8">
-        <aside className="bg-surface-high rounded-card shadow-card p-5 lg:sticky lg:top-24 self-start max-lg:static space-y-4">
-          <div className="h-4 w-24 rounded-full bg-muted/70 animate-pulse" />
-          <div className="space-y-3">
-            <div className="h-10 rounded-xl bg-muted/60 animate-pulse" />
-            <div className="h-10 rounded-xl bg-muted/60 animate-pulse" />
-            <div className="h-10 rounded-xl bg-muted/60 animate-pulse" />
-          </div>
-          <div className="rounded-lg border border-border/70 bg-background/60 p-4">
-            <div className="h-3 w-24 rounded-full bg-muted/70 animate-pulse" />
-            <div className="mt-3 h-14 rounded-2xl bg-muted/60 animate-pulse" />
-          </div>
-        </aside>
+      <div className="space-y-4">
+        <Skeleton className="h-3 w-36 rounded-full" />
+        <div className="grid gap-4 sm:grid-cols-3">
+          {Array.from({ length: 3 }).map((_, index) => (
+            <Skeleton key={index} className="h-40 rounded-glass" />
+          ))}
+        </div>
+      </div>
 
-        <section className="space-y-6">
-          <div className="bg-glass backdrop-blur-[20px] border border-glass-border shadow-glass rounded-glass space-y-4 p-6 md:p-8">
-            <div className="h-3 w-24 rounded-full bg-muted/70 animate-pulse" />
-            <div className="h-8 w-full max-w-lg rounded-2xl bg-muted/70 animate-pulse" />
-            <div className="grid gap-3 sm:grid-cols-3">
-              <div className="h-20 rounded-2xl bg-muted/60 animate-pulse" />
-              <div className="h-20 rounded-2xl bg-muted/60 animate-pulse" />
-              <div className="h-20 rounded-2xl bg-muted/60 animate-pulse" />
-            </div>
-          </div>
-
-          <div className="space-y-3">
-            {queueSlots.map((_, index) => (
-              <div
-                key={index}
-                className="rounded-2xl border border-border/70 bg-card/90 p-5 shadow-soft"
-              >
-                <div className="flex items-center justify-between gap-4">
-                  <div className="space-y-2">
-                    <div className="h-3 w-20 rounded-full bg-muted/70 animate-pulse" />
-                    <div className="h-5 w-64 rounded-full bg-muted/70 animate-pulse" />
-                  </div>
-                  <div className="h-8 w-24 rounded-full bg-muted/60 animate-pulse" />
-                </div>
-                <div className="mt-4 h-4 w-full rounded-full bg-muted/60 animate-pulse" />
-                <div className="mt-2 h-4 w-3/4 rounded-full bg-muted/60 animate-pulse" />
-              </div>
-            ))}
-          </div>
-        </section>
+      <div className="space-y-4">
+        <Skeleton className="h-3 w-28 rounded-full" />
+        <Skeleton className="h-28 rounded-glass sm:max-w-xs" />
       </div>
     </div>
   );

--- a/src/app/(protected)/admin/dashboard/page.tsx
+++ b/src/app/(protected)/admin/dashboard/page.tsx
@@ -1,116 +1,111 @@
 import type { Metadata } from "next";
 import Link from "next/link";
+import { AlertTriangle, ClipboardList, UserCheck } from "lucide-react";
 
 import { getAdminDashboardStats } from "@/lib/supabase/moderation";
+import { PageHeader } from "@/components/shared/page-header";
 import { Badge } from "@/components/ui/badge";
+import { Card, CardContent } from "@/components/ui/card";
 
 export const metadata: Metadata = {
   title: "Панель администратора",
 };
 
-const statCards = [
+const actionableCards = [
+  {
+    key: "openDisputes",
+    label: "Открытые споры",
+    href: "/admin/disputes",
+    Icon: AlertTriangle,
+  },
   {
     key: "pendingGuideApplications",
     label: "Заявки гидов",
     href: "/admin/guides",
+    Icon: UserCheck,
   },
   {
     key: "pendingListingReviews",
     label: "Проверка листингов",
     href: "/admin/listings",
-  },
-  {
-    key: "openDisputes",
-    label: "Открытые споры",
-    href: "/admin/disputes",
-  },
-  {
-    key: "totalBookings",
-    label: "Всего бронирований",
-    href: "/admin/bookings",
+    Icon: ClipboardList,
   },
 ] as const;
+
+function formatDelta(delta: number) {
+  return `${delta > 0 ? `+${delta}` : delta} за неделю`;
+}
 
 export default async function AdminDashboardPage() {
   const stats = await getAdminDashboardStats();
 
   return (
-    <div className="space-y-8">
-      <div className="space-y-3">
-        <Badge variant="outline">Панель администратора</Badge>
-        <h1 className="text-3xl font-semibold tracking-tight text-foreground">
-          Обзор модерации
-        </h1>
-        <p className="max-w-3xl text-sm text-muted-foreground">
-          Следите за очередью проверки, открытыми спорами и общей нагрузкой на
-          админ-панель.
-        </p>
-      </div>
+    <div className="space-y-10">
+      <PageHeader
+        eyebrow="Панель администратора"
+        title="Обзор"
+        subtitle="Следите за очередью проверки, открытыми спорами и общей нагрузкой на админ-панель."
+      />
 
-      <div className="grid gap-4 md:grid-cols-2 xl:grid-cols-4">
-        {statCards.map((card) => {
-          const delta = stats.weeklyDelta[card.key];
-          return (
-            <Link
-              key={card.key}
-              href={card.href}
-              className="rounded-[1.75rem] border border-border/70 bg-card p-6 shadow-card transition-transform hover:-translate-y-0.5"
-            >
-              <div className="text-sm text-muted-foreground">{card.label}</div>
-              <div className="mt-3 text-4xl font-semibold tracking-tight text-foreground">
-                {stats[card.key]}
+      <section className="space-y-4">
+        <h2 className="text-xs font-semibold uppercase tracking-[0.14em] text-on-surface-muted">
+          Требует действий
+        </h2>
+        <div className="grid gap-4 sm:grid-cols-3">
+          {actionableCards.map((card) => {
+            const count = stats[card.key];
+            const delta = stats.weeklyDelta[card.key];
+            const { Icon } = card;
+            return (
+              <Link key={card.key} href={card.href} className="group block">
+                <Card className="h-full py-6 transition-all duration-150 hover:-translate-y-px hover:border-primary/40 hover:shadow-md">
+                  <CardContent className="px-6">
+                    <div className="flex items-start justify-between gap-4">
+                      <div className="text-sm text-muted-foreground">
+                        {card.label}
+                      </div>
+                      <span className="flex size-10 shrink-0 items-center justify-center rounded-full bg-primary/10 text-primary">
+                        <Icon className="size-5" aria-hidden />
+                      </span>
+                    </div>
+                    <div className="mt-3 text-4xl font-semibold tracking-tight text-foreground">
+                      {count}
+                    </div>
+                    <div className="mt-2 flex items-center gap-2 text-xs text-muted-foreground">
+                      <span>{formatDelta(delta)}</span>
+                      {count > 0 ? <Badge variant="destructive">Ждёт</Badge> : null}
+                    </div>
+                  </CardContent>
+                </Card>
+              </Link>
+            );
+          })}
+        </div>
+      </section>
+
+      <section className="space-y-4">
+        <h2 className="text-xs font-semibold uppercase tracking-[0.14em] text-on-surface-muted">
+          Статистика
+        </h2>
+        <Link href="/admin/bookings" className="group block sm:max-w-xs">
+          <Card
+            size="sm"
+            className="h-full transition-all duration-150 hover:-translate-y-px hover:border-primary/40 hover:shadow-md"
+          >
+            <CardContent>
+              <div className="text-sm text-muted-foreground">
+                Всего бронирований
               </div>
-              <div className="mt-2 text-xs text-muted-foreground">
-                {delta > 0 ? `+${delta}` : delta} за неделю
+              <div className="mt-2 text-3xl font-semibold tracking-tight text-foreground">
+                {stats.totalBookings}
               </div>
-              <div className="mt-4 text-sm font-medium text-primary">
-                Открыть раздел
+              <div className="mt-1 text-xs text-muted-foreground">
+                {formatDelta(stats.weeklyDelta.totalBookings)}
               </div>
-            </Link>
-          );
-        })}
-      </div>
-
-      <div className="grid gap-4 lg:grid-cols-3">
-        <Link
-          href="/admin/guides"
-          className="rounded-[1.75rem] border border-border/70 bg-card p-6 shadow-card"
-        >
-          <div className="text-sm font-medium text-foreground">
-            Гиды ждут проверки
-          </div>
-          <p className="mt-2 text-sm text-muted-foreground">
-            Сейчас в очереди {stats.pendingGuideApplications} анкет. Проверьте
-            документы и статус верификации.
-          </p>
+            </CardContent>
+          </Card>
         </Link>
-
-        <Link
-          href="/admin/listings"
-          className="rounded-[1.75rem] border border-border/70 bg-card p-6 shadow-card"
-        >
-          <div className="text-sm font-medium text-foreground">
-            Листинги на модерации
-          </div>
-          <p className="mt-2 text-sm text-muted-foreground">
-            В проверке {stats.pendingListingReviews} предложений. Подтвердите
-            публикацию или отклоните проблемные карточки.
-          </p>
-        </Link>
-
-        <Link
-          href="/admin/disputes"
-          className="rounded-[1.75rem] border border-border/70 bg-card p-6 shadow-card"
-        >
-          <div className="text-sm font-medium text-foreground">
-            Очередь споров
-          </div>
-          <p className="mt-2 text-sm text-muted-foreground">
-            Открытых кейсов: {stats.openDisputes}. Раздел споров остается
-            отдельным рабочим потоком.
-          </p>
-        </Link>
-      </div>
+      </section>
     </div>
   );
 }


### PR DESCRIPTION
Redesigns /admin/dashboard: PageHeader; two-tier hierarchy (Tier 1 actionable queues = disputes/guide-apps/listing-reviews with Lucide icons + count badges, Tier 2 quieter totalBookings); removes the duplicate quick-access panels; real hover affordance; loading.tsx is now content-only (no fake sidebar). Stats/hrefs/metadata preserved.