### PR TITLE
feat(admin-moderation): split listings/replies into tabs + ListRow + one primary action

### DIFF
--- a/src/app/(protected)/admin/moderation/page.test.tsx
+++ b/src/app/(protected)/admin/moderation/page.test.tsx
@@ -78,7 +78,10 @@ describe("ModerationQueuePage", () => {
     expect(adminClient.from).toHaveBeenCalledWith("listings");
     expect(adminClient.from).toHaveBeenCalledWith("review_replies");
     expect(serverClient.from).not.toHaveBeenCalled();
+
     expect(screen.getByTestId("moderation-queue")).toHaveTextContent("Ладога на каяке");
-    expect(screen.getByText("Спасибо за отзыв")).toBeInTheDocument();
+
+    expect(screen.getByRole("tab", { name: /Объявления/ })).toHaveTextContent("1");
+    expect(screen.getByRole("tab", { name: /Ответы на отзывы/ })).toHaveTextContent("1");
   });
 });

--- a/src/app/(protected)/admin/moderation/page.tsx
+++ b/src/app/(protected)/admin/moderation/page.tsx
@@ -1,7 +1,13 @@
 import type { Metadata } from "next";
 
+import { EmptyState } from "@/components/shared/empty-state";
+import { ListRow } from "@/components/shared/list-row";
+import { PageHeader } from "@/components/shared/page-header";
 import { Badge } from "@/components/ui/badge";
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { ModerationQueueList } from "@/features/admin/components/ModerationQueueItem";
+import { formatRussianDateTime } from "@/lib/dates";
+import { maskPii } from "@/lib/pii/mask";
 import { requireAdminSession } from "@/lib/supabase/moderation";
 
 export const metadata: Metadata = {
@@ -26,40 +32,58 @@ export default async function ModerationQueuePage() {
     .limit(20);
 
   const listingRows = listings ?? [];
+  const replyRows = replies ?? [];
 
   return (
     <div className="container mx-auto py-8">
-      <h1 className="mb-6 text-2xl font-bold">Очередь модерации</h1>
+      <PageHeader eyebrow="Администратор" title="Очередь модерации" />
 
-      <section className="mb-10">
-        <h2 className="mb-4 text-lg font-semibold">
-          Объявления ({listingRows.length})
-        </h2>
-        {listingRows.length === 0 ? (
-          <p className="text-muted-foreground">Нет объявлений на проверке</p>
-        ) : (
-          <ModerationQueueList listings={listingRows} />
-        )}
-      </section>
+      <Tabs defaultValue="listings" className="mt-8">
+        <TabsList>
+          <TabsTrigger value="listings">
+            Объявления
+            <Badge variant="secondary">{listingRows.length}</Badge>
+          </TabsTrigger>
+          <TabsTrigger value="replies">
+            Ответы на отзывы
+            <Badge variant="secondary">{replyRows.length}</Badge>
+          </TabsTrigger>
+        </TabsList>
 
-      {replies && replies.length > 0 ? (
-        <section>
-          <h2 className="mb-4 text-lg font-semibold">
-            Ответы на отзывы ({replies.length})
-          </h2>
-          <div className="space-y-2">
-            {replies.map((reply) => (
-              <div
-                key={reply.id}
-                className="flex items-start gap-4 rounded-card border border-border p-4"
-              >
-                <p className="line-clamp-2 flex-1 text-sm">{reply.body}</p>
-                <Badge variant="secondary">На проверке</Badge>
-              </div>
-            ))}
-          </div>
-        </section>
-      ) : null}
+        <TabsContent value="listings">
+          {listingRows.length === 0 ? (
+            <EmptyState
+              title="Очередь пуста"
+              description="Нет объявлений на проверке."
+            />
+          ) : (
+            <ModerationQueueList listings={listingRows} />
+          )}
+        </TabsContent>
+
+        <TabsContent value="replies">
+          {replyRows.length === 0 ? (
+            <EmptyState
+              title="Очередь пуста"
+              description="Нет ответов на отзывы на проверке."
+            />
+          ) : (
+            <div className="space-y-2">
+              <p className="text-sm text-muted-foreground">
+                Ответы модерируются вручную — действия в разработке.
+              </p>
+              {replyRows.map((reply) => (
+                <ListRow
+                  key={reply.id}
+                  title={maskPii(reply.body)}
+                  subtitle={formatRussianDateTime(reply.submitted_at)}
+                  badge={<Badge>На проверке</Badge>}
+                />
+              ))}
+            </div>
+          )}
+        </TabsContent>
+      </Tabs>
     </div>
   );
 }

--- a/src/features/admin/components/ModerationQueueItem.tsx
+++ b/src/features/admin/components/ModerationQueueItem.tsx
@@ -88,6 +88,7 @@ export function ModerationQueueItem({ listing, onAction }: ModerationQueueItemPr
       onAction();
     } catch (e) {
       setError(e instanceof Error ? e.message : "Не удалось одобрить");
+    } finally {
       setBusy(false);
     }
   }
@@ -107,6 +108,7 @@ export function ModerationQueueItem({ listing, onAction }: ModerationQueueItemPr
       onAction();
     } catch (e) {
       setError(e instanceof Error ? e.message : "Не удалось отклонить");
+    } finally {
       setBusy(false);
     }
   }

--- a/src/features/admin/components/ModerationQueueItem.tsx
+++ b/src/features/admin/components/ModerationQueueItem.tsx
@@ -3,22 +3,31 @@
 import * as React from "react";
 import Link from "next/link";
 import { useRouter } from "next/navigation";
+import { MoreVertical } from "lucide-react";
 
-import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import {
-  Card,
-  CardContent,
-  CardFooter,
-  CardHeader,
-  CardTitle,
-} from "@/components/ui/card";
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
 import { Textarea } from "@/components/ui/textarea";
+import { ListRow } from "@/components/shared/list-row";
 import {
   approveListing,
   rejectListing,
 } from "@/features/admin/actions/moderateListing";
+import { formatRussianDateTime } from "@/lib/dates";
 import { maskPii } from "@/lib/pii/mask";
 import type { ListingRow } from "@/lib/supabase/types";
 
@@ -50,7 +59,7 @@ export function ModerationQueueList({
 }) {
   const router = useRouter();
   return (
-    <div className="space-y-4">
+    <div className="space-y-2">
       {listings.map((listing) => (
         <ModerationQueueItem
           key={listing.id}
@@ -63,29 +72,22 @@ export function ModerationQueueList({
 }
 
 export function ModerationQueueItem({ listing, onAction }: ModerationQueueItemProps) {
-  const [showReject, setShowReject] = React.useState(false);
+  const [rejectOpen, setRejectOpen] = React.useState(false);
   const [reason, setReason] = React.useState("");
   const [busy, setBusy] = React.useState(false);
   const [error, setError] = React.useState<string | null>(null);
-  const [success, setSuccess] = React.useState<string | null>(null);
 
   const maskedDescription = maskPii(listing.description);
-
-  function runAfterSuccess() {
-    onAction();
-  }
+  const subtitle = [listing.region, listing.exp_type].filter(Boolean).join(" · ");
 
   async function handleApprove() {
     setError(null);
-    setSuccess(null);
     setBusy(true);
     try {
       await approveListing(listing.id);
-      setSuccess("Объявление одобрено");
-      runAfterSuccess();
+      onAction();
     } catch (e) {
       setError(e instanceof Error ? e.message : "Не удалось одобрить");
-    } finally {
       setBusy(false);
     }
   }
@@ -97,131 +99,143 @@ export function ModerationQueueItem({ listing, onAction }: ModerationQueueItemPr
       return;
     }
     setError(null);
-    setSuccess(null);
     setBusy(true);
     try {
       await rejectListing(listing.id, trimmed);
-      setShowReject(false);
+      setRejectOpen(false);
       setReason("");
-      setSuccess("Объявление отклонено");
-      runAfterSuccess();
+      onAction();
     } catch (e) {
       setError(e instanceof Error ? e.message : "Не удалось отклонить");
-    } finally {
       setBusy(false);
     }
   }
 
   return (
-    <Card className="border-border/70 bg-card/90">
-      <CardHeader className="space-y-2">
-        <div className="flex flex-col gap-2 sm:flex-row sm:items-start sm:justify-between">
-          <div className="min-w-0 space-y-2">
-            <CardTitle className="text-lg leading-snug">{listing.title}</CardTitle>
-            <div className="flex flex-wrap items-center gap-2 text-sm text-muted-foreground">
-              <span>{listing.region}</span>
-              {listing.exp_type ? (
-                <Badge variant="secondary">{listing.exp_type}</Badge>
-              ) : null}
-            </div>
+    <div className="space-y-1.5">
+      <ListRow
+        title={listing.title}
+        subtitle={subtitle}
+        badge={
+          <div className="flex items-center gap-2">
+            <Badge>На проверке</Badge>
+            <span className="text-xs text-muted-foreground">
+              {formatRussianDateTime(listing.created_at)}
+            </span>
           </div>
-          <Button asChild variant="outline" size="sm" className="shrink-0">
-            <Link href={`/listings/${listing.id}`}>Посмотреть объявление</Link>
-          </Button>
-        </div>
-      </CardHeader>
-      <CardContent className="space-y-4">
-        {maskedDescription ? (
-          <p className="line-clamp-3 text-sm text-muted-foreground">{maskedDescription}</p>
-        ) : null}
-
-        {error ? (
-          <Alert variant="destructive">
-            <AlertTitle>Ошибка</AlertTitle>
-            <AlertDescription>{error}</AlertDescription>
-          </Alert>
-        ) : null}
-
-        {success ? (
-          <Alert className="border-success/30 bg-success/10 text-success">
-            <AlertTitle>Готово</AlertTitle>
-            <AlertDescription className="text-success/90">{success}</AlertDescription>
-          </Alert>
-        ) : null}
-
-        {showReject ? (
-          <div className="space-y-3">
-            <p className="text-sm font-medium text-foreground">Причина отклонения</p>
-            <div className="flex flex-wrap gap-2">
-              {CANNED_REJECTION_REASONS.map((label) => (
+        }
+        actions={
+          <>
+            <Button
+              type="button"
+              size="sm"
+              disabled={busy}
+              className="border-success/30 bg-success/10 text-success hover:bg-success/20"
+              onClick={() => void handleApprove()}
+            >
+              Одобрить
+            </Button>
+            <DropdownMenu>
+              <DropdownMenuTrigger asChild>
                 <Button
-                  key={label}
                   type="button"
                   variant="outline"
-                  size="sm"
-                  onClick={() => setReason(label)}
+                  size="icon"
+                  aria-label="Ещё действия"
+                  disabled={busy}
                 >
-                  {label}
+                  <MoreVertical />
                 </Button>
-              ))}
-            </div>
-            <Textarea
-              value={reason}
-              onChange={(e) => setReason(e.target.value)}
-              placeholder="Текст причины…"
-              aria-label="Причина отклонения"
-              rows={4}
-            />
-            <div className="flex flex-wrap gap-2">
-              <Button
-                type="button"
-                variant="destructive"
-                size="sm"
-                disabled={busy}
-                onClick={() => void handleConfirmReject()}
-              >
-                Подтвердить отклонение
-              </Button>
-              <Button
-                type="button"
-                variant="ghost"
-                size="sm"
-                disabled={busy}
-                onClick={() => {
-                  setShowReject(false);
-                  setReason("");
-                  setError(null);
-                }}
-              >
-                Отмена
-              </Button>
-            </div>
-          </div>
-        ) : null}
-      </CardContent>
-      <CardFooter className="flex flex-wrap gap-2">
-        <Button
-          type="button"
-          size="sm"
-          disabled={busy || showReject || success !== null}
-          className="border-success/30 bg-success/10 text-success hover:bg-success/20"
-          onClick={() => void handleApprove()}
-        >
-          Одобрить
-        </Button>
-        <Button
-          type="button"
-          variant="destructive"
-          size="sm"
-          disabled={busy || success !== null}
-          onClick={() => {
-            setShowReject(true);
+              </DropdownMenuTrigger>
+              <DropdownMenuContent align="end">
+                <DropdownMenuItem
+                  variant="destructive"
+                  onSelect={() => {
+                    setError(null);
+                    setRejectOpen(true);
+                  }}
+                >
+                  Отклонить
+                </DropdownMenuItem>
+                <DropdownMenuItem asChild>
+                  <Link href={`/listings/${listing.id}`}>Посмотреть объявление</Link>
+                </DropdownMenuItem>
+              </DropdownMenuContent>
+            </DropdownMenu>
+          </>
+        }
+      />
+
+      {error && !rejectOpen ? (
+        <p className="px-1 text-sm text-destructive">{error}</p>
+      ) : null}
+
+      <Dialog
+        open={rejectOpen}
+        onOpenChange={(open) => {
+          setRejectOpen(open);
+          if (!open) {
+            setReason("");
             setError(null);
-          }}
-        >
-          Отклонить
-        </Button>
-      </CardFooter>
-    </Card>
+          }
+        }}
+      >
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>Отклонить объявление</DialogTitle>
+            <DialogDescription>
+              Укажите причину отклонения — выберите готовую или впишите свою.
+            </DialogDescription>
+          </DialogHeader>
+
+          {maskedDescription ? (
+            <p className="line-clamp-3 text-sm text-muted-foreground">{maskedDescription}</p>
+          ) : null}
+
+          <div className="flex flex-wrap gap-2">
+            {CANNED_REJECTION_REASONS.map((label) => (
+              <Button
+                key={label}
+                type="button"
+                variant="outline"
+                size="sm"
+                onClick={() => setReason(label)}
+              >
+                {label}
+              </Button>
+            ))}
+          </div>
+
+          <Textarea
+            value={reason}
+            onChange={(e) => setReason(e.target.value)}
+            placeholder="Текст причины…"
+            aria-label="Причина отклонения"
+            rows={4}
+          />
+
+          {error ? <p className="text-sm text-destructive">{error}</p> : null}
+
+          <DialogFooter>
+            <Button
+              type="button"
+              variant="ghost"
+              disabled={busy}
+              onClick={() => setRejectOpen(false)}
+            >
+              Отмена
+            </Button>
+            <Button
+              type="button"
+              variant="destructive"
+              disabled={busy}
+              onClick={() => void handleConfirmReject()}
+            >
+              Подтвердить отклонение
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+    </div>
   );
 }


### PR DESCRIPTION
Redesigns /admin/moderation: shadcn Tabs split listing-moderation vs reply-moderation (reply tab display-only), ListRow rows, one primary Одобрить + Отклонить (reject reason in a Dialog), PageHeader, EmptyState. Approve/reject via direct server-action calls (portal-safe), busy state reset in finally. maskPii + both queries + admin gate preserved.