### PR TITLE
fix(request-card): drop ≥ glyph, show "от N чел." for assembly groups (no text glyph)

### DIFF
--- a/src/components/shared/request-card-final.test.tsx
+++ b/src/components/shared/request-card-final.test.tsx
@@ -39,7 +39,7 @@ describe("RequestCardFinal", () => {
     expect(screen.getByText("Гибкие даты")).toBeInTheDocument();
     expect(screen.getByText("5 июля, 11:30")).toBeInTheDocument();
     expect(screen.queryByText(/2\s*\/\s*\d+/)).not.toBeInTheDocument();
-    expect(screen.getByText(/·\s*2\s*чел\./)).toBeInTheDocument();
+    expect(screen.getByText(/·\s*от\s*2\s*чел\./)).toBeInTheDocument();
     const price = screen.getByText("6 800 ₽ / чел");
     expect(price).toBeInTheDocument();
     expect(price).toHaveClass("shrink-0", "whitespace-nowrap");

--- a/src/components/shared/request-card-final.tsx
+++ b/src/components/shared/request-card-final.tsx
@@ -111,9 +111,11 @@ function GroupTypeBadge({
       <span className={className}>
         <Users size={14} className={iconClassName} />
         {label}
-        {groupType === "assembly" && <span className="inline-block leading-none align-middle">≥</span>}
       </span>
-      <span className="text-xs font-medium text-ink-2">· {participantCount} чел.</span>
+      <span className="text-xs font-medium text-ink-2">
+        · {groupType === "assembly" ? "от " : ""}
+        {participantCount} чел.
+      </span>
     </div>
   );
 }


### PR DESCRIPTION
Z01 traveler-sweep fix. 2 files; 824 green.