### PR TITLE
feat(catalog): distinct hero image per catalog page

### DIFF
--- a/src/app/(site)/search/page.tsx
+++ b/src/app/(site)/search/page.tsx
@@ -77,7 +77,7 @@ export default async function SearchPage({
   return (
     <section className="pb-20">
       <ListHero
-        imageUrl="/hero-valley.jpg"
+        imageUrl="https://images.unsplash.com/photo-1507525428034-b723cf961d3e?auto=format&fit=crop&w=1600&h=1200&q=80"
         title={title}
         intro="Фильтруйте по типу, формату и цене — или опубликуйте запрос, если не нашли."
       />

--- a/src/features/guide/components/public/public-guides-grid.tsx
+++ b/src/features/guide/components/public/public-guides-grid.tsx
@@ -57,7 +57,7 @@ export function PublicGuidesGrid({
   return (
     <>
       <ListHero
-        imageUrl="/hero-valley.jpg"
+        imageUrl="https://images.unsplash.com/photo-1664358201853-d1274b84cbbe?auto=format&fit=crop&w=1600&h=1200&q=80"
         title="Гиды"
         intro="Найдите проверенного местного гида."
       >

--- a/src/features/listings/components/public/public-listing-discovery-screen.tsx
+++ b/src/features/listings/components/public/public-listing-discovery-screen.tsx
@@ -98,7 +98,7 @@ export function PublicListingDiscoveryScreen({
   return (
     <div className="space-y-10">
       <ListHero
-        imageUrl="/hero-valley.jpg"
+        imageUrl="https://images.unsplash.com/photo-1513326738677-b964603b136d?auto=format&fit=crop&w=1600&h=1200&q=80"
         title="Готовые экскурсии"
         intro="Авторские экскурсии от местных гидов."
       >

--- a/src/features/requests/components/public-requests-marketplace-screen.tsx
+++ b/src/features/requests/components/public-requests-marketplace-screen.tsx
@@ -308,7 +308,7 @@ export function PublicRequestsMarketplaceScreen({ initialData }: Props) {
   return (
     <div>
       <ListHero
-        imageUrl="/hero-valley.jpg"
+        imageUrl="https://images.unsplash.com/photo-1657293493705-557ab000afe1?auto=format&fit=crop&w=1600&h=1200&q=80"
         title="Открытые запросы"
         intro="Гиды — выбирайте запросы и предлагайте тур. Путешественники — присоединяйтесь к сборным группам."
       >


### PR DESCRIPTION
All four catalog heroes (/listings, /guides, /search, /requests) used the same valley photo, looking repetitive. Each now uses a distinct, already-vetted destination cover image (Москва/Казань/Сочи/Элиста). CSS-background URLs already used in prod, so no new dependency. /destinations + /become-a-guide keep the neutral valley intentionally. Four one-line swaps; typecheck + lint + 825 tests green.