### PR TITLE
fix(listing-detail): Lucide Star badge + review-count plural (no star glyph)

### DIFF
--- a/src/components/listing-detail/ExcursionShapeDetail.tsx
+++ b/src/components/listing-detail/ExcursionShapeDetail.tsx
@@ -1,3 +1,4 @@
+import { Star } from "lucide-react";
 import Link from "next/link";
 
 import { TransferCrossSellWidget } from "@/features/listings/components/TransferCrossSellWidget";
@@ -18,7 +19,7 @@ import type {
   ListingTariffRow,
 } from "@/lib/supabase/types";
 import { maskPii } from "@/lib/pii/mask";
-import { arrowizeRoute } from "@/lib/utils";
+import { arrowizeRoute, pluralize } from "@/lib/utils";
 
 import { formatExcursionPriceFrom } from "./excursion-price";
 
@@ -132,7 +133,7 @@ export function ExcursionShapeDetail({ listing, photos, schedule, tariffs, guide
               {durationLabel ? <Badge variant="outline">{durationLabel}</Badge> : null}
               {listing.review_count > 0 ? (
                 <span className="text-sm text-muted-foreground">
-                  ★ {listing.average_rating.toFixed(1)} · {listing.review_count} отзывов
+                  <Star className="size-3.5 fill-amber-400 text-amber-400" /> {listing.average_rating.toFixed(1)} · {listing.review_count} {pluralize(listing.review_count, "отзыв", "отзыва", "отзывов")}
                 </span>
               ) : null}
             </div>

--- a/src/components/listing-detail/GuideCard.tsx
+++ b/src/components/listing-detail/GuideCard.tsx
@@ -1,3 +1,4 @@
+import { Star } from "lucide-react";
 import Link from "next/link";
 
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
@@ -5,6 +6,7 @@ import { Card, CardContent } from "@/components/ui/card";
 import type { GuideProfileRow } from "@/lib/supabase/types";
 import { maskPii } from "@/lib/pii/mask";
 import { resolveDisplayName } from "@/lib/profile/resolve-display-name";
+import { pluralize } from "@/lib/utils";
 
 function initials(name: string | null | undefined): string {
   if (!name?.trim()) return "?";
@@ -41,7 +43,7 @@ export function GuideCard({
           <p className="font-medium leading-tight">{guideName}</p>
           {guide.review_count > 0 ? (
             <p className="text-sm text-muted-foreground">
-              ★ {guide.average_rating.toFixed(1)} · {guide.review_count} отзывов
+              <Star className="size-3.5 fill-amber-400 text-amber-400" /> {guide.average_rating.toFixed(1)} · {guide.review_count} {pluralize(guide.review_count, "отзыв", "отзыва", "отзывов")}
             </p>
           ) : null}
           {bio ? (

--- a/src/components/listing-detail/TourShapeDetail.tsx
+++ b/src/components/listing-detail/TourShapeDetail.tsx
@@ -1,3 +1,4 @@
+import { Star } from "lucide-react";
 import Link from "next/link";
 
 import { TransferCrossSellWidget } from "@/features/listings/components/TransferCrossSellWidget";
@@ -21,6 +22,7 @@ import type {
   ListingTourDepartureRow,
 } from "@/lib/supabase/types";
 import { maskPii } from "@/lib/pii/mask";
+import { pluralize } from "@/lib/utils";
 
 const DIFFICULTY_LABELS: Record<string, string> = {
   easy: "Лёгкий",
@@ -123,7 +125,7 @@ export function TourShapeDetail({
         ) : null}
         {listing.review_count > 0 ? (
           <span className="text-sm text-muted-foreground">
-            ★ {listing.average_rating.toFixed(1)} · {listing.review_count} отзывов
+            <Star className="size-3.5 fill-amber-400 text-amber-400" /> {listing.average_rating.toFixed(1)} · {listing.review_count} {pluralize(listing.review_count, "отзыв", "отзыва", "отзывов")}
           </span>
         ) : null}
       </div>


### PR DESCRIPTION
Z01 sweep fix. Verified: typecheck+lint+824 green; Lucide-only, no glyphs.