### PR TITLE
Stage 2: Discovery journey

### DIFF
--- a/src/app/(site)/destinations/[slug]/page.tsx
+++ b/src/app/(site)/destinations/[slug]/page.tsx
@@ -6,6 +6,7 @@ import {
   getDestinationBySlug,
   getGuidesByDestination,
   getListingsByDestination,
+  getOpenRequestsByDestination,
   type GuideRecord,
   type ListingRecord,
 } from "@/data/supabase/queries";
@@ -22,14 +23,16 @@ const getDestinationPageData = cache(async (slug: string) => {
   ]);
 
   const region = destinationResult.data?.region ?? null;
-  const guidesResult = region
-    ? await getGuidesByDestination(supabase, region)
-    : { data: [] };
+  const [guidesResult, openRequestsResult] = await Promise.all([
+    region ? getGuidesByDestination(supabase, region) : Promise.resolve({ data: [] }),
+    region ? getOpenRequestsByDestination(supabase, region) : Promise.resolve({ data: [] }),
+  ]);
 
   return {
     destinationResult,
     listings: listingsResult.data ?? [],
     guides: guidesResult.data ?? [],
+    openRequestCount: openRequestsResult.data?.length ?? 0,
   };
 });
 
@@ -59,7 +62,8 @@ export default async function DestinationDetailPage({
 }) {
   const { slug } = await params;
 
-  const { destinationResult, listings, guides } = await getDestinationPageData(slug);
+  const { destinationResult, listings, guides, openRequestCount } =
+    await getDestinationPageData(slug);
 
   if (!destinationResult.data) notFound();
 
@@ -71,7 +75,7 @@ export default async function DestinationDetailPage({
     imageUrl: d.heroImageUrl,
     description: d.description,
     listingCount: d.listingCount,
-    openRequestCount: 0,
+    openRequestCount,
   };
 
   const jsonLd = {

--- a/src/app/(site)/destinations/page.tsx
+++ b/src/app/(site)/destinations/page.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from "next";
 
 import { ListHero } from "@/components/shared/list-hero";
+import { Alert, AlertDescription } from "@/components/ui/alert";
 import { DestinationsGrid } from "@/features/destinations/components/destinations-grid";
 import { getDestinations, type DestinationRecord } from "@/data/supabase/queries";
 import { createSupabaseServerClient } from "@/lib/supabase/server";
@@ -14,13 +15,15 @@ export function generateMetadata(): Metadata {
 
 export default async function DestinationsPage() {
   let destinations: DestinationRecord[] = [];
+  let loadError = false;
 
   try {
     const supabase = await createSupabaseServerClient();
     const result = await getDestinations(supabase);
-    if (result.data) destinations = result.data;
+    if (result.error) loadError = true;
+    else destinations = result.data ?? [];
   } catch {
-    // destinations stays []
+    loadError = true;
   }
 
   return (
@@ -32,8 +35,12 @@ export default async function DestinationsPage() {
         intro="Откройте города и регионы России — и найдите местного гида в каждом из них."
       />
       <div className="mx-auto w-full max-w-page px-[clamp(20px,4vw,48px)] pt-10">
-        {destinations.length === 0 ? (
-          <p className="mt-2 text-on-surface-muted">Пока нет доступных направлений.</p>
+        {loadError ? (
+          <Alert variant="destructive">
+            <AlertDescription>
+              Не удалось загрузить направления. Попробуйте обновить страницу.
+            </AlertDescription>
+          </Alert>
         ) : (
           <DestinationsGrid destinations={destinations} />
         )}

--- a/src/app/(site)/guides/page.test.tsx
+++ b/src/app/(site)/guides/page.test.tsx
@@ -1,0 +1,67 @@
+import { render, screen } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { getGuidesMock, readAuthContextMock } = vi.hoisted(() => ({
+  getGuidesMock: vi.fn(),
+  readAuthContextMock: vi.fn(),
+}));
+
+vi.mock("@/data/supabase/queries", () => ({
+  getGuides: getGuidesMock,
+}));
+
+vi.mock("@/lib/auth/server-auth", () => ({
+  readAuthContextFromServer: readAuthContextMock,
+}));
+
+vi.mock("@/lib/supabase/server", () => ({
+  createSupabaseServerClient: vi.fn().mockResolvedValue({}),
+}));
+
+vi.mock("@/features/guide/components/public/public-guides-grid", () => ({
+  PublicGuidesGrid: () => <div data-testid="public-guides-grid" />,
+}));
+
+import GuidesPage from "./page";
+
+describe("GuidesPage", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    readAuthContextMock.mockResolvedValue({ role: "guide" });
+  });
+
+  it("renders the EmptyState when there are no guides, specs, or query", async () => {
+    getGuidesMock.mockResolvedValueOnce({ data: [], error: null });
+
+    const ui = await GuidesPage({ searchParams: Promise.resolve({}) });
+    render(ui);
+
+    expect(screen.getByText("Пока нет гидов")).toBeInTheDocument();
+    expect(screen.queryByTestId("public-guides-grid")).not.toBeInTheDocument();
+  });
+
+  it("renders an error alert when the query fails", async () => {
+    getGuidesMock.mockResolvedValueOnce({ data: null, error: new Error("boom") });
+
+    const ui = await GuidesPage({ searchParams: Promise.resolve({}) });
+    render(ui);
+
+    expect(
+      screen.getByText("Не удалось загрузить гидов. Попробуйте обновить страницу."),
+    ).toBeInTheDocument();
+    expect(screen.queryByText("Пока нет гидов")).not.toBeInTheDocument();
+  });
+
+  it("renders the grid when guides are present", async () => {
+    getGuidesMock.mockResolvedValueOnce({
+      data: [{ id: "g1" }],
+      error: null,
+    });
+
+    const ui = await GuidesPage({ searchParams: Promise.resolve({}) });
+    render(ui);
+
+    expect(screen.getByTestId("public-guides-grid")).toBeInTheDocument();
+    expect(screen.queryByText("Пока нет гидов")).not.toBeInTheDocument();
+  });
+});

--- a/src/app/(site)/guides/page.tsx
+++ b/src/app/(site)/guides/page.tsx
@@ -2,7 +2,9 @@ import type { Metadata } from "next";
 import { Users } from "lucide-react";
 import Link from "next/link";
 
+import { Alert, AlertDescription } from "@/components/ui/alert";
 import { Button } from "@/components/ui/button";
+import { EmptyState } from "@/components/ui/empty-state";
 import { PublicGuidesGrid } from "@/features/guide/components/public/public-guides-grid";
 import { getGuides, type GuideRecord } from "@/data/supabase/queries";
 import { INTEREST_CHIPS } from "@/data/interests";
@@ -33,6 +35,7 @@ export default async function GuidesPage({
   const cappedForFilter = rawQ ? rawQ.slice(0, 80) : undefined;
 
   let guides: GuideRecord[] = [];
+  let loadError = false;
 
   const auth = await readAuthContextFromServer();
   try {
@@ -41,24 +44,27 @@ export default async function GuidesPage({
       specializations: activeSpecs,
       ...(cappedForFilter ? { q: cappedForFilter } : {}),
     });
-    if (result.data) guides = result.data;
+    if (result.error) loadError = true;
+    else guides = result.data ?? [];
   } catch {
-    // guides stays []
+    loadError = true;
   }
 
   return (
     <section className="bg-surface pt-[110px] pb-20">
       <div className="mx-auto w-full max-w-page px-[clamp(20px,4vw,48px)]">
-        {guides.length === 0 && activeSpecs.length === 0 && !rawQ ? (
-          <div className="bg-glass backdrop-blur-[20px] border border-glass-border shadow-glass flex flex-col items-center justify-center rounded-[1.5rem] px-6 py-16 text-center">
-            <span className="flex size-14 items-center justify-center rounded-full bg-brand-light text-brand">
-              <Users className="size-6" strokeWidth={1.9} />
-            </span>
-            <h2 className="mt-5 text-[1.35rem] font-semibold text-ink">Пока нет гидов</h2>
-            <p className="mt-2 max-w-[30rem] text-[0.95rem] leading-7 text-ink-2">
-              В этом разделе пока пусто. Если вы гид — добавьте свой профиль, и путешественники найдут вас.
-            </p>
-          </div>
+        {loadError ? (
+          <Alert variant="destructive">
+            <AlertDescription>
+              Не удалось загрузить гидов. Попробуйте обновить страницу.
+            </AlertDescription>
+          </Alert>
+        ) : guides.length === 0 && activeSpecs.length === 0 && !rawQ ? (
+          <EmptyState
+            icon={Users}
+            title="Пока нет гидов"
+            description="В этом разделе пока пусто. Если вы гид — добавьте свой профиль, и путешественники найдут вас."
+          />
         ) : (
           <PublicGuidesGrid
             guides={guides}

--- a/src/app/(site)/listings/page.test.tsx
+++ b/src/app/(site)/listings/page.test.tsx
@@ -1,0 +1,30 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("@/lib/supabase/server", () => ({
+  createSupabaseServerClient: vi.fn(async () => ({})),
+}));
+
+const getActiveListings = vi.fn();
+vi.mock("@/data/supabase/queries", () => ({
+  getActiveListings: (...args: unknown[]) => getActiveListings(...args),
+}));
+
+vi.mock("@/features/listings/components/public/public-listing-discovery-screen", () => ({
+  PublicListingDiscoveryScreen: () => (
+    <section aria-label="discovery">PublicListingDiscoveryScreen</section>
+  ),
+}));
+
+import PublicListingsPage from "./page";
+
+describe("PublicListingsPage", () => {
+  it("renders the error Alert and not the discovery screen when the query errors", async () => {
+    getActiveListings.mockResolvedValueOnce({ data: null, error: new Error("boom") });
+
+    render(await PublicListingsPage({ searchParams: Promise.resolve({}) }));
+
+    expect(screen.getByText("Не удалось загрузить экскурсии. Попробуйте обновить страницу.")).toBeInTheDocument();
+    expect(screen.queryByLabelText("discovery")).not.toBeInTheDocument();
+  });
+});

--- a/src/app/(site)/listings/page.tsx
+++ b/src/app/(site)/listings/page.tsx
@@ -4,6 +4,7 @@ import { mapDbCategoryToThemeSlug } from "@/data/public-listings/mapper";
 import type { PublicListing } from "@/data/public-listings/types";
 import { getActiveListings, type ListingRecord } from "@/data/supabase/queries";
 import { createSupabaseServerClient } from "@/lib/supabase/server";
+import { Alert, AlertDescription } from "@/components/ui/alert";
 import { PublicListingDiscoveryScreen } from "@/features/listings/components/public/public-listing-discovery-screen";
 
 export function generateMetadata(): Metadata {
@@ -50,15 +51,15 @@ export default async function PublicListingsPage({
   searchParams: Promise<{ q?: string }>;
 }) {
   let listings: PublicListing[] = [];
+  let loadError = false;
 
   try {
     const supabase = await createSupabaseServerClient();
     const result = await getActiveListings(supabase);
-    if (result.data && result.data.length > 0) {
-      listings = result.data.map((listing) => mapToPublicListing(listing));
-    }
+    if (result.error) loadError = true;
+    else listings = (result.data ?? []).map((listing) => mapToPublicListing(listing));
   } catch {
-    // listings stays []
+    loadError = true;
   }
 
   const params = await searchParams;
@@ -67,7 +68,15 @@ export default async function PublicListingsPage({
   return (
     <section className="pt-[110px] pb-20">
       <div className="mx-auto w-full max-w-page px-[clamp(20px,4vw,48px)]">
-        <PublicListingDiscoveryScreen listings={listings} initialSearch={initialSearch} />
+        {loadError ? (
+          <Alert variant="destructive">
+            <AlertDescription>
+              Не удалось загрузить экскурсии. Попробуйте обновить страницу.
+            </AlertDescription>
+          </Alert>
+        ) : (
+          <PublicListingDiscoveryScreen listings={listings} initialSearch={initialSearch} />
+        )}
       </div>
     </section>
   );

--- a/src/app/(site)/search/page.test.tsx
+++ b/src/app/(site)/search/page.test.tsx
@@ -1,0 +1,64 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+const limit = vi.fn();
+
+function makeBuilder() {
+  const builder: Record<string, unknown> = {};
+  for (const method of ["select", "eq", "ilike", "gte", "lte", "order"]) {
+    builder[method] = vi.fn(() => builder);
+  }
+  builder.limit = limit;
+  return builder;
+}
+
+vi.mock("@/lib/supabase/server", () => ({
+  createSupabaseServerClient: vi.fn(async () => ({
+    from: vi.fn(() => makeBuilder()),
+  })),
+}));
+
+vi.mock("@sentry/nextjs", () => ({ captureException: vi.fn() }));
+
+vi.mock("@/components/shared/list-hero", () => ({
+  ListHero: () => <div>ListHero</div>,
+}));
+
+vi.mock("@/components/traveler/FilterBar", () => ({
+  FilterBar: () => <div>FilterBar</div>,
+}));
+
+vi.mock("@/components/traveler/ListingGrid", () => ({
+  ListingGrid: () => <div aria-label="grid">ListingGrid</div>,
+}));
+
+import SearchPage from "./page";
+
+describe("SearchPage", () => {
+  it("renders an honest result count from count:'exact'", async () => {
+    limit.mockResolvedValueOnce({
+      data: [{ id: "1", slug: "a" }],
+      error: null,
+      count: 57,
+    });
+
+    render(await SearchPage({ searchParams: Promise.resolve({}) }));
+
+    expect(screen.getByText("Найдено 57 предложений")).toBeInTheDocument();
+  });
+
+  it("renders the error Alert when the query errors", async () => {
+    limit.mockResolvedValueOnce({
+      data: null,
+      error: new Error("boom"),
+      count: null,
+    });
+
+    render(await SearchPage({ searchParams: Promise.resolve({}) }));
+
+    expect(
+      screen.getByText("Не удалось выполнить поиск. Попробуйте обновить страницу."),
+    ).toBeInTheDocument();
+    expect(screen.queryByLabelText("grid")).not.toBeInTheDocument();
+  });
+});

--- a/src/app/(site)/search/page.tsx
+++ b/src/app/(site)/search/page.tsx
@@ -5,10 +5,13 @@ import { Suspense } from "react";
 import { ListHero } from "@/components/shared/list-hero";
 import { FilterBar } from "@/components/traveler/FilterBar";
 import { ListingGrid } from "@/components/traveler/ListingGrid";
+import { Alert, AlertDescription } from "@/components/ui/alert";
 import { Button } from "@/components/ui/button";
 import { Skeleton } from "@/components/ui/skeleton";
+import { ROUTES } from "@/lib/navigation";
 import { createSupabaseServerClient } from "@/lib/supabase/server";
 import type { ListingRow } from "@/lib/supabase/types";
+import { pluralize } from "@/lib/utils";
 
 export const metadata: Metadata = {
   title: "Поиск и направления",
@@ -32,6 +35,8 @@ export default async function SearchPage({
   };
 
   let listings: ListingRow[] = [];
+  let totalCount = 0;
+  let loadError = false;
 
   try {
     const supabase = await createSupabaseServerClient();
@@ -39,6 +44,7 @@ export default async function SearchPage({
       .from("listings")
       .select(
         "id, slug, title, region, city, exp_type, format, duration_minutes, price_from_minor, currency, average_rating, review_count, image_url, languages, difficulty_level",
+        { count: "exact" },
       )
       .eq("status", "published");
 
@@ -61,14 +67,17 @@ export default async function SearchPage({
     else if (sort === "rating") query = query.order("average_rating", { ascending: false });
     else query = query.order("featured_rank", { ascending: true, nullsFirst: false });
 
-    const { data, error } = await query.limit(48);
+    const { data, error, count } = await query.limit(48);
     if (error) {
       const Sentry = await import("@sentry/nextjs");
       Sentry.captureException(error);
+      loadError = true;
     }
     listings = (data ?? []) as ListingRow[];
+    totalCount = count ?? 0;
   } catch {
     listings = [];
+    loadError = true;
   }
 
   const title =
@@ -93,23 +102,39 @@ export default async function SearchPage({
             region={sp.region}
           />
         </Suspense>
-        <ListingGrid listings={listings} />
-        {listings.length === 0 ? (
-          <div className="mt-12 flex flex-col items-center gap-3 text-center">
-            <p className="text-on-surface-muted">Ничего не нашли по вашему запросу</p>
-            <p className="max-w-[420px] text-sm text-on-surface-muted">
-              Опубликуйте запрос — местные гиды предложат варианты под вашу поездку.
-            </p>
-            <div className="mt-1 flex flex-wrap items-center justify-center gap-2">
-              <Button asChild>
-                <Link href="/">Опубликовать запрос</Link>
-              </Button>
-              <Button asChild variant="outline">
-                <Link href="/search">Сбросить фильтры</Link>
-              </Button>
-            </div>
-          </div>
-        ) : null}
+        {loadError ? (
+          <Alert variant="destructive">
+            <AlertDescription>
+              Не удалось выполнить поиск. Попробуйте обновить страницу.
+            </AlertDescription>
+          </Alert>
+        ) : (
+          <>
+            {totalCount > 0 ? (
+              <p className="mb-4 text-sm text-on-surface-muted">
+                Найдено {totalCount}{" "}
+                {pluralize(totalCount, "предложение", "предложения", "предложений")}
+              </p>
+            ) : null}
+            <ListingGrid listings={listings} />
+            {listings.length === 0 ? (
+              <div className="mt-12 flex flex-col items-center gap-3 text-center">
+                <p className="text-on-surface-muted">Ничего не нашли по вашему запросу</p>
+                <p className="max-w-[420px] text-sm text-on-surface-muted">
+                  Опубликуйте запрос — местные гиды предложат варианты под вашу поездку.
+                </p>
+                <div className="mt-1 flex flex-wrap items-center justify-center gap-2">
+                  <Button asChild>
+                    <Link href={ROUTES.newRequest.href}>Опубликовать запрос</Link>
+                  </Button>
+                  <Button asChild variant="outline">
+                    <Link href="/search">Сбросить фильтры</Link>
+                  </Button>
+                </div>
+              </div>
+            ) : null}
+          </>
+        )}
       </div>
     </section>
   );

--- a/src/components/discovery/DestinationCard.tsx
+++ b/src/components/discovery/DestinationCard.tsx
@@ -1,0 +1,91 @@
+import Image from "next/image"
+import Link from "next/link"
+import { Compass, Star, Users } from "lucide-react"
+
+import { Tag } from "@/components/ui/tag"
+import { cn } from "@/lib/utils"
+
+type DestinationCardProps = {
+  name: string
+  slug: string
+  photoUrl: string
+  guidesCount: number
+  tourCount: number
+  tagline?: string
+  category?: string
+  featured?: boolean
+  rating?: number | null
+  className?: string
+}
+
+function DestinationCard({
+  name,
+  slug,
+  photoUrl,
+  guidesCount,
+  tourCount,
+  tagline,
+  category,
+  featured,
+  rating,
+  className,
+}: DestinationCardProps) {
+  const hasRating = typeof rating === "number" && Number.isFinite(rating)
+
+  return (
+    <Link
+      href={`/destinations/${slug}`}
+      data-slot="destination-card"
+      className={cn(
+        "group relative block overflow-hidden rounded-card bg-surface-low shadow-soft transition-shadow hover:shadow-lift",
+        featured ? "min-h-[320px]" : "min-h-[240px]",
+        className
+      )}
+    >
+      <Image
+        src={photoUrl}
+        alt={name}
+        fill
+        sizes="(max-width: 767px) 100vw, (max-width: 1023px) 50vw, 360px"
+        className="object-cover transition-transform duration-300 group-hover:scale-[1.03]"
+      />
+      <div className="absolute inset-0 bg-gradient-to-t from-foreground/80 via-foreground/20 to-transparent" />
+
+      <div className="absolute inset-0 z-[1] flex flex-col justify-between p-5">
+        <div className="flex items-start justify-between gap-2">
+          {category ? <Tag color="primary">{category}</Tag> : <span />}
+          {hasRating ? (
+            <span
+              data-slot="destination-rating"
+              className="inline-flex items-center gap-1 rounded-full bg-card/90 px-2.5 py-1 text-sm font-semibold text-on-surface backdrop-blur-[8px]"
+            >
+              <Star className="size-4 fill-amber text-amber" aria-hidden="true" />
+              {rating}
+            </span>
+          ) : null}
+        </div>
+
+        <div className="flex flex-col gap-1.5">
+          <p className="font-display text-2xl font-semibold leading-tight text-primary-foreground">
+            {name}
+          </p>
+          {tagline ? (
+            <p className="text-sm text-primary-foreground/75">{tagline}</p>
+          ) : null}
+          <div className="mt-1 flex items-center gap-4 text-sm text-primary-foreground/80">
+            <span className="inline-flex items-center gap-1.5">
+              <Users className="size-4" aria-hidden="true" />
+              {guidesCount} гидов
+            </span>
+            <span className="inline-flex items-center gap-1.5">
+              <Compass className="size-4" aria-hidden="true" />
+              {tourCount} экскурсий
+            </span>
+          </div>
+        </div>
+      </div>
+    </Link>
+  )
+}
+
+export { DestinationCard }

--- a/src/components/discovery/FilterBar.tsx
+++ b/src/components/discovery/FilterBar.tsx
@@ -1,0 +1,67 @@
+"use client"
+
+import { cn } from "@/lib/utils"
+
+type FilterChip = {
+  id: string
+  label: string
+}
+
+type FilterBarProps = {
+  chips: FilterChip[]
+  activeIds: string[]
+  onToggle: (id: string) => void
+  overflowLabel?: string
+  className?: string
+}
+
+const MAX_VISIBLE = 6
+
+function FilterBar({
+  chips,
+  activeIds,
+  onToggle,
+  overflowLabel,
+  className,
+}: FilterBarProps) {
+  const visible = chips.slice(0, MAX_VISIBLE)
+  const overflowCount = chips.length - visible.length
+
+  return (
+    <div data-slot="filter-bar" className={cn("relative", className)}>
+      <div className="flex items-center gap-2 overflow-x-auto pr-10 [scrollbar-width:none] [&::-webkit-scrollbar]:hidden">
+        {visible.map((chip) => {
+          const active = activeIds.includes(chip.id)
+
+          return (
+            <button
+              key={chip.id}
+              type="button"
+              aria-pressed={active}
+              onClick={() => onToggle(chip.id)}
+              className={cn(
+                "inline-flex min-h-[44px] shrink-0 items-center rounded-full border px-4 text-sm font-semibold transition-colors",
+                active
+                  ? "border-primary bg-primary text-primary-foreground"
+                  : "border-line bg-card text-on-surface hover:bg-primary-tint"
+              )}
+            >
+              {chip.label}
+            </button>
+          )
+        })}
+        {overflowCount > 0 ? (
+          <span className="inline-flex min-h-[44px] shrink-0 items-center rounded-full border border-line bg-card px-4 text-sm font-semibold text-muted-foreground">
+            {overflowLabel ?? `+${overflowCount}`}
+          </span>
+        ) : null}
+      </div>
+      <div
+        aria-hidden="true"
+        className="pointer-events-none absolute inset-y-0 right-0 w-10 bg-gradient-to-l from-surface to-transparent"
+      />
+    </div>
+  )
+}
+
+export { FilterBar }

--- a/src/components/discovery/IdentityRevealCard.tsx
+++ b/src/components/discovery/IdentityRevealCard.tsx
@@ -1,0 +1,94 @@
+import Image from "next/image"
+import { Star } from "lucide-react"
+
+import { Badge } from "@/components/ui/badge"
+import { cn } from "@/lib/utils"
+
+type IdentityRevealCardProps = {
+  name: string
+  avatarUrl: string | null
+  verified: boolean
+  rating: number | null
+  reviewCount: number
+  tripsCompleted: number
+  recommendPct: number | null
+  className?: string
+}
+
+function IdentityRevealCard({
+  name,
+  avatarUrl,
+  verified,
+  rating,
+  reviewCount,
+  tripsCompleted,
+  recommendPct,
+  className,
+}: IdentityRevealCardProps) {
+  const hasRating = typeof rating === "number" && Number.isFinite(rating)
+  const hasRecommend =
+    typeof recommendPct === "number" && Number.isFinite(recommendPct)
+  const initial = name.trim().charAt(0).toUpperCase()
+
+  return (
+    <div
+      data-slot="identity-reveal-card"
+      className={cn(
+        "flex items-center gap-4 rounded-card border border-line bg-card p-4 shadow-soft",
+        className
+      )}
+    >
+      {avatarUrl ? (
+        <Image
+          src={avatarUrl}
+          alt={name}
+          width={56}
+          height={56}
+          className="size-14 shrink-0 rounded-full object-cover"
+        />
+      ) : (
+        <span
+          data-slot="identity-avatar-fallback"
+          aria-hidden="true"
+          className="flex size-14 shrink-0 items-center justify-center rounded-full bg-primary text-lg font-semibold text-primary-foreground"
+        >
+          {initial}
+        </span>
+      )}
+
+      <div className="flex min-w-0 flex-col gap-1.5">
+        <div className="flex items-center gap-2">
+          <span className="truncate text-base font-semibold text-on-surface">
+            {name}
+          </span>
+          {verified ? <Badge variant="success">Проверен</Badge> : null}
+        </div>
+
+        <div className="flex flex-wrap items-center gap-x-2 gap-y-1 text-sm text-muted-foreground">
+          {hasRating ? (
+            <span
+              data-slot="identity-rating"
+              className="inline-flex items-center gap-1 font-semibold text-on-surface"
+            >
+              <Star className="size-4 fill-amber text-amber" aria-hidden="true" />
+              {rating}
+            </span>
+          ) : null}
+          <span>{reviewCount} отзывов</span>
+          <span aria-hidden="true">·</span>
+          <span>{tripsCompleted} поездок</span>
+          {hasRecommend ? (
+            <>
+              <span aria-hidden="true">·</span>
+              <span data-slot="identity-recommend">
+                {recommendPct}% рекомендуют
+              </span>
+            </>
+          ) : null}
+        </div>
+      </div>
+    </div>
+  )
+}
+
+export { IdentityRevealCard }

--- a/src/components/discovery/NewGuideFrame.tsx
+++ b/src/components/discovery/NewGuideFrame.tsx
@@ -1,0 +1,32 @@
+import { Sparkles } from "lucide-react"
+
+import { Tag } from "@/components/ui/tag"
+import { cn } from "@/lib/utils"
+
+type NewGuideFrameProps = {
+  guideName: string
+  className?: string
+}
+
+function NewGuideFrame({ guideName, className }: NewGuideFrameProps) {
+  return (
+    <div
+      data-slot="new-guide-frame"
+      className={cn(
+        "flex flex-col gap-2 rounded-card border border-line bg-amber-tint/40 p-4",
+        className
+      )}
+    >
+      <Tag color="amber" className="gap-1.5">
+        <Sparkles className="size-3.5" aria-hidden="true" />
+        Первые туры
+      </Tag>
+      <p className="text-sm text-on-surface">
+        {guideName} — новый гид на платформе. Будьте одним из первых, кто откроет
+        его маршруты.
+      </p>
+    </div>
+  )
+}
+
+export { NewGuideFrame }

--- a/src/components/discovery/SearchInput.tsx
+++ b/src/components/discovery/SearchInput.tsx
@@ -1,0 +1,83 @@
+"use client"
+
+import * as React from "react"
+import { Search } from "lucide-react"
+
+import { Input } from "@/components/ui/input"
+import { cn } from "@/lib/utils"
+
+type SearchInputProps = {
+  value: string
+  onChange: (v: string) => void
+  onSubmit: (v: string) => void
+  placeholder?: string
+  debounceMs?: number
+  className?: string
+}
+
+function SearchInput({
+  value,
+  onChange,
+  onSubmit,
+  placeholder = "Куда вы хотите поехать?",
+  debounceMs,
+  className,
+}: SearchInputProps) {
+  const [internal, setInternal] = React.useState(value)
+  const timer = React.useRef<ReturnType<typeof setTimeout> | null>(null)
+  const delay = debounceMs ?? 300
+
+  React.useEffect(() => {
+    setInternal(value)
+  }, [value])
+
+  React.useEffect(() => {
+    return () => {
+      if (timer.current) clearTimeout(timer.current)
+    }
+  }, [])
+
+  const handleChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+    const next = event.target.value
+    setInternal(next)
+    if (timer.current) clearTimeout(timer.current)
+    timer.current = setTimeout(() => onChange(next), delay)
+  }
+
+  const handleSubmit = (event: React.FormEvent<HTMLFormElement>) => {
+    event.preventDefault()
+    if (timer.current) clearTimeout(timer.current)
+    onChange(internal)
+    onSubmit(internal)
+  }
+
+  return (
+    <form
+      role="search"
+      onSubmit={handleSubmit}
+      className={cn("relative w-full", className)}
+    >
+      <Search
+        className="pointer-events-none absolute left-4 top-1/2 size-5 -translate-y-1/2 text-muted-foreground"
+        aria-hidden="true"
+      />
+      <Input
+        type="search"
+        value={internal}
+        onChange={handleChange}
+        placeholder={placeholder}
+        aria-label={placeholder}
+        className="h-12 pl-12"
+      />
+      <button
+        type="submit"
+        aria-label="Искать"
+        className="absolute right-1.5 top-1/2 flex size-11 -translate-y-1/2 items-center justify-center rounded-full text-primary transition-colors hover:bg-primary-tint focus-visible:outline-none focus-visible:ring-3 focus-visible:ring-ring/40"
+      >
+        <Search className="size-5" aria-hidden="true" />
+      </button>
+    </form>
+  )
+}
+
+export { SearchInput }

--- a/src/components/discovery/StatStrip.tsx
+++ b/src/components/discovery/StatStrip.tsx
@@ -1,0 +1,44 @@
+import { cn } from "@/lib/utils"
+
+type StatStripProps = {
+  guides: number
+  tours: number
+  activeGroups: number
+  className?: string
+}
+
+function safeCount(value: number): number {
+  return typeof value === "number" && Number.isFinite(value) ? value : 0
+}
+
+function StatStrip({ guides, tours, activeGroups, className }: StatStripProps) {
+  const parts: Array<{ value: number; label: string }> = [
+    { value: safeCount(guides), label: "гидов" },
+    { value: safeCount(tours), label: "экскурсий" },
+    { value: safeCount(activeGroups), label: "активных групп" },
+  ]
+
+  return (
+    <p
+      data-slot="discovery-stat-strip"
+      className={cn(
+        "flex flex-wrap items-center gap-x-2 text-sm text-muted-foreground",
+        className
+      )}
+    >
+      {parts.map((part, index) => (
+        <span key={part.label} className="inline-flex items-center gap-2">
+          <span className="inline-flex items-center gap-1">
+            <span className="font-semibold text-on-surface">{part.value}</span>
+            {part.label}
+          </span>
+          {index < parts.length - 1 ? (
+            <span aria-hidden="true">·</span>
+          ) : null}
+        </span>
+      ))}
+    </p>
+  )
+}
+
+export { StatStrip }

--- a/src/components/discovery/TrustRibbon.tsx
+++ b/src/components/discovery/TrustRibbon.tsx
@@ -1,0 +1,44 @@
+import { BadgeCheck, MessageSquare, ShieldCheck } from "lucide-react"
+import type { LucideIcon } from "lucide-react"
+
+import { cn } from "@/lib/utils"
+
+type TrustRibbonProps = {
+  items?: string[]
+  className?: string
+}
+
+const DEFAULT_ITEMS = [
+  "Проверенные гиды",
+  "Оплата при встрече",
+  "Поддержка 24/7",
+]
+
+const ICONS: LucideIcon[] = [ShieldCheck, BadgeCheck, MessageSquare]
+
+function TrustRibbon({ items, className }: TrustRibbonProps) {
+  const signals = items ?? DEFAULT_ITEMS
+
+  return (
+    <div
+      data-slot="trust-ribbon"
+      className={cn(
+        "flex flex-wrap items-center gap-x-5 gap-y-2 text-sm text-muted-foreground",
+        className
+      )}
+    >
+      {signals.map((label, index) => {
+        const Icon = ICONS[index % ICONS.length]
+
+        return (
+          <span key={label} className="inline-flex items-center gap-2">
+            <Icon className="size-4 text-success" aria-hidden="true" />
+            {label}
+          </span>
+        )
+      })}
+    </div>
+  )
+}
+
+export { TrustRibbon }

--- a/src/components/discovery/__tests__/primitives.test.tsx
+++ b/src/components/discovery/__tests__/primitives.test.tsx
@@ -1,0 +1,192 @@
+import { fireEvent, render } from "@testing-library/react"
+import { describe, expect, it, vi } from "vitest"
+
+import { DestinationCard } from "../DestinationCard"
+import { FilterBar } from "../FilterBar"
+import { IdentityRevealCard } from "../IdentityRevealCard"
+import { NewGuideFrame } from "../NewGuideFrame"
+import { SearchInput } from "../SearchInput"
+import { StatStrip } from "../StatStrip"
+import { TrustRibbon } from "../TrustRibbon"
+
+describe("DestinationCard", () => {
+  it("renders the destination name and a link to its slug", () => {
+    const { container, getByText } = render(
+      <DestinationCard
+        name="Самарканд"
+        slug="samarkand"
+        photoUrl="/samarkand.jpg"
+        guidesCount={5}
+        tourCount={12}
+      />
+    )
+
+    expect(getByText("Самарканд")).toBeTruthy()
+    expect(
+      container.querySelector('a[href="/destinations/samarkand"]')
+    ).toBeTruthy()
+  })
+
+  it("omits the rating when rating is null", () => {
+    const { container } = render(
+      <DestinationCard
+        name="Самарканд"
+        slug="samarkand"
+        photoUrl="/samarkand.jpg"
+        guidesCount={5}
+        tourCount={12}
+        rating={null}
+      />
+    )
+
+    expect(
+      container.querySelector('[data-slot="destination-rating"]')
+    ).toBeNull()
+    expect(container.textContent).not.toContain("★")
+    expect(container.textContent).not.toContain("рейтинг")
+  })
+
+  it("renders the rating when a real number is passed", () => {
+    const { container, getByText } = render(
+      <DestinationCard
+        name="Самарканд"
+        slug="samarkand"
+        photoUrl="/samarkand.jpg"
+        guidesCount={5}
+        tourCount={12}
+        rating={4.8}
+      />
+    )
+
+    expect(getByText("4.8")).toBeTruthy()
+    expect(
+      container.querySelector('[data-slot="destination-rating"]')
+    ).toBeTruthy()
+  })
+})
+
+describe("NewGuideFrame", () => {
+  it("renders the cold-start label and the guide name", () => {
+    const { container, getByText } = render(
+      <NewGuideFrame guideName="Алишер" />
+    )
+
+    expect(getByText("Первые туры")).toBeTruthy()
+    expect(container.textContent).toContain("Алишер")
+  })
+})
+
+describe("StatStrip", () => {
+  it("renders the three counts with their labels", () => {
+    const { container } = render(
+      <StatStrip guides={12} tours={34} activeGroups={3} />
+    )
+
+    expect(container.textContent).toContain("12")
+    expect(container.textContent).toContain("34")
+    expect(container.textContent).toContain("3")
+    expect(container.textContent).toContain("гидов")
+    expect(container.textContent).toContain("экскурсий")
+    expect(container.textContent).toContain("активных групп")
+  })
+
+  it("never renders literal null/undefined, even with all zeros", () => {
+    const { container } = render(
+      <StatStrip guides={0} tours={0} activeGroups={0} />
+    )
+
+    expect(container.textContent).not.toContain("null")
+    expect(container.textContent).not.toContain("undefined")
+    expect(container.textContent).toContain("0")
+  })
+})
+
+describe("IdentityRevealCard", () => {
+  it("renders the name, verified badge and rating, never contact details", () => {
+    const { container, getByText } = render(
+      <IdentityRevealCard
+        name="Дилноза"
+        avatarUrl={null}
+        verified={true}
+        rating={4.9}
+        reviewCount={20}
+        tripsCompleted={15}
+        recommendPct={98}
+      />
+    )
+
+    expect(getByText("Дилноза")).toBeTruthy()
+    expect(getByText("Проверен")).toBeTruthy()
+    expect(container.textContent).toContain("4.9")
+    expect(container.textContent).not.toContain("+7")
+    expect(container.textContent).not.toContain("телефон")
+    expect(container.textContent).not.toContain("telegram")
+  })
+
+  it("omits the rating when rating is null and the badge when not verified", () => {
+    const { container, queryByText } = render(
+      <IdentityRevealCard
+        name="Дилноза"
+        avatarUrl={null}
+        verified={false}
+        rating={null}
+        reviewCount={0}
+        tripsCompleted={0}
+        recommendPct={null}
+      />
+    )
+
+    expect(
+      container.querySelector('[data-slot="identity-rating"]')
+    ).toBeNull()
+    expect(queryByText("Проверен")).toBeNull()
+    expect(container.textContent).not.toContain("рекомендуют")
+  })
+})
+
+describe("SearchInput", () => {
+  it("renders the default placeholder and submits the value on Enter", () => {
+    const onSubmit = vi.fn()
+    const { container, getByPlaceholderText } = render(
+      <SearchInput value="Бухара" onChange={() => {}} onSubmit={onSubmit} />
+    )
+
+    expect(getByPlaceholderText("Куда вы хотите поехать?")).toBeTruthy()
+
+    const form = container.querySelector("form")
+    expect(form).toBeTruthy()
+    fireEvent.submit(form as HTMLFormElement)
+    expect(onSubmit).toHaveBeenCalledWith("Бухара")
+  })
+})
+
+describe("FilterBar", () => {
+  it("renders chip labels and toggles on click", () => {
+    const onToggle = vi.fn()
+    const { getByText } = render(
+      <FilterBar
+        chips={[
+          { id: "city", label: "Город" },
+          { id: "nature", label: "Природа" },
+        ]}
+        activeIds={["city"]}
+        onToggle={onToggle}
+      />
+    )
+
+    const chip = getByText("Природа")
+    expect(chip).toBeTruthy()
+    fireEvent.click(chip)
+    expect(onToggle).toHaveBeenCalledWith("nature")
+  })
+})
+
+describe("TrustRibbon", () => {
+  it("renders the default trust signals", () => {
+    const { getByText } = render(<TrustRibbon />)
+
+    expect(getByText("Проверенные гиды")).toBeTruthy()
+    expect(getByText("Оплата при встрече")).toBeTruthy()
+    expect(getByText("Поддержка 24/7")).toBeTruthy()
+  })
+})

--- a/src/components/listing-detail/ExcursionShapeDetail.tsx
+++ b/src/components/listing-detail/ExcursionShapeDetail.tsx
@@ -85,7 +85,7 @@ export function ExcursionShapeDetail({ listing, schedule, tariffs, guide }: Prop
   const coverUrl = listing.image_url ?? null;
 
   const bookingCard = (
-    <Card className="bg-glass backdrop-blur-[20px] border border-glass-border shadow-glass rounded-glass">
+    <Card className="bg-surface border border-line shadow-sm rounded-card">
       <CardContent className="space-y-4 p-5">
         <div>
           <p className="text-3xl font-semibold">

--- a/src/components/listing-detail/GuideCard.tsx
+++ b/src/components/listing-detail/GuideCard.tsx
@@ -45,7 +45,7 @@ export function GuideCard({
   const roleLine = roleParts.join(" · ");
 
   return (
-    <Card className="bg-glass backdrop-blur-[20px] border border-glass-border shadow-glass rounded-glass">
+    <Card className="bg-surface border border-line shadow-sm rounded-card">
       <CardContent className="flex gap-4 p-4">
         <Avatar className="size-[72px] shrink-0 rounded-[12px]">
           <AvatarImage src={guide.avatar_url ?? undefined} alt={guideName} className="object-cover" />

--- a/src/components/listing-detail/TourDeparturesList.tsx
+++ b/src/components/listing-detail/TourDeparturesList.tsx
@@ -59,7 +59,7 @@ export function TourDeparturesList({
           return (
             <Card
               key={dep.id}
-              className="bg-glass backdrop-blur-[20px] border border-glass-border shadow-glass rounded-glass"
+              className="bg-surface border border-line shadow-sm rounded-card"
             >
               <CardContent className="space-y-3 p-4">
                 <div className="flex items-start justify-between gap-2">

--- a/src/components/listing-detail/TourShapeDetail.tsx
+++ b/src/components/listing-detail/TourShapeDetail.tsx
@@ -93,7 +93,7 @@ export function TourShapeDetail({
   );
 
   const bookingCard = (
-    <div className="rounded-[28px] border border-glass-border bg-glass p-5 shadow-glass backdrop-blur-[20px] space-y-4">
+    <div className="rounded-card border border-line bg-surface p-5 shadow-sm space-y-4">
       <div>
         <p className="text-3xl font-semibold">от {formatRubMinor(listing.price_from_minor)} ₽</p>
         <p className="text-sm text-muted-foreground">на человека</p>

--- a/src/data/supabase/queries.test.ts
+++ b/src/data/supabase/queries.test.ts
@@ -513,6 +513,34 @@ describe("guide stats layering (no fabricated zeros)", () => {
   });
 });
 
+describe("destination ratings (no fabricated stars)", () => {
+  it("keeps the real rating and returns null when no rating exists in getDestinations", async () => {
+    const client = createFakeClient({
+      destinations: [
+        { id: "dest-1", slug: "moscow", name: "Москва", rating: 4.2 },
+        { id: "dest-2", slug: "kazan", name: "Казань", rating: null },
+      ],
+    });
+
+    const result = await getDestinations(client);
+
+    expect(result.error).toBeNull();
+    expect(result.data?.[0]?.avgRating).toBe(4.2);
+    expect(result.data?.[1]?.avgRating).toBeNull();
+  });
+
+  it("returns null avgRating from getDestinationBySlug when the row has no rating", async () => {
+    const client = createFakeClient({
+      destinations: [{ id: "dest-1", slug: "moscow", name: "Москва", rating: null }],
+    });
+
+    const result = await getDestinationBySlug(client, "moscow");
+
+    expect(result.error).toBeNull();
+    expect(result.data?.avgRating).toBeNull();
+  });
+});
+
 describe("getPlatformStats", () => {
   it("maps the single platform_stats view row to camelCase counts", async () => {
     const client = createFakeClient({

--- a/src/data/supabase/queries.test.ts
+++ b/src/data/supabase/queries.test.ts
@@ -25,6 +25,8 @@ import {
   mapRequestRow,
   getOffersForRequest,
   getOpenRequests,
+  getOpenRequestsByDestination,
+  getPlatformStats,
   getListingReviews,
   getListingsByDestination,
   getListingsByGuide,
@@ -508,5 +510,81 @@ describe("guide stats layering (no fabricated zeros)", () => {
     expect(result.error).toBeNull();
     expect(result.data?.[0]?.rating).toBe(4.9);
     expect(result.data?.[0]?.verified).toBe(true);
+  });
+});
+
+describe("getPlatformStats", () => {
+  it("maps the single platform_stats view row to camelCase counts", async () => {
+    const client = createFakeClient({
+      platform_stats: [{ guides_active: 15, listings_total: 12, trips_total: 10 }],
+    });
+
+    const result = await getPlatformStats(client);
+
+    expect(result.error).toBeNull();
+    expect(result.data).toEqual({ guidesActive: 15, listingsTotal: 12, tripsTotal: 10 });
+  });
+
+  it("returns the error when the view query fails", async () => {
+    const statsError = new Error("platform_stats policy denied");
+    const client = createFakeClient({}, { platform_stats: statsError });
+
+    const result = await getPlatformStats(client);
+
+    expect(result.data).toBeNull();
+    expect(result.error).toBeTruthy();
+  });
+
+  it("returns null data without an error when no row is present", async () => {
+    const client = createFakeClient({ platform_stats: [] });
+
+    const result = await getPlatformStats(client);
+
+    expect(result.data).toBeNull();
+    expect(result.error).toBeNull();
+  });
+});
+
+describe("getOpenRequestsByDestination", () => {
+  it("returns mapped open requests for the given region", async () => {
+    const client = createFakeClient({
+      traveler_requests: [
+        {
+          id: "request-1",
+          destination: "Элиста",
+          region: "Калмыкия",
+          budget_minor: 100_000,
+          participants_count: 2,
+          status: "open",
+          created_at: "2026-06-03T00:00:00Z",
+          traveler_id: "traveler-1",
+        },
+        {
+          id: "request-2",
+          destination: "Городовиковск",
+          region: "Калмыкия",
+          budget_minor: 80_000,
+          participants_count: 1,
+          status: "open",
+          created_at: "2026-06-02T00:00:00Z",
+          traveler_id: "traveler-2",
+        },
+      ],
+    });
+
+    const result = await getOpenRequestsByDestination(client, "Калмыкия");
+
+    expect(result.error).toBeNull();
+    expect(result.data).toHaveLength(2);
+    expect(result.data?.every((rec) => rec.status === "open")).toBe(true);
+  });
+
+  it("returns an empty list when no open requests match the region", async () => {
+    const client = createFakeClient({ traveler_requests: [] });
+
+    const result = await getOpenRequestsByDestination(client, "Калмыкия");
+
+    expect(result.error).toBeNull();
+    expect(result.data).toEqual([]);
   });
 });

--- a/src/data/supabase/queries.test.ts
+++ b/src/data/supabase/queries.test.ts
@@ -438,3 +438,75 @@ describe("query performance safeguards", () => {
     expect(destinationFilterIndex).toBeLessThan(limitIndex);
   });
 });
+
+describe("guide stats layering (no fabricated zeros)", () => {
+  it("layers real view stats and approved verification onto getGuideBySlug", async () => {
+    const client = createFakeClient({
+      guide_profiles: [
+        {
+          user_id: "guide-1",
+          slug: "guide-1",
+          display_name: "Иван Гид",
+          regions: ["Москва"],
+          verification_status: "approved",
+        },
+      ],
+      v_guide_public_profile: [
+        { average_rating: 4.6, review_count: 8, response_rate: 91 },
+      ],
+    });
+
+    const result = await getGuideBySlug(client, "guide-1");
+
+    expect(result.error).toBeNull();
+    expect(result.data?.rating).toBe(4.6);
+    expect(result.data?.reviewCount).toBe(8);
+    expect(result.data?.responseRate).toBe(91);
+    expect(result.data?.verified).toBe(true);
+  });
+
+  it("keeps getGuideBySlug unverified with null responseRate when stats are absent", async () => {
+    const client = createFakeClient({
+      guide_profiles: [
+        {
+          user_id: "guide-1",
+          slug: "guide-1",
+          display_name: "Иван Гид",
+          regions: ["Москва"],
+          verification_status: "pending",
+        },
+      ],
+      v_guide_public_profile: [],
+    });
+
+    const result = await getGuideBySlug(client, "guide-1");
+
+    expect(result.error).toBeNull();
+    expect(result.data?.verified).toBe(false);
+    expect(result.data?.rating).toBe(0);
+    expect(result.data?.responseRate).toBeNull();
+  });
+
+  it("layers real view stats and approved verification onto getGuidesByDestination", async () => {
+    const client = createFakeClient({
+      "rpc:search_guides": [
+        {
+          user_id: "guide-1",
+          slug: "guide-1",
+          display_name: "Иван Гид",
+          regions: ["Москва"],
+          years_experience: 7,
+          verification_status: "approved",
+        },
+      ],
+      profiles: [],
+      v_guide_public_profile: [{ user_id: "guide-1", average_rating: 4.9 }],
+    });
+
+    const result = await getGuidesByDestination(client, "Москва");
+
+    expect(result.error).toBeNull();
+    expect(result.data?.[0]?.rating).toBe(4.9);
+    expect(result.data?.[0]?.verified).toBe(true);
+  });
+});

--- a/src/data/supabase/queries.ts
+++ b/src/data/supabase/queries.ts
@@ -74,6 +74,12 @@ export type GuideRecord = {
   languages: string[];
 };
 
+export type PlatformStats = {
+  guidesActive: number;
+  listingsTotal: number;
+  tripsTotal: number;
+};
+
 export type RequestMember = {
   id: string;
   displayName: string;
@@ -604,6 +610,29 @@ export async function getDestinationBySlug(client: SupabaseClient, slug: string)
   }
 }
 
+export async function getPlatformStats(
+  client: SupabaseClient,
+): Promise<QueryResult<PlatformStats | null>> {
+  try {
+    const { data, error } = await client
+      .from("platform_stats")
+      .select("guides_active, listings_total, trips_total")
+      .maybeSingle();
+    if (error) throw error;
+    if (!data) return { data: null, error: null };
+    return {
+      data: {
+        guidesActive: (data.guides_active as number | null) ?? 0,
+        listingsTotal: (data.listings_total as number | null) ?? 0,
+        tripsTotal: (data.trips_total as number | null) ?? 0,
+      },
+      error: null,
+    };
+  } catch (error) {
+    return { data: null, error: makeError(error) };
+  }
+}
+
 // ---------------------------------------------------------------------------
 // Listings (public.listings — RLS: published are readable)
 // ---------------------------------------------------------------------------
@@ -701,6 +730,38 @@ export async function getOpenRequests(
     }
 
     return { data: applyRequestFilters(records, filters), error: null };
+  } catch (error) {
+    return { data: [], error: makeError(error) };
+  }
+}
+
+export async function getOpenRequestsByDestination(
+  client: SupabaseClient,
+  region: string,
+): Promise<QueryResult<RequestRecord[]>> {
+  try {
+    const db = client;
+    const { data, error } = await db
+      .from("traveler_requests")
+      .select("*")
+      .eq("status", "open")
+      .ilike("region", `%${region}%`)
+      .order("created_at", { ascending: false })
+      .limit(12);
+
+    if (error) throw error;
+    if (!data || data.length === 0) return { data: [], error: null };
+
+    const records = data.map((row) => mapRequestRow(row));
+    const membersMap = await fetchMembersForRequests(
+      db,
+      data.map((row) => ({ id: row.id as string, creatorId: row.traveler_id as string })),
+    );
+    for (const rec of records) {
+      rec.members = membersMap.get(rec.id) ?? [];
+    }
+
+    return { data: records, error: null };
   } catch (error) {
     return { data: [], error: makeError(error) };
   }

--- a/src/data/supabase/queries.ts
+++ b/src/data/supabase/queries.ts
@@ -69,6 +69,7 @@ export type GuideRecord = {
   specialties: string[];
   tripsCompleted: number;
   recommendPct: number | null;
+  responseRate?: number | null;
   verified: boolean;
   languages: string[];
 };
@@ -783,7 +784,7 @@ export async function getGuides(
 
     const { data: statRows } = await client
       .from("v_guide_public_profile")
-      .select("user_id, avatar_url, average_rating, review_count, trips_completed, recommend_pct, specialties, languages")
+      .select("user_id, avatar_url, average_rating, review_count, trips_completed, recommend_pct, specialties, languages, response_rate")
       .in("user_id", guideIds);
 
     const ratingMap = new Map<
@@ -793,6 +794,7 @@ export async function getGuides(
         reviewCount: number;
         tripsCompleted: number;
         recommendPct: number | null;
+        responseRate: number | null;
         specialties: string[];
         languages: string[];
         avatarUrl: string | null;
@@ -804,6 +806,7 @@ export async function getGuides(
         reviewCount: (row.review_count as number | null) ?? 0,
         tripsCompleted: (row.trips_completed as number | null) ?? 0,
         recommendPct: (row.recommend_pct as number | null) ?? null,
+        responseRate: (row.response_rate as number | null) ?? null,
         specialties: (row.specialties as string[] | null) ?? [],
         languages: (row.languages as string[] | null) ?? [],
         avatarUrl: (row.avatar_url as string | null) ?? null,
@@ -824,6 +827,7 @@ export async function getGuides(
             reviewCount: stats?.reviewCount ?? 0,
             tripsCompleted: stats?.tripsCompleted ?? base.tripsCompleted,
             recommendPct: stats?.recommendPct ?? base.recommendPct,
+            responseRate: stats?.responseRate ?? null,
             specialties: stats?.specialties ?? base.specialties,
             languages: stats?.languages ?? base.languages,
             verified: (row.verification_status as string | null) === "approved",
@@ -865,8 +869,31 @@ export async function getGuidesByDestination(
       rows.map((row) => row.user_id as string),
     );
 
+    const { data: statRows } = await client
+      .from("v_guide_public_profile")
+      .select("user_id, avatar_url, average_rating, review_count, trips_completed, recommend_pct, specialties, languages, response_rate")
+      .in("user_id", rows.map((r) => r.user_id as string));
+    const statsMap = new Map<string, Record<string, unknown>>();
+    for (const s of statRows ?? []) statsMap.set(s.user_id as string, s);
+
     return {
-      data: rows.map((row) => mapGuideRow(row, profileMap.get(row.user_id as string) ?? null)),
+      data: rows.map((row) => {
+        const uid = row.user_id as string;
+        const s = statsMap.get(uid);
+        const base = mapGuideRow(row, profileMap.get(uid) ?? null);
+        return {
+          ...base,
+          avatarUrl: (s?.avatar_url as string) ?? base.avatarUrl ?? undefined,
+          rating: (s?.average_rating as number | null) ?? 0,
+          reviewCount: (s?.review_count as number | null) ?? 0,
+          tripsCompleted: (s?.trips_completed as number | null) ?? base.tripsCompleted,
+          recommendPct: (s?.recommend_pct as number | null) ?? null,
+          specialties: (s?.specialties as string[] | null) ?? base.specialties,
+          languages: (s?.languages as string[] | null) ?? base.languages,
+          responseRate: (s?.response_rate as number | null) ?? null,
+          verified: (row.verification_status as string | null) === "approved",
+        };
+      }),
       error: null,
     };
   } catch (error) {
@@ -892,7 +919,7 @@ export async function getGuideBySlug(
 
     const { data: stats } = await client
       .from("v_guide_public_profile")
-      .select("average_rating, review_count, trips_completed, recommend_pct, languages, specialties")
+      .select("average_rating, review_count, trips_completed, recommend_pct, languages, specialties, response_rate")
       .eq("user_id", record.id)
       .maybeSingle();
     record.rating = stats?.average_rating ?? 0;
@@ -901,6 +928,8 @@ export async function getGuideBySlug(
     record.recommendPct = stats?.recommend_pct ?? null;
     record.languages = stats?.languages ?? [];
     record.specialties = stats?.specialties ?? [];
+    record.responseRate = (stats?.response_rate as number | null) ?? null;
+    record.verified = (data.verification_status as string | null) === "approved";
 
     return { data: record, error: null };
   } catch (error) {

--- a/src/data/supabase/queries.ts
+++ b/src/data/supabase/queries.ts
@@ -20,7 +20,7 @@ export type DestinationRecord = {
   heroImageUrl: string;
   listingCount: number;
   guidesCount: number;
-  avgRating: number;
+  avgRating: number | null;
 };
 
 export type ListingRecord = {
@@ -565,7 +565,7 @@ export async function getDestinations(client: SupabaseClient): Promise<QueryResu
     if (!data || data.length === 0) return { data: [], error: null };
 
     return {
-      data: data.map((row, index) => ({
+      data: data.map((row) => ({
         id: row.id,
         slug: row.slug,
         name: row.name,
@@ -575,7 +575,7 @@ export async function getDestinations(client: SupabaseClient): Promise<QueryResu
         heroImageUrl: row.hero_image_url ?? fallbackHeroImage,
         listingCount: row.listing_count ?? 0,
         guidesCount: row.guides_count ?? 0,
-        avgRating: row.rating ?? 4.7 + ((index % 3) * 0.1),
+        avgRating: typeof row.rating === "number" ? row.rating : null,
       })),
       error: null,
     };
@@ -601,7 +601,7 @@ export async function getDestinationBySlug(client: SupabaseClient, slug: string)
         heroImageUrl: data.hero_image_url ?? fallbackHeroImage,
         listingCount: data.listing_count ?? 0,
         guidesCount: data.guides_count ?? 0,
-        avgRating: data.rating ?? 4.8,
+        avgRating: typeof data.rating === "number" ? data.rating : null,
       },
       error: null,
     };

--- a/src/features/destinations/components/destination-detail-screen.test.tsx
+++ b/src/features/destinations/components/destination-detail-screen.test.tsx
@@ -1,0 +1,49 @@
+import { render } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import { DestinationDetailScreen } from "./destination-detail-screen";
+import type { DestinationSummary } from "@/data/destinations/types";
+
+function makeDestination(overrides: Partial<DestinationSummary> = {}): DestinationSummary {
+  return {
+    slug: "altai",
+    name: "Алтай",
+    region: "Алтай",
+    imageUrl: "/hero.jpg",
+    description: "",
+    listingCount: 0,
+    openRequestCount: 0,
+    ...overrides,
+  };
+}
+
+describe("DestinationDetailScreen — requests section", () => {
+  it("renders a real count when there are open requests", () => {
+    const { container } = render(
+      <DestinationDetailScreen destination={makeDestination({ openRequestCount: 3 })} />,
+    );
+
+    expect(container.textContent).toContain("3 активных запроса");
+    expect(container.textContent).not.toContain(
+      "Сейчас нет активных запросов по этому направлению.",
+    );
+  });
+
+  it("renders the empty message when there are no open requests", () => {
+    const { container } = render(
+      <DestinationDetailScreen destination={makeDestination({ openRequestCount: 0 })} />,
+    );
+
+    expect(container.textContent).toContain(
+      "Сейчас нет активных запросов по этому направлению.",
+    );
+  });
+
+  it("points the «Создать запрос» CTA at /form", () => {
+    const { getByText } = render(
+      <DestinationDetailScreen destination={makeDestination()} />,
+    );
+
+    expect(getByText("Создать запрос").closest("a")).toHaveAttribute("href", "/form");
+  });
+});

--- a/src/features/destinations/components/destination-detail-screen.tsx
+++ b/src/features/destinations/components/destination-detail-screen.tsx
@@ -9,6 +9,7 @@ import type { DestinationSummary } from "@/data/destinations/types";
 import type { OpenRequestRecord } from "@/data/open-requests/types";
 import type { GuideRecord, ListingRecord } from "@/data/supabase/queries";
 import { PublicGuideCard } from "@/features/guide/components/public/public-guide-card";
+import { ROUTES } from "@/lib/navigation";
 import { pluralize } from "@/lib/utils";
 
 import { ListingsFilter } from "./listings-filter";
@@ -226,14 +227,27 @@ export function DestinationDetailScreen({
           </div>
 
           <div className="flex flex-col gap-3">
-            <p className="text-sm text-muted-foreground">
-              Сейчас нет активных запросов по этому направлению.
-            </p>
+            {formingGroupCount > 0 ? (
+              <p className="text-base text-foreground">
+                Сейчас {formingGroupCount}{" "}
+                {pluralize(
+                  formingGroupCount,
+                  "активный запрос",
+                  "активных запроса",
+                  "активных запросов",
+                )}{" "}
+                — путешественники ищут гида в {destination.name}.
+              </p>
+            ) : (
+              <p className="text-sm text-muted-foreground">
+                Сейчас нет активных запросов по этому направлению.
+              </p>
+            )}
           </div>
 
           <div className="mt-6 flex flex-wrap gap-3">
             <Link
-              href={`/?destination=${encodeURIComponent(destination.name)}`}
+              href={ROUTES.newRequest.href}
               className="inline-flex items-center rounded-full bg-foreground px-5 py-2.5 text-sm font-semibold text-background transition-opacity hover:opacity-90"
             >
               Создать запрос

--- a/src/features/destinations/components/destinations-grid.test.tsx
+++ b/src/features/destinations/components/destinations-grid.test.tsx
@@ -1,0 +1,52 @@
+import { render } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import { DestinationsGrid } from "./destinations-grid";
+import type { DestinationRecord } from "@/data/supabase/queries";
+
+function makeDestination(i: number, overrides: Partial<DestinationRecord> = {}): DestinationRecord {
+  return {
+    id: `id-${i}`,
+    slug: `dest-${i}`,
+    name: `Направление ${i}`,
+    region: "Россия",
+    category: "city",
+    description: "",
+    heroImageUrl: "/hero.jpg",
+    listingCount: 3,
+    guidesCount: 2,
+    avgRating: 4.5,
+    ...overrides,
+  };
+}
+
+describe("DestinationsGrid", () => {
+  it("renders all destinations without capping at 5", () => {
+    const destinations = Array.from({ length: 8 }, (_, i) => makeDestination(i));
+
+    const { container } = render(<DestinationsGrid destinations={destinations} />);
+
+    expect(
+      container.querySelectorAll('[data-slot="destination-card"]')
+    ).toHaveLength(8);
+  });
+
+  it("renders no rating star when avgRating is null", () => {
+    const destinations = [makeDestination(0, { avgRating: null })];
+
+    const { container } = render(<DestinationsGrid destinations={destinations} />);
+
+    expect(
+      container.querySelector('[data-slot="destination-rating"]')
+    ).toBeNull();
+  });
+
+  it("shows an empty state when there are no destinations", () => {
+    const { container } = render(<DestinationsGrid destinations={[]} />);
+
+    expect(
+      container.querySelector('[data-slot="destination-card"]')
+    ).toBeNull();
+    expect(container.textContent).toContain("Пока нет доступных направлений");
+  });
+});

--- a/src/features/destinations/components/destinations-grid.tsx
+++ b/src/features/destinations/components/destinations-grid.tsx
@@ -1,21 +1,12 @@
 "use client";
 
 import * as React from "react";
-import Image from "next/image";
-import Link from "next/link";
-import { Search } from "lucide-react";
+import { Compass, Search } from "lucide-react";
 
 import type { DestinationRecord } from "@/data/supabase/queries";
+import { DestinationCard } from "@/components/discovery/DestinationCard";
+import { EmptyState } from "@/components/ui/empty-state";
 import { Input } from "@/components/ui/input";
-
-function toursWord(n: number) {
-  const mod10 = n % 10;
-  const mod100 = n % 100;
-  if (mod100 >= 11 && mod100 <= 14) return "туров";
-  if (mod10 === 1) return "тур";
-  if (mod10 >= 2 && mod10 <= 4) return "тура";
-  return "туров";
-}
 
 function normalize(value: string) {
   return value.trim().toLowerCase();
@@ -37,7 +28,15 @@ export function DestinationsGrid({
     });
   }, [destinations, query]);
 
-  const [featured, ...rest] = filtered;
+  if (destinations.length === 0) {
+    return (
+      <EmptyState
+        icon={Compass}
+        title="Пока нет доступных направлений"
+        description="Загляните позже — мы добавляем новые города и регионы."
+      />
+    );
+  }
 
   return (
     <>
@@ -61,72 +60,24 @@ export function DestinationsGrid({
         </div>
       </div>
 
-      {filtered.length === 0 && (
+      {filtered.length === 0 ? (
         <p className="mt-8 text-on-surface-muted">
           Ничего не найдено. Попробуйте другой запрос.
         </p>
-      )}
-
-      {filtered.length > 0 && (
-        <div className="mt-12 grid grid-cols-1 gap-4 md:grid-cols-2 lg:grid-cols-[1.35fr_1fr_1fr] lg:grid-rows-[280px_280px]">
-          {featured && (
-            <Link
-              href={`/destinations/${featured.slug}`}
-              className="relative block min-h-[240px] overflow-hidden rounded-glass bg-surface-low lg:row-span-2"
-            >
-              <Image
-                src={
-                  featured.heroImageUrl ||
-                  "https://images.unsplash.com/photo-1476514525535-07fb3b4ae5f1?auto=format&fit=crop&w=1600&q=80"
-                }
-                alt={featured.name}
-                fill
-                style={{ objectFit: "cover" }}
-                sizes="(max-width: 767px) 100vw, (max-width: 1023px) 100vw, 560px"
-              />
-              <div className="absolute inset-0 bg-gradient-to-t from-foreground/80 to-foreground/10" />
-              <div className="absolute inset-0 z-[1] flex flex-col justify-end p-6">
-                {featured.listingCount ? (
-                  <span className="mb-2.5 inline-flex w-fit items-center gap-1.5 rounded-full border border-primary-foreground/20 bg-primary-foreground/15 px-3 py-1 text-xs font-medium text-primary-foreground/90 backdrop-blur-[12px]">
-                    {featured.listingCount} {toursWord(featured.listingCount)}
-                  </span>
-                ) : null}
-                <p className="font-display text-[1.75rem] font-semibold leading-[1.1] text-primary-foreground">
-                  {featured.name}
-                </p>
-                {featured.region && normalize(featured.region) !== normalize(featured.name) ? (
-                  <p className="mt-1 text-[0.8125rem] text-primary-foreground/70">{featured.region}</p>
-                ) : null}
-              </div>
-            </Link>
-          )}
-
-          {rest.slice(0, 4).map((dest) => (
-            <Link
-              key={dest.slug}
-              href={`/destinations/${dest.slug}`}
-              className="relative block min-h-[240px] overflow-hidden rounded-glass bg-surface-low"
-            >
-              <Image
-                src={
-                  dest.heroImageUrl ||
-                  "https://images.unsplash.com/photo-1476514525535-07fb3b4ae5f1?auto=format&fit=crop&w=800&q=80"
-                }
-                alt={dest.name}
-                fill
-                style={{ objectFit: "cover" }}
-                sizes="(max-width: 767px) 100vw, (max-width: 1023px) 50vw, 320px"
-              />
-              <div className="absolute inset-0 bg-gradient-to-t from-foreground/80 to-foreground/10" />
-              <div className="absolute inset-0 z-[1] flex flex-col justify-end p-6">
-                <p className="font-display text-[1.25rem] font-semibold leading-[1.1] text-primary-foreground">
-                  {dest.name}
-                </p>
-                {dest.region && normalize(dest.region) !== normalize(dest.name) ? (
-                  <p className="mt-1 text-[0.8125rem] text-primary-foreground/70">{dest.region}</p>
-                ) : null}
-              </div>
-            </Link>
+      ) : (
+        <div className="mt-12 grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3">
+          {filtered.map((d, index) => (
+            <DestinationCard
+              key={d.slug}
+              name={d.name}
+              slug={d.slug}
+              photoUrl={d.heroImageUrl}
+              guidesCount={d.guidesCount}
+              tourCount={d.listingCount}
+              category={d.category}
+              rating={d.avgRating}
+              featured={index === 0}
+            />
           ))}
         </div>
       )}

--- a/src/features/guide/components/public/guide-profile-screen.test.tsx
+++ b/src/features/guide/components/public/guide-profile-screen.test.tsx
@@ -1,0 +1,60 @@
+import { render } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import { GuideProfileScreen } from "./guide-profile-screen";
+import type { PublicGuideProfile } from "@/data/public-guides/types";
+
+function makeGuide(overrides: Partial<PublicGuideProfile> = {}): PublicGuideProfile {
+  return {
+    slug: "ivan-petrov",
+    displayName: "Иван Петров",
+    headline: "Авторские маршруты по Алтаю",
+    homeBase: "Горно-Алтайск",
+    verificationStatus: "approved",
+    completedTours: 0,
+    tripsCompleted: 0,
+    recommendPct: null,
+    yearsExperience: 3,
+    regions: ["Алтай"],
+    languages: ["Русский"],
+    specialties: ["Треккинг", "Этнотуры"],
+    bio: "Вожу группы по горам уже несколько лет.",
+    reviewsSummary: { averageRating: 0, totalReviews: 0 },
+    ...overrides,
+  };
+}
+
+describe("GuideProfileScreen", () => {
+  it("renders the NewGuideFrame cold-start frame when there are no reviews", () => {
+    const { container } = render(<GuideProfileScreen guide={makeGuide()} />);
+
+    expect(container.textContent).toContain("Первые туры");
+  });
+
+  it("hides the cold-start frame once the guide has reviews", () => {
+    const { container } = render(
+      <GuideProfileScreen
+        guide={makeGuide({ reviewsSummary: { averageRating: 4.8, totalReviews: 5 } })}
+      />,
+    );
+
+    expect(container.textContent).not.toContain("Первые туры");
+  });
+
+  it("renders specialties without retired tokens or raw rgba classes", () => {
+    const { getByText } = render(<GuideProfileScreen guide={makeGuide()} />);
+
+    const specialty = getByText("Треккинг");
+    expect(specialty.className).not.toContain("text-ink-2");
+    expect(specialty.className).not.toContain("rgba");
+  });
+
+  it("points the request CTA at /form?guide=<slug>", () => {
+    const { getByText } = render(<GuideProfileScreen guide={makeGuide()} />);
+
+    expect(getByText("Запросить этого гида").closest("a")).toHaveAttribute(
+      "href",
+      "/form?guide=ivan-petrov",
+    );
+  });
+});

--- a/src/features/guide/components/public/guide-profile-screen.tsx
+++ b/src/features/guide/components/public/guide-profile-screen.tsx
@@ -2,10 +2,13 @@ import Link from "next/link";
 import { BadgeCheck, Star } from "lucide-react";
 
 import { Button } from "@/components/ui/button";
+import { Tag } from "@/components/ui/tag";
 import { ImmersiveHero } from "@/components/shared/immersive-hero";
 import { TourCard } from "@/components/shared/tour-card";
+import { NewGuideFrame } from "@/components/discovery/NewGuideFrame";
 import type { PublicGuideProfile } from "@/data/public-guides/types";
 import { formatRussianDate } from "@/lib/dates";
+import { ROUTES } from "@/lib/navigation";
 import { pluralize } from "@/lib/utils";
 import { GuidePhotoGrid } from "./guide-photo-grid";
 
@@ -166,6 +169,13 @@ export function GuideProfileScreen({ guide, listings, reviews, photos = [] }: Pr
               </div>
             ) : null}
 
+            {totalReviews === 0 ? (
+              <NewGuideFrame
+                guideName={guide.displayName}
+                className="mt-6 w-full max-w-[38rem] text-left"
+              />
+            ) : null}
+
             <p className="mt-6 max-w-[38rem] leading-[1.7] text-muted-foreground">
               {guide.bio}
             </p>
@@ -173,12 +183,9 @@ export function GuideProfileScreen({ guide, listings, reviews, photos = [] }: Pr
             {guide.specialties.length > 0 ? (
               <div className="mt-6 flex flex-wrap justify-center gap-[7px]">
                 {guide.specialties.map((specialty) => (
-                  <span
-                    key={specialty}
-                    className="rounded-full bg-[rgba(20,28,40,.05)] px-3 py-[5px] text-[12.5px] font-medium text-ink-2"
-                  >
+                  <Tag key={specialty} color="primary">
                     {specialty}
-                  </span>
+                  </Tag>
                 ))}
               </div>
             ) : null}
@@ -188,7 +195,7 @@ export function GuideProfileScreen({ guide, listings, reviews, photos = [] }: Pr
                 {guide.languages.map((lang) => (
                   <span
                     key={lang}
-                    className="rounded-full bg-[rgba(20,28,40,.05)] px-3 py-[5px] text-[12.5px] font-medium text-on-surface-muted"
+                    className="rounded-full border border-line bg-surface-low px-3 py-[5px] text-[12.5px] font-medium text-on-surface-muted"
                   >
                     {lang}
                   </span>
@@ -198,7 +205,9 @@ export function GuideProfileScreen({ guide, listings, reviews, photos = [] }: Pr
 
             <div className="mt-8 flex flex-wrap items-center justify-center gap-3">
               <Button asChild>
-                <Link href="/">Оставить запрос</Link>
+                <Link href={`${ROUTES.newRequest.href}?guide=${guide.slug}`}>
+                  Запросить этого гида
+                </Link>
               </Button>
               {guideHasListings ? (
                 <Button asChild variant="outline">

--- a/src/lib/__tests__/format.test.ts
+++ b/src/lib/__tests__/format.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, test } from "vitest";
+import { formatDuration, getFormatLabel } from "../format";
+
+describe("getFormatLabel", () => {
+  test("maps known formats to Russian labels", () => {
+    expect(getFormatLabel("private")).toBe("Частный");
+    expect(getFormatLabel("group")).toBe("Групповой");
+    expect(getFormatLabel("combo")).toBe("Смешанный");
+  });
+
+  test("returns null for null or unknown formats", () => {
+    expect(getFormatLabel(null)).toBeNull();
+    expect(getFormatLabel("unknown")).toBeNull();
+  });
+});
+
+describe("formatDuration", () => {
+  test("renders sub-day durations in rounded hours", () => {
+    expect(formatDuration(60)).toBe("1 ч.");
+    expect(formatDuration(90)).toBe("2 ч.");
+    expect(formatDuration(479)).toBe("8 ч.");
+  });
+
+  test("renders day-scale durations in ceil'd days", () => {
+    expect(formatDuration(480)).toBe("1 дн.");
+    expect(formatDuration(960)).toBe("2 дн.");
+    expect(formatDuration(1000)).toBe("3 дн.");
+  });
+});

--- a/src/lib/format.ts
+++ b/src/lib/format.ts
@@ -1,0 +1,14 @@
+/** Canonical excursion-format + duration labels for Discovery surfaces. */
+export function getFormatLabel(format: string | null): string | null {
+  switch (format) {
+    case "private": return "Частный";
+    case "group": return "Групповой";
+    case "combo": return "Смешанный";
+    default: return null;
+  }
+}
+
+export function formatDuration(minutes: number): string {
+  if (minutes < 480) return `${Math.round(minutes / 60)} ч.`;
+  return `${Math.ceil(minutes / 480)} дн.`;
+}

--- a/src/lib/navigation.ts
+++ b/src/lib/navigation.ts
@@ -21,6 +21,7 @@ export const ROUTES = {
   guides:       { href: "/guides",       label: "Гиды",              icon: UserSearch },
   destinations: { href: "/destinations", label: "Направления",       icon: Map },
   search:       { href: "/search",       label: "Поиск",             icon: Search },
+  newRequest:   { href: "/form",         label: "Создать запрос",    icon: ClipboardList },
   howItWorks:   { href: "/how-it-works", label: "Как это работает",  icon: Route },
   becomeGuide:  { href: "/become-a-guide", label: "Стать гидом",     icon: BadgeCheck },
   trust:        { href: "/trust",        label: "Доверие и безопасность", icon: ShieldCheck },


### PR DESCRIPTION
J2 Discovery — real guide stats (getGuidesByDestination/getGuideBySlug), killed fabricated destination ratings, getPlatformStats + getOpenRequestsByDestination, 7 discovery primitives, /destinations + /guides + /listings + /search rebuilt with canon tokens, honest counts (count:exact), error states (destructive Alert), identity-reveal, /form CTAs, retired glass-token sweep on listing-detail. Home = Phase-1 shipped. All gates green.