### PR TITLE
feat(account): unified canon layout + PageHeader + language checkboxes (no native select)

### DIFF
--- a/src/app/(protected)/account/page.tsx
+++ b/src/app/(protected)/account/page.tsx
@@ -3,6 +3,7 @@ import Link from "next/link";
 
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
+import { PageHeader } from "@/components/shared/page-header";
 import { PersonalSettingsForm } from "@/features/profile/components/PersonalSettingsForm";
 import { TravelerProfileCompletionChecklist } from "@/features/profile/components/traveler-profile-completion-checklist";
 import {
@@ -107,14 +108,16 @@ export default async function PersonalSettingsPage() {
       travelerProfile.full_name?.trim() || displayNameFallback;
 
     return (
-      <div className="space-y-6">
-        <div className="space-y-2">
-          <Badge variant="outline">Кабинет путешественника</Badge>
-          <h1 className="text-3xl font-semibold tracking-tight text-foreground">
-            Профиль
-          </h1>
-        </div>
-        <TravelerProfileCompletionChecklist profile={travelerProfile} />
+      <div className="mx-auto w-full max-w-3xl space-y-6 py-8">
+        <PageHeader
+          eyebrow="Кабинет путешественника"
+          title="Профиль"
+          actions={
+            <Button asChild variant="outline">
+              <Link href="/trips">Мои запросы</Link>
+            </Button>
+          }
+        />
         <AvatarUploadBlock
           avatarUrl={travelerProfile.avatar_url}
           displayName={avatarDisplayName}
@@ -129,9 +132,7 @@ export default async function PersonalSettingsPage() {
           ].join("|")}
           profile={travelerProfile}
         />
-        <Button asChild variant="outline">
-          <Link href="/trips">Мои запросы</Link>
-        </Button>
+        <TravelerProfileCompletionChecklist profile={travelerProfile} />
       </div>
     );
   }
@@ -168,10 +169,8 @@ export default async function PersonalSettingsPage() {
       resolveDisplayName("guide", { full_name: auth.email ?? null }),
     );
     return (
-      <div className="mx-auto w-full max-w-3xl space-y-6 py-2">
-        <h1 className="font-display text-2xl text-foreground md:text-3xl">
-          Личные настройки
-        </h1>
+      <div className="mx-auto w-full max-w-3xl space-y-6 py-8">
+        <PageHeader eyebrow="Личные настройки" title="Профиль" />
         <AvatarUploadBlock avatarUrl={avatar.url} displayName={avatar.name} />
         <PersonalSettingsForm
           initialLocale={locale}

--- a/src/features/profile/components/traveler-profile-form.tsx
+++ b/src/features/profile/components/traveler-profile-form.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState } from "react";
+import { Check } from "lucide-react";
 
 import { updateTravelerProfile } from "@/features/profile/account-settings-actions";
 import { Button } from "@/components/ui/button";
@@ -30,6 +31,16 @@ export function TravelerProfileForm({ profile }: { profile: TravelerProfile }) {
   const [birthYear, setBirthYear] = useState(profile.birth_year?.toString() ?? "");
   const [error, setError] = useState<string | null>(null);
   const [bioError, setBioError] = useState<string | null>(null);
+
+  function toggleLanguage(value: string, checked: boolean) {
+    setSelectedLanguages((prev) =>
+      checked
+        ? prev.includes(value)
+          ? prev
+          : [...prev, value]
+        : prev.filter((entry) => entry !== value),
+    );
+  }
 
   async function onSubmit(formData: FormData) {
     setError(null);
@@ -94,28 +105,52 @@ export function TravelerProfileForm({ profile }: { profile: TravelerProfile }) {
             ) : null}
           </div>
 
-          <div className="grid gap-6 sm:grid-cols-2">
-            <div className="space-y-2">
-              <Label htmlFor="languages">Языки</Label>
-              <select
-                id="languages"
-                name="languages"
-                multiple
-                value={selectedLanguages}
-                onChange={(e) => {
-                  const options = Array.from(e.target.options);
-                  setSelectedLanguages(options.filter((o) => o.selected).map((o) => o.value));
-                }}
-                className="min-h-28 w-full rounded-md border border-input bg-background px-3 py-2 text-sm text-foreground shadow-xs outline-none focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50"
-              >
-                {languageOptions.map((language) => (
-                  <option key={language.value} value={language.value}>
-                    {language.label}
-                  </option>
-                ))}
-              </select>
+          <fieldset
+            aria-labelledby="languages-legend"
+            className="space-y-2"
+          >
+            <legend
+              id="languages-legend"
+              className="text-sm font-medium text-foreground"
+            >
+              Языки
+            </legend>
+            <div className="grid gap-2 sm:grid-cols-2">
+              {languageOptions.map((language) => {
+                const checked = selectedLanguages.includes(language.value);
+                const checkboxId = `language-${language.value}`;
+                return (
+                  <Label
+                    key={language.value}
+                    htmlFor={checkboxId}
+                    className="flex min-h-11 cursor-pointer items-center gap-3 rounded-md border border-input bg-background px-3 py-2 font-normal"
+                  >
+                    <span className="relative flex size-5 shrink-0 items-center justify-center">
+                      <input
+                        id={checkboxId}
+                        name="languages"
+                        type="checkbox"
+                        value={language.value}
+                        checked={checked}
+                        onChange={(event) =>
+                          toggleLanguage(language.value, event.target.checked)
+                        }
+                        className="peer size-5 cursor-pointer appearance-none rounded-[4px] border border-input bg-background outline-none checked:border-primary checked:bg-primary focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50"
+                      />
+                      <Check
+                        aria-hidden
+                        strokeWidth={3}
+                        className="pointer-events-none absolute size-3.5 text-primary-foreground opacity-0 peer-checked:opacity-100"
+                      />
+                    </span>
+                    <span className="text-sm text-foreground">{language.label}</span>
+                  </Label>
+                );
+              })}
             </div>
+          </fieldset>
 
+          <div className="grid gap-6 sm:grid-cols-2">
             <div className="space-y-2">
               <Label htmlFor="birthYear">Год рождения</Label>
               <Input


### PR DESCRIPTION
Redesigns /account: unifies the traveler+guide branches into one max-w-3xl container with PageHeader; replaces the native multi-select for languages with an accessible labeled checkbox group (≥44px, submits languages[] array); single primary Save; checklist moved below the form; /trips shortcut becomes a secondary header action. Save fields + AvatarUploadBlock + guide form preserved.