### PR TITLE
feat(guide-calendar): Tabs split + surfaced errors + semantic dots + responsive grid

### DIFF
--- a/src/app/(protected)/guide/calendar/page.tsx
+++ b/src/app/(protected)/guide/calendar/page.tsx
@@ -33,7 +33,7 @@ function formatDateOnlyLocal(d: Date): string {
 }
 
 function rangeStartDate(range: DateRangePreset): Date {
-  const d = new Date();
+  const d = new Date(`${todayMoscowISODate()}T00:00:00`);
   if (range === "7d") d.setDate(d.getDate() - 7);
   else if (range === "90d") d.setDate(d.getDate() - 90);
   else d.setDate(d.getDate() - 30);
@@ -67,6 +67,8 @@ export default async function GuideCalendarPage({
   const rawRange = resolvedParams.range;
   const range: DateRangePreset =
     rawRange === "7d" || rawRange === "90d" ? rawRange : "30d";
+
+  const todayStr = todayMoscowISODate();
 
   const supabase = await createSupabaseServerClient();
   const {
@@ -110,7 +112,6 @@ export default async function GuideCalendarPage({
 
     const listingIds = listings.map((l) => l.id);
 
-    const todayStr = todayMoscowISODate();
     const [todayYear, todayMonth] = todayStr.split("-").map(Number);
     const twoMonthsOut = new Date(todayYear ?? 0, (todayMonth ?? 1) - 1 + 2, 1);
     const twoMonthsOutStr = formatDateOnlyLocal(twoMonthsOut);
@@ -208,6 +209,7 @@ export default async function GuideCalendarPage({
                 </TabsList>
                 <TabsContent value="week" className="mt-0">
                   <WeeklyCalendar
+                    todayStr={todayStr}
                     schedules={schedules}
                     extras={extras}
                     departures={departures}
@@ -216,6 +218,7 @@ export default async function GuideCalendarPage({
                 </TabsContent>
                 <TabsContent value="month" className="mt-0">
                   <MonthlyCalendar
+                    todayStr={todayStr}
                     schedules={schedules}
                     extras={extras}
                     departures={departures}

--- a/src/app/(protected)/guide/calendar/page.tsx
+++ b/src/app/(protected)/guide/calendar/page.tsx
@@ -1,7 +1,10 @@
 import type { Metadata } from "next";
 
+import { PageHeader } from "@/components/shared/page-header";
+import { Alert, AlertDescription } from "@/components/ui/alert";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
+import { kopecksToRub } from "@/data/money";
 import { MonthlyCalendar } from "@/features/guide/components/calendar/MonthlyCalendar";
 import { WeeklyCalendar } from "@/features/guide/components/calendar/WeeklyCalendar";
 import {
@@ -9,6 +12,7 @@ import {
   type DateRangePreset,
 } from "@/features/guide/components/statistics/DateRangePicker";
 import { StatsChart } from "@/features/guide/components/statistics/StatsChart";
+import { todayMoscowISODate } from "@/lib/dates";
 import { createSupabaseServerClient } from "@/lib/supabase/server";
 import type {
   BookingRow,
@@ -57,6 +61,7 @@ export default async function GuideCalendarPage({
   let departures: ListingTourDepartureRow[] = [];
   let listings: { id: string; title: string; exp_type: string | null }[] = [];
   let bookings: BookingRow[] = [];
+  let loadFailed = false;
 
   const resolvedParams = await searchParams;
   const rawRange = resolvedParams.range;
@@ -105,9 +110,9 @@ export default async function GuideCalendarPage({
 
     const listingIds = listings.map((l) => l.id);
 
-    const today = new Date();
-    const todayStr = formatDateOnlyLocal(today);
-    const twoMonthsOut = new Date(today.getFullYear(), today.getMonth() + 2, 1);
+    const todayStr = todayMoscowISODate();
+    const [todayYear, todayMonth] = todayStr.split("-").map(Number);
+    const twoMonthsOut = new Date(todayYear ?? 0, (todayMonth ?? 1) - 1 + 2, 1);
     const twoMonthsOutStr = formatDateOnlyLocal(twoMonthsOut);
     const rangeStart = formatDateOnlyLocal(rangeStartDate(range));
 
@@ -148,11 +153,7 @@ export default async function GuideCalendarPage({
       bookings = (bookingsRaw ?? []) as BookingRow[];
     }
   } catch {
-    schedules = [];
-    extras = [];
-    departures = [];
-    listings = [];
-    bookings = [];
+    loadFailed = true;
   }
 
   const listingSummaries = listings.map((l) => ({
@@ -168,89 +169,108 @@ export default async function GuideCalendarPage({
   );
   const completedBookings = bookings.filter((b) => b.status === "completed");
   const totalRevenue = completedBookings.reduce(
-    (sum, b) => sum + Math.round(b.subtotal_minor / 100),
+    (sum, b) => sum + kopecksToRub(b.subtotal_minor),
     0,
   );
   const chartData = groupByDay(bookings);
 
   return (
     <div className="space-y-6">
-      <Card className="border-border/70 bg-card/90">
-        <CardHeader>
-          <CardTitle className="text-xl">Календарь</CardTitle>
-          <p className="text-sm text-muted-foreground">
-            Расписание слотов и даты отправлений по вашим активным экскурсиям.
-          </p>
-        </CardHeader>
-        <CardContent>
-          <Tabs defaultValue="week">
-            <TabsList className="mb-4 grid w-full max-w-md grid-cols-2">
-              <TabsTrigger value="week">Неделя</TabsTrigger>
-              <TabsTrigger value="month">Месяц</TabsTrigger>
-            </TabsList>
-            <TabsContent value="week" className="mt-0">
-              <WeeklyCalendar
-                schedules={schedules}
-                extras={extras}
-                departures={departures}
-                listings={listingSummaries}
-              />
-            </TabsContent>
-            <TabsContent value="month" className="mt-0">
-              <MonthlyCalendar
-                schedules={schedules}
-                extras={extras}
-                departures={departures}
-                listings={listingSummaries}
-              />
-            </TabsContent>
-          </Tabs>
-        </CardContent>
-      </Card>
+      <PageHeader eyebrow="Кабинет гида" title="Календарь" />
 
-      <section id="stats">
-        <Card className="border-border/70 bg-card/90">
-          <CardHeader>
-            <CardTitle className="text-xl">Статистика</CardTitle>
-            <p className="text-sm text-muted-foreground">
-              Бронирования и оборот за выбранный период.
-            </p>
-          </CardHeader>
-          <CardContent className="space-y-6">
-            <DateRangePicker value={range} />
-            <div className="grid gap-3 sm:grid-cols-3">
-              <div className="rounded-lg border border-border/70 bg-background/60 p-3">
-                <p className="text-xs text-muted-foreground">Всего бронирований</p>
-                <p className="mt-1 text-base font-semibold">{bookings.length}</p>
-              </div>
-              <div className="rounded-lg border border-border/70 bg-background/60 p-3">
-                <p className="text-xs text-muted-foreground">Активных</p>
-                <p className="mt-1 text-base font-semibold">{activeBookings.length}</p>
-              </div>
-              <div className="rounded-lg border border-border/70 bg-background/60 p-3">
-                <p className="text-xs text-muted-foreground">Оборот (завершённые)</p>
-                <p className="mt-1 text-base font-semibold">
-                  {totalRevenue > 0
-                    ? new Intl.NumberFormat("ru-RU", {
-                        style: "currency",
-                        currency: "RUB",
-                        currencyDisplay: "symbol",
-                        maximumFractionDigits: 0,
-                      }).format(totalRevenue)
-                    : "—"}
-                </p>
-              </div>
-            </div>
-            {chartData.length > 0 ? (
-              <StatsChart data={chartData} label="Бронирований в день" />
-            ) : (
+      {loadFailed ? (
+        <Alert variant="destructive">
+          <AlertDescription>
+            Ошибка загрузки календаря. Попробуйте обновить страницу.
+          </AlertDescription>
+        </Alert>
+      ) : null}
+
+      <Tabs defaultValue="calendar">
+        <TabsList className="grid w-full max-w-md grid-cols-2">
+          <TabsTrigger value="calendar">Расписание</TabsTrigger>
+          <TabsTrigger value="stats">Статистика</TabsTrigger>
+        </TabsList>
+
+        <TabsContent value="calendar" className="mt-4">
+          <Card className="border-border/70 bg-card/90">
+            <CardHeader>
+              <CardTitle className="text-xl">Расписание</CardTitle>
               <p className="text-sm text-muted-foreground">
-                Нет данных за выбранный период.
+                Расписание слотов и даты отправлений по вашим активным экскурсиям.
               </p>
-            )}
-          </CardContent>
-        </Card>
-      </section>
+            </CardHeader>
+            <CardContent>
+              <Tabs defaultValue="week">
+                <TabsList className="mb-4 grid w-full max-w-md grid-cols-2">
+                  <TabsTrigger value="week">Неделя</TabsTrigger>
+                  <TabsTrigger value="month">Месяц</TabsTrigger>
+                </TabsList>
+                <TabsContent value="week" className="mt-0">
+                  <WeeklyCalendar
+                    schedules={schedules}
+                    extras={extras}
+                    departures={departures}
+                    listings={listingSummaries}
+                  />
+                </TabsContent>
+                <TabsContent value="month" className="mt-0">
+                  <MonthlyCalendar
+                    schedules={schedules}
+                    extras={extras}
+                    departures={departures}
+                    listings={listingSummaries}
+                  />
+                </TabsContent>
+              </Tabs>
+            </CardContent>
+          </Card>
+        </TabsContent>
+
+        <TabsContent value="stats" className="mt-4">
+          <Card id="stats" className="border-border/70 bg-card/90">
+            <CardHeader>
+              <CardTitle className="text-xl">Статистика</CardTitle>
+              <p className="text-sm text-muted-foreground">
+                Бронирования и оборот за выбранный период.
+              </p>
+            </CardHeader>
+            <CardContent className="space-y-6">
+              <DateRangePicker value={range} />
+              <div className="grid gap-3 sm:grid-cols-3">
+                <div className="rounded-lg border border-border/70 bg-background/60 p-3">
+                  <p className="text-xs text-muted-foreground">Всего бронирований</p>
+                  <p className="mt-1 text-base font-semibold">{bookings.length}</p>
+                </div>
+                <div className="rounded-lg border border-border/70 bg-background/60 p-3">
+                  <p className="text-xs text-muted-foreground">Активных</p>
+                  <p className="mt-1 text-base font-semibold">{activeBookings.length}</p>
+                </div>
+                <div className="rounded-lg border border-border/70 bg-background/60 p-3">
+                  <p className="text-xs text-muted-foreground">Оборот (завершённые)</p>
+                  <p className="mt-1 text-base font-semibold">
+                    {totalRevenue > 0
+                      ? new Intl.NumberFormat("ru-RU", {
+                          style: "currency",
+                          currency: "RUB",
+                          currencyDisplay: "symbol",
+                          maximumFractionDigits: 0,
+                        }).format(totalRevenue)
+                      : "—"}
+                  </p>
+                </div>
+              </div>
+              {chartData.length > 0 ? (
+                <StatsChart data={chartData} label="Бронирований в день" />
+              ) : (
+                <p className="text-sm text-muted-foreground">
+                  Нет данных за выбранный период.
+                </p>
+              )}
+            </CardContent>
+          </Card>
+        </TabsContent>
+      </Tabs>
     </div>
   );
 }

--- a/src/features/guide/components/calendar/MonthlyCalendar.test.tsx
+++ b/src/features/guide/components/calendar/MonthlyCalendar.test.tsx
@@ -13,6 +13,7 @@ describe("MonthlyCalendar", () => {
   it("requires an explicit listing selection before opening the day panel", () => {
     render(
       <MonthlyCalendar
+        todayStr="2026-01-15"
         schedules={[]}
         extras={[]}
         departures={[]}

--- a/src/features/guide/components/calendar/MonthlyCalendar.tsx
+++ b/src/features/guide/components/calendar/MonthlyCalendar.tsx
@@ -10,15 +10,6 @@ import type {
 } from "@/lib/supabase/types";
 import { DayPanel } from "./day-panel";
 
-const LISTING_DOT_CLASSES = [
-  "bg-primary",
-  "bg-success",
-  "bg-warning",
-  "bg-destructive",
-  "bg-brand-500",
-  "bg-gold",
-] as const;
-
 function formatDateOnlyLocal(d: Date): string {
   const y = d.getFullYear();
   const m = String(d.getMonth() + 1).padStart(2, "0");
@@ -55,10 +46,10 @@ export function MonthlyCalendar({
     return m;
   }, [listings]);
 
-  const listingColorClass = React.useMemo(() => {
+  const listingDotClass = React.useMemo(() => {
     const m = new Map<string, string>();
     listings.forEach((l, i) => {
-      m.set(l.id, LISTING_DOT_CLASSES[i % LISTING_DOT_CLASSES.length]!);
+      m.set(l.id, i % 2 === 0 ? "bg-primary" : "bg-primary/50");
     });
     return m;
   }, [listings]);
@@ -193,7 +184,7 @@ export function MonthlyCalendar({
                 {[...listingIdsWithSlot].map((id) => (
                   <span
                     key={id}
-                    className={`size-1.5 shrink-0 rounded-full ${listingColorClass.get(id) ?? "bg-muted-foreground"}`}
+                    className={`size-1.5 shrink-0 rounded-full ${listingDotClass.get(id) ?? "bg-primary"}`}
                     title={titleByListingId.get(id) ?? ""}
                   />
                 ))}
@@ -207,6 +198,17 @@ export function MonthlyCalendar({
             </button>
           );
         })}
+      </div>
+
+      <div className="flex flex-wrap items-center gap-4 text-xs text-muted-foreground">
+        <span className="inline-flex items-center gap-1.5">
+          <span className="size-1.5 shrink-0 rounded-full bg-primary" />
+          Слот
+        </span>
+        <span className="inline-flex items-center gap-1.5">
+          <span className="size-1.5 shrink-0 rounded-sm bg-gold ring-1 ring-gold/40" />
+          Отправление
+        </span>
       </div>
 
       {dayPanelDate && dayPanelListing && (

--- a/src/features/guide/components/calendar/MonthlyCalendar.tsx
+++ b/src/features/guide/components/calendar/MonthlyCalendar.tsx
@@ -23,6 +23,7 @@ function jsDayToDbWeekday(date: Date): number {
 }
 
 export type MonthlyCalendarProps = {
+  todayStr: string;
   schedules: ListingScheduleRow[];
   extras: ListingScheduleExtraRow[];
   departures: ListingTourDepartureRow[];
@@ -30,6 +31,7 @@ export type MonthlyCalendarProps = {
 };
 
 export function MonthlyCalendar({
+  todayStr,
   schedules,
   extras,
   departures,
@@ -61,12 +63,12 @@ export function MonthlyCalendar({
   }, [listings, selectedListingId]);
 
   const visibleMonth = React.useMemo(() => {
-    const d = new Date();
+    const d = new Date(`${todayStr}T00:00:00`);
     d.setMonth(d.getMonth() + monthOffset);
     d.setDate(1);
     d.setHours(0, 0, 0, 0);
     return d;
-  }, [monthOffset]);
+  }, [monthOffset, todayStr]);
 
   const monthTitle = React.useMemo(
     () =>

--- a/src/features/guide/components/calendar/WeeklyCalendar.tsx
+++ b/src/features/guide/components/calendar/WeeklyCalendar.tsx
@@ -3,6 +3,7 @@
 import { useMemo, useState } from "react";
 
 import { Button } from "@/components/ui/button";
+import { kopecksToRub } from "@/data/money";
 import { formatTimeRange } from "@/lib/dates";
 import type {
   ListingScheduleExtraRow,
@@ -34,7 +35,7 @@ function jsDayToDbWeekday(date: Date): number {
 }
 
 function formatRub(minor: number): string {
-  return new Intl.NumberFormat("ru-RU").format(Math.round(minor / 100));
+  return new Intl.NumberFormat("ru-RU").format(Math.round(kopecksToRub(minor)));
 }
 
 function departureStatusLabel(status: string): string {
@@ -45,6 +46,7 @@ function departureStatusLabel(status: string): string {
 }
 
 export type WeeklyCalendarProps = {
+  todayStr: string;
   schedules: ListingScheduleRow[];
   extras: ListingScheduleExtraRow[];
   departures: ListingTourDepartureRow[];
@@ -52,6 +54,7 @@ export type WeeklyCalendarProps = {
 };
 
 export function WeeklyCalendar({
+  todayStr,
   schedules,
   extras,
   departures,
@@ -66,10 +69,10 @@ export function WeeklyCalendar({
   }, [listings]);
 
   const anchor = useMemo(() => {
-    const d = new Date();
+    const d = new Date(`${todayStr}T00:00:00`);
     d.setDate(d.getDate() + weekOffset * 7);
     return d;
-  }, [weekOffset]);
+  }, [weekOffset, todayStr]);
 
   const monday = useMemo(() => startOfWeekMonday(anchor), [anchor]);
 

--- a/src/features/guide/components/calendar/WeeklyCalendar.tsx
+++ b/src/features/guide/components/calendar/WeeklyCalendar.tsx
@@ -3,6 +3,7 @@
 import { useMemo, useState } from "react";
 
 import { Button } from "@/components/ui/button";
+import { formatTimeRange } from "@/lib/dates";
 import type {
   ListingScheduleExtraRow,
   ListingScheduleRow,
@@ -30,13 +31,6 @@ function startOfWeekMonday(base: Date): Date {
 function jsDayToDbWeekday(date: Date): number {
   const js = date.getDay();
   return js === 0 ? 6 : js - 1;
-}
-
-function formatTime(t: string | null): string {
-  if (!t) return "—";
-  const parts = t.split(":");
-  if (parts.length >= 2) return `${parts[0]}:${parts[1]}`;
-  return t;
 }
 
 function formatRub(minor: number): string {
@@ -126,7 +120,7 @@ export function WeeklyCalendar({
         </div>
       </div>
 
-      <div className="grid grid-cols-1 gap-3 sm:grid-cols-7">
+      <div className="grid grid-cols-2 gap-2 sm:grid-cols-4 md:grid-cols-7">
         {weekDays.map((day, idx) => {
           const iso = formatDateOnlyLocal(day);
           const dbWeekday = jsDayToDbWeekday(day);
@@ -155,7 +149,8 @@ export function WeeklyCalendar({
                       {titleByListingId.get(s.listing_id) ?? "Экскурсия"}
                     </span>
                     <span className="block text-muted-foreground">
-                      Еженедельно · {formatTime(s.time_start)}–{formatTime(s.time_end)}
+                      Еженедельно ·{" "}
+                      {formatTimeRange(s.time_start.slice(0, 5), s.time_end.slice(0, 5))}
                     </span>
                   </li>
                 ))}
@@ -167,7 +162,7 @@ export function WeeklyCalendar({
                     <span className="block text-muted-foreground">
                       Особая дата ·{" "}
                       {e.time_start && e.time_end
-                        ? `${formatTime(e.time_start)}–${formatTime(e.time_end)}`
+                        ? formatTimeRange(e.time_start.slice(0, 5), e.time_end.slice(0, 5))
                         : "время не задано"}
                     </span>
                   </li>


### PR DESCRIPTION
Redesigns /guide/calendar: PageHeader, Tabs split (Расписание primary / Статистика), Alert on fetch error, semantic 2-color dots (no rainbow), responsive week grid, TZ-safe dates (todayMoscowISODate + todayStr props), kopecksToRub. Week/month toggle + DayPanel + slot actions + 4 data sources preserved.