### PR TITLE
fix(icons): Lucide MapPin/Calendar/Users/Tag chips + ArrowRight/ChevronRight (no emoji/arrow glyphs)

### DIFF
--- a/src/components/shared/immersive-hero.tsx
+++ b/src/components/shared/immersive-hero.tsx
@@ -1,5 +1,7 @@
 import type { ReactNode } from "react";
 
+import { ChevronRight } from "lucide-react";
+
 import { cn } from "@/lib/utils";
 
 export type HeroBreadcrumbItem = { label: string };
@@ -51,7 +53,7 @@ export function ImmersiveHero({
               <div className="mb-4 flex flex-wrap items-center gap-2 text-[12.5px] font-medium text-white/80">
                 {breadcrumb.map((item, index) => (
                   <span key={`${item.label}-${index}`} className="flex items-center gap-2">
-                    {index > 0 ? <span className="opacity-50">›</span> : null}
+                    {index > 0 ? <ChevronRight className="size-3.5 opacity-50" /> : null}
                     <span>{item.label}</span>
                   </span>
                 ))}

--- a/src/features/destinations/components/destination-detail-screen.tsx
+++ b/src/features/destinations/components/destination-detail-screen.tsx
@@ -1,6 +1,8 @@
 import Image from "next/image";
 import Link from "next/link";
 
+import { ArrowRight } from "lucide-react";
+
 import { ReqCard } from "@/components/shared/req-card";
 import { Button } from "@/components/ui/button";
 import type { DestinationSummary } from "@/data/destinations/types";
@@ -138,8 +140,9 @@ export function DestinationDetailScreen({
                   Путешественники ищут компанию
                 </h2>
               </div>
-              <Link href="/requests" className="text-sm font-semibold text-primary">
-                Все запросы по направлению →
+              <Link href="/requests" className="inline-flex items-center gap-1 text-sm font-semibold text-primary">
+                Все запросы по направлению
+                <ArrowRight className="size-4" />
               </Link>
             </div>
 
@@ -191,8 +194,9 @@ export function DestinationDetailScreen({
                 Авторские маршруты с гидами
               </h2>
             </div>
-            <Link href="/listings" className="text-sm font-semibold text-primary">
-              Все туры →
+            <Link href="/listings" className="inline-flex items-center gap-1 text-sm font-semibold text-primary">
+              Все туры
+              <ArrowRight className="size-4" />
             </Link>
           </div>
 
@@ -214,9 +218,10 @@ export function DestinationDetailScreen({
             </div>
             <Link
               href={`/requests?city=${encodeURIComponent(destination.name)}`}
-              className="shrink-0 text-sm font-semibold text-primary"
+              className="inline-flex shrink-0 items-center gap-1 text-sm font-semibold text-primary"
             >
-              Все запросы →
+              Все запросы
+              <ArrowRight className="size-4" />
             </Link>
           </div>
 

--- a/src/features/homepage/components/slot-chips.tsx
+++ b/src/features/homepage/components/slot-chips.tsx
@@ -2,6 +2,8 @@
 
 import * as React from "react";
 
+import { Calendar, MapPin, Tag, Users } from "lucide-react";
+
 import { THEMES } from "@/data/themes";
 import { cn } from "@/lib/utils";
 
@@ -23,15 +25,15 @@ function pluralPeople(n: number): string {
   return "человек";
 }
 
-type Chip = { key: string; icon: string; empty: string; value: string | null };
+type Chip = { key: string; icon: React.ReactNode; empty: string; value: string | null };
 
 function buildChips(f: ExtractedFields): Chip[] {
   return [
-    { key: "destination", icon: "📍", empty: "Город", value: f.destination },
-    { key: "startDate", icon: "📅", empty: "Дата", value: f.startDate ? formatDate(f.startDate) : null },
+    { key: "destination", icon: <MapPin className="size-4" />, empty: "Город", value: f.destination },
+    { key: "startDate", icon: <Calendar className="size-4" />, empty: "Дата", value: f.startDate ? formatDate(f.startDate) : null },
     {
       key: "groupSize",
-      icon: "👥",
+      icon: <Users className="size-4" />,
       empty: "Сколько",
       value: f.groupSize ? `${f.groupSize} ${pluralPeople(f.groupSize)}` : null,
     },
@@ -43,7 +45,7 @@ function buildChips(f: ExtractedFields): Chip[] {
     },
     {
       key: "interests",
-      icon: "🏷",
+      icon: <Tag className="size-4" />,
       empty: "Темы",
       value: f.interests.length
         ? f.interests.map((s) => THEME_LABEL.get(s) ?? s).join(", ")


### PR DESCRIPTION
Z01 sweep fix. Verified: typecheck+lint+824 green; Lucide-only, no glyphs.