### PR TITLE
fix(guides): render guide portraits for anon visitors (RLS-safe avatar source)

### DIFF
--- a/src/data/supabase/queries.ts
+++ b/src/data/supabase/queries.ts
@@ -783,7 +783,7 @@ export async function getGuides(
 
     const { data: statRows } = await client
       .from("v_guide_public_profile")
-      .select("user_id, average_rating, review_count, trips_completed, recommend_pct, specialties, languages")
+      .select("user_id, avatar_url, average_rating, review_count, trips_completed, recommend_pct, specialties, languages")
       .in("user_id", guideIds);
 
     const ratingMap = new Map<
@@ -795,6 +795,7 @@ export async function getGuides(
         recommendPct: number | null;
         specialties: string[];
         languages: string[];
+        avatarUrl: string | null;
       }
     >();
     for (const row of statRows ?? []) {
@@ -805,6 +806,7 @@ export async function getGuides(
         recommendPct: (row.recommend_pct as number | null) ?? null,
         specialties: (row.specialties as string[] | null) ?? [],
         languages: (row.languages as string[] | null) ?? [],
+        avatarUrl: (row.avatar_url as string | null) ?? null,
       });
     }
 
@@ -817,6 +819,7 @@ export async function getGuides(
           return {
             ...base,
             listingCount: countMap[userId] ?? 0,
+            avatarUrl: stats?.avatarUrl ?? base.avatarUrl ?? undefined,
             rating: stats?.rating ?? 0,
             reviewCount: stats?.reviewCount ?? 0,
             tripsCompleted: stats?.tripsCompleted ?? base.tripsCompleted,


### PR DESCRIPTION
Public /guides showed grey initials instead of portraits. Root cause: getGuides sourced avatar_url from the RLS-protected profiles table, which anon/SSR visitors cannot read (rows silently filtered). Now sources avatar_url from the RLS-safe v_guide_public_profile view (already queried for stats). Single-file change in the data layer; typecheck + lint + 825 tests green.