### PR TITLE
fix(rsc): mark interactive shared components as client (fixes /admin/guides crash + hardens cards)

### DIFF
--- a/src/components/shared/guide-offer-card.tsx
+++ b/src/components/shared/guide-offer-card.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import type { ReactNode } from "react";
 import { BadgeCheck, Check, MapPin, Star } from "lucide-react";
 

--- a/src/components/shared/list-row.tsx
+++ b/src/components/shared/list-row.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import * as React from "react";
 import Link from "next/link";
 

--- a/src/components/shared/sticky-action-bar.tsx
+++ b/src/components/shared/sticky-action-bar.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import type { ReactNode } from "react";
 
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";


### PR DESCRIPTION
P0-D. list-row + guide-offer-card + sticky-action-bar → client. Fixes /admin/guides RSC crash (latent on bookings/listings/moderation too). 825 green.