### PR TITLE
fix(cards): Lucide Star rating icon + Russian review-count plural (no star glyph)

### DIFF
--- a/src/components/shared/listing-card.tsx
+++ b/src/components/shared/listing-card.tsx
@@ -1,8 +1,9 @@
 import Image from "next/image";
 import Link from "next/link";
+import { Star } from "lucide-react";
 
 import type { ListingRecord } from "@/data/supabase/queries";
-import { arrowizeRoute } from "@/lib/utils";
+import { arrowizeRoute, pluralize } from "@/lib/utils";
 
 function getFormatLabel(format: string): string {
   if (format === "private") return "Индивидуальный";
@@ -64,8 +65,8 @@ export function ListingCard({ listing, priority }: ListingCardProps) {
           <div className="space-y-0.5">
             <p className="text-sm font-medium text-primary-foreground/90">{listing.guideName}</p>
             {listing.rating > 0 ? (
-              <p className="text-xs text-primary-foreground/70">
-                ★ {listing.rating.toFixed(1)} · {listing.reviewCount} отзывов
+              <p className="inline-flex items-center gap-1 text-xs text-primary-foreground/70">
+                <Star className="size-3.5 fill-amber-400 text-amber-400" /> {listing.rating.toFixed(1)} · {listing.reviewCount} {pluralize(listing.reviewCount, "отзыв", "отзыва", "отзывов")}
               </p>
             ) : null}
           </div>

--- a/src/components/shared/tour-card.tsx
+++ b/src/components/shared/tour-card.tsx
@@ -1,5 +1,6 @@
 import Image from "next/image";
 import Link from "next/link";
+import { Star } from "lucide-react";
 
 interface TourCardProps {
   href: string;
@@ -44,9 +45,15 @@ export function TourCard({
         <h3 className="font-display text-[2rem] font-semibold leading-[1.02]">{title}</h3>
 
         <div className="mt-3 grid gap-1.5 text-sm text-primary-foreground/80">
-          <span>
+          <span className="inline-flex items-center gap-1">
             {guide}
-            {rating !== undefined && rating > 0 ? ` · ${rating} ★` : null}
+            {rating !== undefined && rating > 0 ? (
+              <>
+                ·
+                <Star className="size-3.5 fill-amber-400 text-amber-400" />
+                {rating}
+              </>
+            ) : null}
           </span>
         </div>
 

--- a/src/components/traveler/ListingCard.tsx
+++ b/src/components/traveler/ListingCard.tsx
@@ -1,5 +1,6 @@
 import Image from "next/image";
 import Link from "next/link";
+import { Star } from "lucide-react";
 
 import { Badge } from "@/components/ui/badge";
 import { Card, CardContent } from "@/components/ui/card";
@@ -93,8 +94,8 @@ export function ListingCard({ listing }: Props) {
             ) : null}
           </div>
           {listing.average_rating > 0 ? (
-            <p className="text-sm text-muted-foreground">
-              ★ {listing.average_rating.toFixed(1)}
+            <p className="inline-flex items-center gap-1 text-sm text-muted-foreground">
+              <Star className="size-3.5 fill-amber-400 text-amber-400" /> {listing.average_rating.toFixed(1)}
             </p>
           ) : null}
         </CardContent>

--- a/src/features/guide/components/public/public-guide-card.tsx
+++ b/src/features/guide/components/public/public-guide-card.tsx
@@ -1,5 +1,6 @@
 import Image from "next/image";
 import Link from "next/link";
+import { Star } from "lucide-react";
 
 import { Badge } from "@/components/ui/badge";
 import { cn } from "@/lib/utils";
@@ -61,8 +62,8 @@ export function PublicGuideCard({
             {guide.name}
           </span>
           {hasRating ? (
-            <span className="text-sm text-amber-500" aria-label={`Рейтинг ${ratingLabel}`}>
-              ★ {ratingLabel}
+            <span className="inline-flex items-center gap-1 text-sm text-amber-500" aria-label={`Рейтинг ${ratingLabel}`}>
+              <Star className="size-3.5 fill-amber-400 text-amber-400" /> {ratingLabel}
             </span>
           ) : null}
           {hasTours ? (

--- a/src/features/traveler/components/trip-card/trip-card.test.tsx
+++ b/src/features/traveler/components/trip-card/trip-card.test.tsx
@@ -314,13 +314,13 @@ describe("TripCard", () => {
     expect(screen.getByText("Оставить отзыв")).toBeInTheDocument();
   });
 
-  it("shows «Ваш отзыв · ★ N» for completed with review", () => {
+  it("shows «Ваш отзыв» with rating for completed with review", () => {
     render(
       <TripCard
         phase="completed"
         trip={{ ...baseTrip, hasReview: true, reviewRating: 5 }}
       />,
     );
-    expect(screen.getByText("Ваш отзыв · ★ 5")).toBeInTheDocument();
+    expect(screen.getByText("Ваш отзыв · 5")).toBeInTheDocument();
   });
 });

--- a/src/features/traveler/components/trip-card/trip-card.tsx
+++ b/src/features/traveler/components/trip-card/trip-card.tsx
@@ -1,6 +1,6 @@
 import Image from "next/image";
 import Link from "next/link";
-import { CalendarDays, Clock, Users, Wallet } from "lucide-react";
+import { CalendarDays, Clock, Star, Users, Wallet } from "lucide-react";
 
 import { Badge } from "@/components/ui/badge";
 import { BADGE_CLASS } from "@/lib/styles";
@@ -324,7 +324,7 @@ function TripCardContent({
         )}
       {phase === "completed" &&
         (trip.hasReview ? (
-          <p>Ваш отзыв · ★ {trip.reviewRating}</p>
+          <p className="inline-flex items-center gap-1">Ваш отзыв · <Star className="size-3.5 fill-amber-400 text-amber-400" /> {trip.reviewRating}</p>
         ) : (
           <span className="text-sm font-medium text-primary">Оставить отзыв</span>
         ))}


### PR DESCRIPTION
Z01 sweep fix. Verified: typecheck+lint+824 green; Lucide-only, no glyphs.