### PR TITLE
feat(guide-reviews): Lucide stars + Tabs filter + PageHeader/EmptyState/Alert

### DIFF
--- a/src/app/(protected)/guide/reviews/page.test.tsx
+++ b/src/app/(protected)/guide/reviews/page.test.tsx
@@ -110,7 +110,7 @@ describe("GuideReviewsPage", () => {
 
     render(await GuideReviewsPage());
 
-    expect(screen.getByText("Нет отзывов в этой категории.")).toBeInTheDocument();
+    expect(screen.getByText("Отзывов пока нет")).toBeInTheDocument();
     expect(redirectMock).not.toHaveBeenCalledWith("/guide");
   });
 });

--- a/src/app/(protected)/guide/reviews/page.tsx
+++ b/src/app/(protected)/guide/reviews/page.tsx
@@ -1,7 +1,10 @@
 import type { Metadata } from "next";
+import { MessageSquare } from "lucide-react";
 import { redirect } from "next/navigation";
 
-import { Badge } from "@/components/ui/badge";
+import { EmptyState } from "@/components/shared/empty-state";
+import { PageHeader } from "@/components/shared/page-header";
+import { Alert, AlertDescription } from "@/components/ui/alert";
 import { ReviewsList } from "@/features/reviews/components/ReviewsList";
 import { createSupabaseServerClient } from "@/lib/supabase/server";
 import type {
@@ -46,6 +49,7 @@ export default async function GuideReviewsPage() {
     breakdown: ReviewRatingsBreakdownRow[];
     reply: ReviewReplyRow | null;
   })[] = [];
+  let loadFailed = false;
 
   try {
     const supabase = await createSupabaseServerClient();
@@ -68,27 +72,29 @@ export default async function GuideReviewsPage() {
 
     items = ((reviews ?? []) as RawReview[]).map((row) => toListItem(row, guideId));
   } catch {
-    return (
-      <div className="space-y-4">
-        <Badge variant="outline">Кабинет гида</Badge>
-        <h1 className="text-3xl font-semibold tracking-tight text-foreground">Отзывы</h1>
-        <p className="text-sm text-muted-foreground">
-          Раздел временно недоступен. Напишите в поддержку.
-        </p>
-      </div>
-    );
+    loadFailed = true;
   }
 
   return (
     <div className="space-y-6">
-      <div className="space-y-2">
-        <Badge variant="outline">Кабинет гида</Badge>
-        <h1 className="text-3xl font-semibold tracking-tight text-foreground">Отзывы</h1>
-        <p className="text-sm text-muted-foreground">
-          Опубликованные отзывы с оценками по четырём критериям и ответы гида.
-        </p>
-      </div>
-      <ReviewsList reviews={items} showReplyComposer />
+      <PageHeader
+        eyebrow="Кабинет гида"
+        title="Отзывы"
+        subtitle="Отзывы путешественников о ваших турах"
+      />
+      {loadFailed ? (
+        <Alert variant="destructive">
+          <AlertDescription>Не удалось загрузить отзывы</AlertDescription>
+        </Alert>
+      ) : items.length === 0 ? (
+        <EmptyState
+          icon={<MessageSquare />}
+          title="Отзывов пока нет"
+          description="Они появятся после первых завершённых поездок"
+        />
+      ) : (
+        <ReviewsList reviews={items} showReplyComposer />
+      )}
     </div>
   );
 }

--- a/src/features/reviews/components/ReviewCard.tsx
+++ b/src/features/reviews/components/ReviewCard.tsx
@@ -1,3 +1,5 @@
+import { Star } from "lucide-react";
+
 import { Card, CardContent, CardHeader } from "@/components/ui/card";
 import { Separator } from "@/components/ui/separator";
 import { ReplyComposer } from "@/features/reviews/components/ReplyComposer";
@@ -24,10 +26,18 @@ export type ReviewCardProps = {
   showReplyComposer?: boolean;
 };
 
-function Stars({ n }: { n: number }) {
+function StarRow({ n, size = "size-4" }: { n: number; size?: string }) {
   const clamped = Math.min(5, Math.max(0, Math.round(n)));
   return (
-    <span>{Array.from({ length: 5 }, (_, i) => (i < clamped ? "★" : "☆")).join("")}</span>
+    <span className="inline-flex items-center gap-0.5" role="img" aria-label={`${clamped} из 5`}>
+      {Array.from({ length: 5 }, (_, i) =>
+        i < clamped ? (
+          <Star key={i} className={`${size} fill-gold text-gold`} aria-hidden="true" />
+        ) : (
+          <Star key={i} className={`${size} text-muted-foreground/40`} aria-hidden="true" />
+        ),
+      )}
+    </span>
   );
 }
 
@@ -46,8 +56,8 @@ export function ReviewCard({
     <Card className="border-border/70">
       <CardHeader className="space-y-2 pb-2">
         <div className="flex flex-wrap items-baseline justify-between gap-2">
-          <div className="text-lg text-foreground">
-            <Stars n={review.rating} />
+          <div className="text-foreground">
+            <StarRow n={review.rating} />
           </div>
           <time className="text-sm text-muted-foreground" dateTime={review.created_at}>
             {new Date(review.created_at).toLocaleDateString("ru-RU")}
@@ -65,7 +75,7 @@ export function ReviewCard({
           {AXIS_ORDER.map((axis) => (
             <div key={axis} className="flex flex-wrap items-center gap-2">
               <span className="text-muted-foreground">{AXIS_LABELS[axis]}:</span>
-              <Stars n={byAxis.get(axis) ?? 0} />
+              <StarRow n={byAxis.get(axis) ?? 0} size="size-3" />
             </div>
           ))}
         </div>

--- a/src/features/reviews/components/ReviewsList.tsx
+++ b/src/features/reviews/components/ReviewsList.tsx
@@ -3,7 +3,7 @@
 import * as React from "react";
 
 import { Badge } from "@/components/ui/badge";
-import { Button } from "@/components/ui/button";
+import { Tabs, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { ReviewCard } from "@/features/reviews/components/ReviewCard";
 import type {
   ReviewRatingsBreakdownRow,
@@ -42,44 +42,32 @@ export function ReviewsList({ reviews, showReplyComposer }: ReviewsListProps) {
 
   return (
     <div className="space-y-6">
-      <div className="flex flex-wrap gap-2">
-        <Button
-          type="button"
-          variant={bucket === "all" ? "default" : "outline"}
-          size="sm"
-          className="gap-2"
-          onClick={() => setBucket("all")}
-        >
-          Все
-          <Badge variant="secondary" className="tabular-nums">
-            {counts.all}
-          </Badge>
-        </Button>
-        <Button
-          type="button"
-          variant={bucket === "positive" ? "default" : "outline"}
-          size="sm"
-          className="gap-2"
-          onClick={() => setBucket("positive")}
-        >
-          Положительные (4–5 ★)
-          <Badge variant="secondary" className="tabular-nums">
-            {counts.positive}
-          </Badge>
-        </Button>
-        <Button
-          type="button"
-          variant={bucket === "critical" ? "default" : "outline"}
-          size="sm"
-          className="gap-2"
-          onClick={() => setBucket("critical")}
-        >
-          Критические (1–3 ★)
-          <Badge variant="secondary" className="tabular-nums">
-            {counts.critical}
-          </Badge>
-        </Button>
-      </div>
+      <Tabs
+        defaultValue="all"
+        value={bucket}
+        onValueChange={(value) => setBucket(value as Bucket)}
+      >
+        <TabsList>
+          <TabsTrigger value="all" className="min-h-[44px] gap-2">
+            Все
+            <Badge variant="secondary" className="tabular-nums">
+              {counts.all}
+            </Badge>
+          </TabsTrigger>
+          <TabsTrigger value="positive" className="min-h-[44px] gap-2">
+            Положительные
+            <Badge variant="secondary" className="tabular-nums">
+              {counts.positive}
+            </Badge>
+          </TabsTrigger>
+          <TabsTrigger value="critical" className="min-h-[44px] gap-2">
+            Критические
+            <Badge variant="secondary" className="tabular-nums">
+              {counts.critical}
+            </Badge>
+          </TabsTrigger>
+        </TabsList>
+      </Tabs>
 
       {visible.length === 0 ? (
         <p className="text-sm text-muted-foreground">Нет отзывов в этой категории.</p>


### PR DESCRIPTION
Redesigns /guide/reviews: replaces text-glyph stars (★/☆) with Lucide Star icons, swaps the filter buttons for shadcn Tabs (≥44px, count badges), adds PageHeader (once), Alert on load error, and EmptyState for zero reviews. maskPii on bodies + reply-composer flow + bucket logic preserved.