### PR TITLE
feat(guide-profile): checklist with one next-step CTA + ConfirmDialog

### DIFF
--- a/src/app/(protected)/guide/profile/page.test.tsx
+++ b/src/app/(protected)/guide/profile/page.test.tsx
@@ -146,7 +146,9 @@ describe("GuideProfilePage", () => {
       screen.getByRole("heading", { level: 1, name: "Профиль гида" }),
     ).toBeInTheDocument();
     expect(screen.getByLabelText("О себе")).toBeInTheDocument();
-    expect(screen.getByLabelText("Разделы профиля")).toBeInTheDocument();
+    expect(
+      screen.getByRole("heading", { name: "Готовность профиля" }),
+    ).toBeInTheDocument();
     expect(
       screen.getByRole("heading", { name: "Документ о квалификации" }),
     ).toBeInTheDocument();
@@ -168,7 +170,6 @@ describe("GuideProfilePage", () => {
     const ui = await GuideProfilePage();
     render(ui);
 
-    expect(screen.getByRole("link", { name: "Квалификация" })).toHaveAttribute("href", "#license");
     expect(
       screen.getAllByRole("heading", { name: /^Документ о квалификации$/ }),
     ).toHaveLength(1);

--- a/src/app/(protected)/guide/profile/page.tsx
+++ b/src/app/(protected)/guide/profile/page.tsx
@@ -9,6 +9,8 @@ import {
   CardTitle,
 } from "@/components/ui/card";
 import { GuideAboutForm } from "@/features/guide/components/profile/guide-about-form";
+import { GuideProfileChecklist } from "@/features/guide/components/profile/guide-profile-checklist";
+import type { ChecklistStep } from "@/features/guide/components/profile/guide-profile-checklist-types";
 import { LegalInformationForm } from "@/features/profile/components/LegalInformationForm";
 import {
   LicenseManager,
@@ -235,32 +237,70 @@ export default async function GuideProfilePage() {
     console.error("[GuideProfilePage] data fetch failed:", err);
   }
 
+  const avatarDone = avatarUrl != null;
+  const aboutDone =
+    (profile?.bio ?? "").trim().length > 0 &&
+    (profile?.specializations?.length ?? 0) > 0;
+  const legalDone = Boolean(
+    legalInitialData.legalStatus &&
+      legalInitialData.inn &&
+      legalInitialData.documentCountry,
+  );
+  const licenseDone = licenses.length > 0;
+  const verificationDone = verificationStatus !== "draft";
+
+  const lockedStatus: ChecklistStep["status"] = isVerifiedDataLocked
+    ? "locked"
+    : "todo";
+
+  const steps: ChecklistStep[] = [
+    {
+      id: "avatar",
+      label: "Аватар",
+      anchor: "avatar",
+      status: avatarDone ? "done" : "todo",
+    },
+    {
+      id: "about",
+      label: "О себе",
+      anchor: "about",
+      status: aboutDone ? "done" : lockedStatus,
+    },
+    {
+      id: "legal",
+      label: "Юр. данные",
+      anchor: "legal",
+      status: legalDone ? "done" : lockedStatus,
+    },
+    {
+      id: "license",
+      label: "Лицензия",
+      anchor: "license",
+      status: licenseDone ? "done" : lockedStatus,
+    },
+    {
+      id: "verification",
+      label: "Верификация",
+      anchor: "verification",
+      status: verificationDone ? "done" : "todo",
+    },
+  ];
+  const firstIncompleteStep = steps.find((step) => step.status !== "done") ?? null;
+
   return (
     <div className="space-y-10">
       <header className="space-y-2">
         <h1 className="text-3xl font-semibold tracking-tight text-foreground">Профиль гида</h1>
         <p className="text-sm text-muted-foreground">
-          Заполните разделы ниже — переходы ведут к блокам анкеты.
+          Заполните разделы ниже — мы подскажем следующий шаг.
         </p>
       </header>
 
-      <nav aria-label="Разделы профиля" className="flex flex-wrap gap-2">
-        {[
-          ["#avatar", "Фото"],
-          ["#about", "О себе"],
-          ["#legal", "Юридические данные"],
-          ["#license", "Квалификация"],
-          ["#verification", "Верификация"],
-        ].map(([href, label]) => (
-          <a
-            key={href}
-            href={href}
-            className="inline-flex h-9 items-center rounded-md border border-border/70 bg-background px-3 text-sm font-medium text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
-          >
-            {label}
-          </a>
-        ))}
-      </nav>
+      <GuideProfileChecklist
+        steps={steps}
+        firstIncompleteStep={firstIncompleteStep}
+        verificationStatus={verificationStatus}
+      />
 
       <GuideProfileSectionBoundary id="avatar" title="Фото">
         {() => <AvatarUploadBlock avatarUrl={avatarUrl} displayName={displayName} />}

--- a/src/features/guide/components/profile/guide-profile-checklist-types.ts
+++ b/src/features/guide/components/profile/guide-profile-checklist-types.ts
@@ -1,0 +1,16 @@
+import type { GuideVerificationStatusDb } from "@/lib/supabase/types";
+
+export type ChecklistStepStatus = "done" | "todo" | "locked";
+
+export type ChecklistStep = {
+  id: string;
+  label: string;
+  anchor: string;
+  status: ChecklistStepStatus;
+};
+
+export type GuideProfileChecklistProps = {
+  steps: ChecklistStep[];
+  firstIncompleteStep: ChecklistStep | null;
+  verificationStatus: GuideVerificationStatusDb;
+};

--- a/src/features/guide/components/profile/guide-profile-checklist.tsx
+++ b/src/features/guide/components/profile/guide-profile-checklist.tsx
@@ -1,0 +1,124 @@
+"use client";
+
+import { CircleCheck, Circle, Lock, ShieldCheck } from "lucide-react";
+
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import { cn } from "@/lib/utils";
+
+import type {
+  ChecklistStep,
+  ChecklistStepStatus,
+  GuideProfileChecklistProps,
+} from "./guide-profile-checklist-types";
+
+function scrollToAnchor(anchor: string) {
+  document
+    .getElementById(anchor)
+    ?.scrollIntoView({ behavior: "smooth", block: "start" });
+}
+
+const STATUS_META: Record<
+  ChecklistStepStatus,
+  {
+    label: string;
+    badgeVariant: "default" | "outline" | "secondary";
+    Icon: typeof CircleCheck;
+    iconClass: string;
+  }
+> = {
+  done: {
+    label: "Готово",
+    badgeVariant: "default",
+    Icon: CircleCheck,
+    iconClass: "text-success",
+  },
+  todo: {
+    label: "Нужно заполнить",
+    badgeVariant: "outline",
+    Icon: Circle,
+    iconClass: "text-muted-foreground",
+  },
+  locked: {
+    label: "Заблокировано",
+    badgeVariant: "secondary",
+    Icon: Lock,
+    iconClass: "text-muted-foreground",
+  },
+};
+
+function ChecklistRow({ step }: { step: ChecklistStep }) {
+  const meta = STATUS_META[step.status];
+  const { Icon } = meta;
+  return (
+    <li className="flex items-center justify-between gap-3 rounded-lg border border-border/70 bg-background/60 px-4 py-3">
+      <span className="flex items-center gap-2.5">
+        <Icon className={cn("size-5 shrink-0", meta.iconClass)} aria-hidden />
+        <span className="text-sm font-medium text-foreground">{step.label}</span>
+      </span>
+      <Badge variant={meta.badgeVariant}>{meta.label}</Badge>
+    </li>
+  );
+}
+
+export function GuideProfileChecklist({
+  steps,
+  firstIncompleteStep,
+  verificationStatus,
+}: GuideProfileChecklistProps) {
+  const isApproved = verificationStatus === "approved";
+  const isSubmitted = verificationStatus === "submitted";
+  const showStatusBadge = isApproved || isSubmitted;
+
+  const showFillCta =
+    !showStatusBadge &&
+    firstIncompleteStep !== null &&
+    firstIncompleteStep.id !== "verification";
+  const showSubmitCta = !showStatusBadge && !showFillCta;
+
+  return (
+    <Card className="border-border/70 bg-card/90">
+      <CardHeader>
+        <CardTitle className="text-xl">Готовность профиля</CardTitle>
+        <CardDescription>
+          Заполните шаги ниже, чтобы отправить профиль на проверку.
+        </CardDescription>
+      </CardHeader>
+      <CardContent className="space-y-5">
+        <ul className="space-y-2.5">
+          {steps.map((step) => (
+            <ChecklistRow key={step.id} step={step} />
+          ))}
+        </ul>
+
+        {showStatusBadge ? (
+          <Badge
+            variant={isApproved ? "default" : "secondary"}
+            className="gap-1.5"
+          >
+            <ShieldCheck className="size-3.5" aria-hidden />
+            {isApproved ? "Профиль подтверждён" : "Отправлено на проверку"}
+          </Badge>
+        ) : showFillCta && firstIncompleteStep ? (
+          <Button
+            type="button"
+            onClick={() => scrollToAnchor(firstIncompleteStep.anchor)}
+          >
+            Заполнить
+          </Button>
+        ) : showSubmitCta ? (
+          <Button type="button" onClick={() => scrollToAnchor("verification")}>
+            Подать на верификацию
+          </Button>
+        ) : null}
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/features/profile/components/LicenseManager.tsx
+++ b/src/features/profile/components/LicenseManager.tsx
@@ -1,12 +1,14 @@
 "use client";
 
 import { useRouter } from "next/navigation";
-import { useTransition } from "react";
+import { useState, useTransition } from "react";
 
 import { deleteLicense } from "@/features/profile/actions/licenseActions";
+import { Alert, AlertDescription } from "@/components/ui/alert";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { useConfirm } from "@/components/shared/confirm-dialog";
 
 export type GuideLicenseView = {
   id: string;
@@ -31,15 +33,24 @@ type Props = {
 export function LicenseManager({ licenses, isLocked = false }: Props) {
   const router = useRouter();
   const [pending, startTransition] = useTransition();
+  const [deleteError, setDeleteError] = useState<string | null>(null);
+  const { confirm, ConfirmDialog } = useConfirm();
 
-  function handleDelete(id: string) {
-    if (!window.confirm("Удалить этот документ?")) return;
+  async function handleDelete(id: string) {
+    const ok = await confirm({
+      title: "Удалить лицензию?",
+      description: "Это действие нельзя отменить.",
+      confirmText: "Удалить",
+      destructive: true,
+    });
+    if (!ok) return;
+    setDeleteError(null);
     startTransition(async () => {
       try {
         await deleteLicense(id);
         router.refresh();
       } catch (e) {
-        window.alert(e instanceof Error ? e.message : "Ошибка удаления");
+        setDeleteError(e instanceof Error ? e.message : "Ошибка при удалении");
       }
     });
   }
@@ -53,8 +64,14 @@ export function LicenseManager({ licenses, isLocked = false }: Props) {
   }
 
   return (
-    <ul className="space-y-4">
-      {licenses.map((lic) => (
+    <div className="space-y-4">
+      {deleteError ? (
+        <Alert variant="destructive">
+          <AlertDescription>{deleteError}</AlertDescription>
+        </Alert>
+      ) : null}
+      <ul className="space-y-4">
+        {licenses.map((lic) => (
         <li key={lic.id}>
           <Card className="border-border/80">
             <CardHeader className="flex flex-row flex-wrap items-start justify-between gap-3 space-y-0 pb-2">
@@ -72,7 +89,9 @@ export function LicenseManager({ licenses, isLocked = false }: Props) {
                 variant="destructive"
                 size="sm"
                 disabled={pending || isLocked}
-                onClick={() => handleDelete(lic.id)}
+                onClick={() => {
+                  void handleDelete(lic.id);
+                }}
               >
                 Удалить
               </Button>
@@ -95,7 +114,9 @@ export function LicenseManager({ licenses, isLocked = false }: Props) {
             </CardContent>
           </Card>
         </li>
-      ))}
-    </ul>
+        ))}
+      </ul>
+      {ConfirmDialog}
+    </div>
   );
 }


### PR DESCRIPTION
Restructures /guide/profile as a completion checklist with one clear next-step CTA (computed server-side, rendered by a new client component); replaces window.confirm/alert in LicenseManager with useConfirm/ConfirmDialog + inline Alert. Save flows + verified-data lock + section boundaries preserved.