### PR TITLE
fix(guide-calendar): Lucide chevrons in week/month nav

### DIFF
--- a/src/features/guide/components/calendar/MonthlyCalendar.tsx
+++ b/src/features/guide/components/calendar/MonthlyCalendar.tsx
@@ -2,6 +2,8 @@
 
 import * as React from "react";
 
+import { ChevronLeft, ChevronRight } from "lucide-react";
+
 import { Button } from "@/components/ui/button";
 import type {
   ListingScheduleExtraRow,
@@ -124,7 +126,8 @@ export function MonthlyCalendar({
             size="sm"
             onClick={() => setMonthOffset((o) => o - 1)}
           >
-            ← Предыдущий месяц
+            <ChevronLeft className="h-4 w-4" aria-hidden="true" />
+            Предыдущий месяц
           </Button>
           <Button
             type="button"
@@ -132,7 +135,8 @@ export function MonthlyCalendar({
             size="sm"
             onClick={() => setMonthOffset((o) => o + 1)}
           >
-            Следующий →
+            Следующий
+            <ChevronRight className="h-4 w-4" aria-hidden="true" />
           </Button>
         </div>
       </div>

--- a/src/features/guide/components/calendar/WeeklyCalendar.tsx
+++ b/src/features/guide/components/calendar/WeeklyCalendar.tsx
@@ -2,6 +2,8 @@
 
 import { useMemo, useState } from "react";
 
+import { ChevronLeft, ChevronRight } from "lucide-react";
+
 import { Button } from "@/components/ui/button";
 import { kopecksToRub } from "@/data/money";
 import { formatTimeRange } from "@/lib/dates";
@@ -110,7 +112,8 @@ export function WeeklyCalendar({
             size="sm"
             onClick={() => setWeekOffset((o) => o - 1)}
           >
-            ← Предыдущая неделя
+            <ChevronLeft className="h-4 w-4" aria-hidden="true" />
+            Предыдущая неделя
           </Button>
           <Button
             type="button"
@@ -118,7 +121,8 @@ export function WeeklyCalendar({
             size="sm"
             onClick={() => setWeekOffset((o) => o + 1)}
           >
-            Следующая неделя →
+            Следующая неделя
+            <ChevronRight className="h-4 w-4" aria-hidden="true" />
           </Button>
         </div>
       </div>


### PR DESCRIPTION
Guide calendar week/month navigation buttons used raw ←/→ character glyphs, violating the Lucide-only icon canon (a page guides use daily). Swapped for Lucide ChevronLeft/ChevronRight. Pure visual swap. Two files; typecheck + lint + 825 tests green.