### PR TITLE
Stage 5 (C1): payment agreement seam

### DIFF
--- a/src/app/(protected)/bookings/[bookingId]/page.tsx
+++ b/src/app/(protected)/bookings/[bookingId]/page.tsx
@@ -5,6 +5,7 @@ import { BookingDetailScreen } from "@/features/bookings/components/booking-deta
 import { openBookingThreadAction } from "@/features/bookings/booking-actions";
 import { viewerRoleForBooking } from "@/lib/auth/viewer-role-for-booking";
 import { getBooking } from "@/lib/supabase/bookings";
+import { getPaymentAgreementForBooking } from "@/lib/supabase/payment-agreements";
 import { getReviewForBooking } from "@/lib/supabase/reviews";
 import { createSupabaseServerClient } from "@/lib/supabase/server";
 
@@ -46,6 +47,10 @@ export default async function BookingDetailPage({
   const booking = await getBooking(bookingId);
   if (!booking) notFound();
 
+  const paymentAgreement = await getPaymentAgreementForBooking(bookingId).catch(
+    () => null,
+  );
+
   const supabase = await createSupabaseServerClient();
   let listingTitle: string | undefined;
   if (booking.listing_id) {
@@ -65,6 +70,7 @@ export default async function BookingDetailPage({
         viewerRole="admin"
         booking={booking}
         listingTitle={listingTitle}
+        paymentAgreement={paymentAgreement}
       />
     );
   }
@@ -81,6 +87,7 @@ export default async function BookingDetailPage({
       booking={booking}
       existingReview={existingReview}
       listingTitle={listingTitle}
+      paymentAgreement={paymentAgreement}
       reviewStatus={reviewStatus}
       disputeStatus={disputeStatus}
       openBookingThreadAction={async (bookingId: string) => {

--- a/src/features/bookings/components/booking-detail-screen.test.tsx
+++ b/src/features/bookings/components/booking-detail-screen.test.tsx
@@ -68,6 +68,8 @@ const booking = {
   currency: "RUB",
   cancellation_policy_snapshot: null,
   meeting_point: "Площадь Ленина",
+  payment_method: "in_person",
+  payment_status: "pending",
   created_at: "2026-06-01T00:00:00.000Z",
   updated_at: "2026-06-01T00:00:00.000Z",
   guide_phone: "+79990000000",

--- a/src/features/bookings/components/booking-detail-screen.test.tsx
+++ b/src/features/bookings/components/booking-detail-screen.test.tsx
@@ -51,6 +51,10 @@ vi.mock("@/app/(protected)/guide/bookings/[bookingId]/actions", () => ({
   getGuideBookingDetailAction,
 }));
 
+vi.mock("@/features/bookings/payment-agreement-actions", () => ({
+  confirmPaymentAgreementAction: vi.fn().mockResolvedValue({ ok: true }),
+}));
+
 const booking = {
   id: "booking-1",
   traveler_id: "traveler-1",
@@ -328,6 +332,75 @@ describe("BookingDetailScreen", () => {
 
     expect(await screen.findByText(/Выплата:/)).toBeInTheDocument();
     vi.unstubAllEnvs();
+  });
+
+  it("renders the payment agreement card with a confirm button when the traveler has not confirmed", () => {
+    render(
+      <BookingDetailScreen
+        viewerRole="traveler"
+        booking={booking}
+        existingReview={null}
+        listingTitle="Городская прогулка"
+        paymentAgreement={{
+          id: "agreement-1",
+          bookingId: "booking-1",
+          agreedTotalMinor: 600000,
+          currency: "RUB",
+          method: "in_person",
+          travelerConfirmedAt: null,
+          guideConfirmedAt: null,
+        }}
+        openBookingThreadAction={async () => ({ threadId: "thread-1" })}
+      />,
+    );
+
+    expect(screen.getByText("Договорённость об оплате")).toBeInTheDocument();
+    expect(screen.getByText("Оплата при встрече")).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: "Подтвердить договорённость" }),
+    ).toBeInTheDocument();
+  });
+
+  it("shows the confirmed state and hides the button once the traveler has confirmed", () => {
+    render(
+      <BookingDetailScreen
+        viewerRole="traveler"
+        booking={booking}
+        existingReview={null}
+        listingTitle="Городская прогулка"
+        paymentAgreement={{
+          id: "agreement-1",
+          bookingId: "booking-1",
+          agreedTotalMinor: 600000,
+          currency: "RUB",
+          method: "in_person",
+          travelerConfirmedAt: "2026-06-23T10:00:00Z",
+          guideConfirmedAt: null,
+        }}
+        openBookingThreadAction={async () => ({ threadId: "thread-1" })}
+      />,
+    );
+
+    expect(screen.getByText("Договорённость об оплате")).toBeInTheDocument();
+    expect(screen.getByText("подтвердил")).toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", { name: "Подтвердить договорённость" }),
+    ).not.toBeInTheDocument();
+  });
+
+  it("omits the payment agreement card when no agreement exists", () => {
+    render(
+      <BookingDetailScreen
+        viewerRole="traveler"
+        booking={booking}
+        existingReview={null}
+        listingTitle="Городская прогулка"
+        paymentAgreement={null}
+        openBookingThreadAction={async () => ({ threadId: "thread-1" })}
+      />,
+    );
+
+    expect(screen.queryByText("Договорённость об оплате")).not.toBeInTheDocument();
   });
 
   it("renders BookingDetailSkeleton placeholder blocks", () => {

--- a/src/features/bookings/components/booking-detail-screen.tsx
+++ b/src/features/bookings/components/booking-detail-screen.tsx
@@ -38,6 +38,8 @@ import { formatRussianDateRange, formatRussianTime } from "@/lib/dates";
 import { flags } from "@/lib/flags";
 import { resolveDisplayName } from "@/lib/profile/resolve-display-name";
 import type { BookingWithDetails } from "@/lib/supabase/bookings";
+import type { PaymentAgreement } from "@/lib/supabase/payment-agreements";
+import { confirmPaymentAgreementAction } from "@/features/bookings/payment-agreement-actions";
 import {
   confirmBookingAction,
   completeBookingAction,
@@ -57,6 +59,7 @@ type BookingDetailScreenProps =
       booking: BookingWithDetails;
       existingReview: unknown | null;
       listingTitle?: string;
+      paymentAgreement?: PaymentAgreement | null;
       reviewStatus?: string;
       disputeStatus?: string;
       openBookingThreadAction: OpenBookingThreadAction;
@@ -69,6 +72,7 @@ type BookingDetailScreenProps =
       viewerRole: "admin";
       booking: BookingWithDetails;
       listingTitle?: string;
+      paymentAgreement?: PaymentAgreement | null;
     };
 
 const ACTION_LABEL_RU: Record<string, string> = {
@@ -90,6 +94,7 @@ export function BookingDetailScreen(props: BookingDetailScreenProps) {
       booking={props.booking}
       existingReview={props.viewerRole === "traveler" ? props.existingReview : null}
       listingTitle={props.listingTitle}
+      paymentAgreement={props.paymentAgreement ?? null}
       reviewStatus={props.viewerRole === "traveler" ? props.reviewStatus : undefined}
       disputeStatus={props.viewerRole === "traveler" ? props.disputeStatus : undefined}
       openBookingThreadAction={
@@ -104,6 +109,7 @@ function TravelerBookingDetailView({
   booking,
   existingReview,
   listingTitle,
+  paymentAgreement,
   reviewStatus,
   disputeStatus,
   openBookingThreadAction,
@@ -112,6 +118,7 @@ function TravelerBookingDetailView({
   booking: BookingWithDetails;
   existingReview: unknown | null;
   listingTitle?: string;
+  paymentAgreement?: PaymentAgreement | null;
   reviewStatus?: string;
   disputeStatus?: string;
   openBookingThreadAction?: OpenBookingThreadAction;
@@ -119,6 +126,20 @@ function TravelerBookingDetailView({
 }) {
   const router = useRouter();
   const [isOpeningThread, startOpenThread] = React.useTransition();
+  const [isConfirmingAgreement, startConfirmAgreement] = React.useTransition();
+  const [agreementError, setAgreementError] = React.useState<string | null>(null);
+
+  const handleConfirmAgreement = React.useCallback(() => {
+    setAgreementError(null);
+    startConfirmAgreement(async () => {
+      const result = await confirmPaymentAgreementAction(booking.id);
+      if (result.ok) {
+        router.refresh();
+      } else {
+        setAgreementError(result.error ?? "Не удалось подтвердить договорённость.");
+      }
+    });
+  }, [booking.id, router]);
 
   const guideProfile = booking.guide_profile;
   const guideProfileData = guideProfile?.profile ?? null;
@@ -368,6 +389,49 @@ function TravelerBookingDetailView({
               />
             </CardContent>
           </Card>
+
+          {paymentAgreement ? (
+            <Card className="border-border/70 bg-card/90">
+              <CardContent className="flex flex-col gap-3 p-5">
+                <p className="font-sans text-[0.6875rem] font-medium tracking-[0.18em] uppercase text-muted-foreground">Договорённость об оплате</p>
+                <div className="flex flex-wrap items-baseline justify-between gap-2">
+                  <span className="font-display text-[1.375rem] font-semibold text-foreground leading-[1.2]">
+                    {formatRub(paymentAgreement.agreedTotalMinor)}
+                  </span>
+                  {paymentAgreement.method === "in_person" ? (
+                    <span className="font-sans text-sm text-muted-foreground">Оплата при встрече</span>
+                  ) : null}
+                </div>
+                <div className="flex flex-col gap-1.5">
+                  <PaymentAgreementRow
+                    label="Путешественник"
+                    confirmedAt={paymentAgreement.travelerConfirmedAt}
+                  />
+                  <PaymentAgreementRow
+                    label="Гид"
+                    confirmedAt={paymentAgreement.guideConfirmedAt}
+                  />
+                </div>
+                {showTravelerPanel && !paymentAgreement.travelerConfirmedAt ? (
+                  <>
+                    {agreementError ? (
+                      <Alert variant="destructive">
+                        <AlertDescription>{agreementError}</AlertDescription>
+                      </Alert>
+                    ) : null}
+                    <Button
+                      type="button"
+                      onClick={handleConfirmAgreement}
+                      disabled={isConfirmingAgreement}
+                      className="min-h-[44px] w-full sm:w-auto"
+                    >
+                      {isConfirmingAgreement ? "Подтверждаю…" : "Подтвердить договорённость"}
+                    </Button>
+                  </>
+                ) : null}
+              </CardContent>
+            </Card>
+          ) : null}
 
           {showTravelerPanel ? (
             <>
@@ -786,6 +850,28 @@ function GuideBookingDetailView({ bookingId }: { bookingId: string }) {
           </CardContent>
         </Card>
       ) : null}
+    </div>
+  );
+}
+
+function PaymentAgreementRow({
+  label,
+  confirmedAt,
+}: {
+  label: string;
+  confirmedAt: string | null;
+}) {
+  return (
+    <div className="flex items-center justify-between gap-3">
+      <span className="font-sans text-sm text-foreground">{label}</span>
+      {confirmedAt ? (
+        <span className="inline-flex items-center gap-1 font-sans text-sm font-medium text-success">
+          <Check className="size-4 text-success" />
+          подтвердил
+        </span>
+      ) : (
+        <span className="font-sans text-sm text-muted-foreground">ожидает</span>
+      )}
     </div>
   );
 }

--- a/src/features/bookings/payment-agreement-actions.ts
+++ b/src/features/bookings/payment-agreement-actions.ts
@@ -1,0 +1,21 @@
+"use server";
+
+import { revalidatePath } from "next/cache";
+import { z } from "zod";
+
+import { confirmPaymentAgreement } from "@/lib/supabase/payment-agreements";
+
+export async function confirmPaymentAgreementAction(
+  bookingId: string,
+): Promise<{ ok: boolean; error?: string }> {
+  const parsed = z.string().uuid().safeParse(bookingId);
+  if (!parsed.success) {
+    return { ok: false, error: "Некорректный идентификатор бронирования." };
+  }
+
+  const result = await confirmPaymentAgreement(parsed.data);
+  if (result.ok) {
+    revalidatePath(`/bookings/${parsed.data}`);
+  }
+  return result;
+}

--- a/src/lib/supabase/bookings.ts
+++ b/src/lib/supabase/bookings.ts
@@ -68,7 +68,7 @@ export type BookingWithDetails = BookingRow & {
 // ---------------------------------------------------------------------------
 
 const BOOKING_SELECT =
-  "id, traveler_id, guide_id, request_id, offer_id, listing_id, status, party_size, starts_at, ends_at, subtotal_minor, deposit_minor, remainder_minor, currency, cancellation_policy_snapshot, meeting_point, created_at, updated_at";
+  "id, traveler_id, guide_id, request_id, offer_id, listing_id, status, party_size, starts_at, ends_at, subtotal_minor, deposit_minor, remainder_minor, currency, cancellation_policy_snapshot, meeting_point, payment_method, payment_status, created_at, updated_at";
 
 // ---------------------------------------------------------------------------
 // Public API
@@ -111,6 +111,21 @@ export async function createBooking(
     .single();
 
   if (error) throw error;
+
+  // Seed the face-to-face payment agreement (agreed price + pay-in-person).
+  // Best-effort: booking creation must stay an atomic success, so a failed
+  // agreement insert is logged but never propagated.
+  try {
+    await supabase.from("payment_agreements").insert({
+      booking_id: row.id,
+      agreed_total_minor: data.subtotal_minor,
+      currency: "RUB",
+      method: "in_person",
+    });
+  } catch (e) {
+    console.warn("[createBooking] payment_agreement seed failed", e);
+  }
+
   return row as Booking;
 }
 

--- a/src/lib/supabase/payment-agreements.test.ts
+++ b/src/lib/supabase/payment-agreements.test.ts
@@ -1,0 +1,141 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { createSupabaseServerClient } = vi.hoisted(() => ({
+  createSupabaseServerClient: vi.fn(),
+}));
+
+vi.mock("@/lib/supabase/server", () => ({
+  createSupabaseServerClient,
+}));
+
+import {
+  confirmPaymentAgreement,
+  getPaymentAgreementForBooking,
+} from "./payment-agreements";
+
+beforeEach(() => {
+  createSupabaseServerClient.mockReset();
+});
+
+describe("getPaymentAgreementForBooking", () => {
+  it("maps a snake_case row to the camelCase model", async () => {
+    const row = {
+      id: "agreement-1",
+      booking_id: "booking-1",
+      agreed_total_minor: 150000,
+      currency: "RUB",
+      method: "in_person",
+      traveler_confirmed_at: "2026-06-23T10:00:00Z",
+      guide_confirmed_at: null,
+    };
+    const query = {
+      select: vi.fn().mockReturnThis(),
+      eq: vi.fn().mockReturnThis(),
+      maybeSingle: vi.fn().mockResolvedValue({ data: row, error: null }),
+    };
+    createSupabaseServerClient.mockResolvedValue({
+      from: vi.fn(() => query),
+    });
+
+    const result = await getPaymentAgreementForBooking("booking-1");
+
+    expect(result).toEqual({
+      id: "agreement-1",
+      bookingId: "booking-1",
+      agreedTotalMinor: 150000,
+      currency: "RUB",
+      method: "in_person",
+      travelerConfirmedAt: "2026-06-23T10:00:00Z",
+      guideConfirmedAt: null,
+    });
+    expect(query.eq).toHaveBeenCalledWith("booking_id", "booking-1");
+  });
+
+  it("returns null when no agreement exists", async () => {
+    const query = {
+      select: vi.fn().mockReturnThis(),
+      eq: vi.fn().mockReturnThis(),
+      maybeSingle: vi.fn().mockResolvedValue({ data: null, error: null }),
+    };
+    createSupabaseServerClient.mockResolvedValue({
+      from: vi.fn(() => query),
+    });
+
+    await expect(getPaymentAgreementForBooking("booking-x")).resolves.toBeNull();
+  });
+});
+
+describe("confirmPaymentAgreement", () => {
+  function buildClient(userId: string | null, booking: unknown) {
+    const updateQuery = {
+      update: vi.fn().mockReturnThis(),
+      eq: vi.fn().mockResolvedValue({ error: null }),
+    };
+    const bookingQuery = {
+      select: vi.fn().mockReturnThis(),
+      eq: vi.fn().mockReturnThis(),
+      maybeSingle: vi.fn().mockResolvedValue({ data: booking, error: null }),
+    };
+    const from = vi.fn((table: string) => {
+      if (table === "bookings") return bookingQuery;
+      if (table === "payment_agreements") return updateQuery;
+      throw new Error(`Unexpected table: ${table}`);
+    });
+    const client = {
+      from,
+      auth: {
+        getUser: vi
+          .fn()
+          .mockResolvedValue({ data: { user: userId ? { id: userId } : null } }),
+      },
+    };
+    return { client, updateQuery };
+  }
+
+  it("stamps traveler_confirmed_at when the caller is the traveler", async () => {
+    const { client, updateQuery } = buildClient("traveler-1", {
+      id: "booking-1",
+      traveler_id: "traveler-1",
+      guide_id: "guide-1",
+    });
+    createSupabaseServerClient.mockResolvedValue(client);
+
+    const result = await confirmPaymentAgreement("booking-1");
+
+    expect(result).toEqual({ ok: true });
+    expect(updateQuery.update).toHaveBeenCalledWith(
+      expect.objectContaining({ traveler_confirmed_at: expect.any(String) }),
+    );
+    expect(updateQuery.eq).toHaveBeenCalledWith("booking_id", "booking-1");
+  });
+
+  it("stamps guide_confirmed_at when the caller is the guide", async () => {
+    const { client, updateQuery } = buildClient("guide-1", {
+      id: "booking-1",
+      traveler_id: "traveler-1",
+      guide_id: "guide-1",
+    });
+    createSupabaseServerClient.mockResolvedValue(client);
+
+    const result = await confirmPaymentAgreement("booking-1");
+
+    expect(result).toEqual({ ok: true });
+    expect(updateQuery.update).toHaveBeenCalledWith(
+      expect.objectContaining({ guide_confirmed_at: expect.any(String) }),
+    );
+  });
+
+  it("returns an access error when the caller is neither party", async () => {
+    const { client, updateQuery } = buildClient("stranger-1", {
+      id: "booking-1",
+      traveler_id: "traveler-1",
+      guide_id: "guide-1",
+    });
+    createSupabaseServerClient.mockResolvedValue(client);
+
+    const result = await confirmPaymentAgreement("booking-1");
+
+    expect(result).toEqual({ ok: false, error: "Нет доступа" });
+    expect(updateQuery.update).not.toHaveBeenCalled();
+  });
+});

--- a/src/lib/supabase/payment-agreements.ts
+++ b/src/lib/supabase/payment-agreements.ts
@@ -1,0 +1,113 @@
+import "server-only";
+
+/**
+ * payment-agreements.ts — face-to-face payment agreement service layer (server-only)
+ *
+ * Every booking carries a written «agreed price + pay-in-person» record. Both
+ * the traveler and the guide can confirm it. There is no card/gateway logic —
+ * payment happens directly between the parties at the meeting point.
+ *
+ * All functions use createSupabaseServerClient (RLS-respecting); RLS limits
+ * reads/writes to the booking's own parties (traveler/guide) + admins.
+ */
+
+import { createSupabaseServerClient } from "@/lib/supabase/server";
+import type { Uuid } from "@/lib/supabase/types";
+
+export type PaymentAgreement = {
+  id: string;
+  bookingId: string;
+  agreedTotalMinor: number;
+  currency: string;
+  method: string;
+  travelerConfirmedAt: string | null;
+  guideConfirmedAt: string | null;
+};
+
+const AGREEMENT_SELECT =
+  "id, booking_id, agreed_total_minor, currency, method, traveler_confirmed_at, guide_confirmed_at";
+
+type PaymentAgreementRow = {
+  id: string;
+  booking_id: string;
+  agreed_total_minor: number;
+  currency: string;
+  method: string;
+  traveler_confirmed_at: string | null;
+  guide_confirmed_at: string | null;
+};
+
+function mapAgreement(row: PaymentAgreementRow): PaymentAgreement {
+  return {
+    id: row.id,
+    bookingId: row.booking_id,
+    agreedTotalMinor: row.agreed_total_minor,
+    currency: row.currency,
+    method: row.method,
+    travelerConfirmedAt: row.traveler_confirmed_at,
+    guideConfirmedAt: row.guide_confirmed_at,
+  };
+}
+
+/**
+ * Load the payment agreement for a booking. RLS returns null for non-parties.
+ */
+export async function getPaymentAgreementForBooking(
+  bookingId: Uuid,
+): Promise<PaymentAgreement | null> {
+  const supabase = await createSupabaseServerClient();
+
+  const { data, error } = await supabase
+    .from("payment_agreements")
+    .select(AGREEMENT_SELECT)
+    .eq("booking_id", bookingId)
+    .maybeSingle();
+
+  if (error) throw error;
+  if (!data) return null;
+
+  return mapAgreement(data as PaymentAgreementRow);
+}
+
+/**
+ * Confirm the face-to-face payment agreement on behalf of the caller.
+ * The caller's role is derived from the booking parties: the traveler stamps
+ * traveler_confirmed_at, the guide stamps guide_confirmed_at. RLS enforces
+ * party-only access; non-parties get «Нет доступа».
+ */
+export async function confirmPaymentAgreement(
+  bookingId: Uuid,
+): Promise<{ ok: boolean; error?: string }> {
+  const supabase = await createSupabaseServerClient();
+
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+  if (!user) return { ok: false, error: "Нет доступа" };
+
+  const { data: booking, error: bookingError } = await supabase
+    .from("bookings")
+    .select("id, traveler_id, guide_id")
+    .eq("id", bookingId)
+    .maybeSingle();
+  if (bookingError) return { ok: false, error: bookingError.message };
+  if (!booking) return { ok: false, error: "Нет доступа" };
+
+  let patch: { traveler_confirmed_at: string } | { guide_confirmed_at: string };
+  const now = new Date().toISOString();
+  if (user.id === booking.traveler_id) {
+    patch = { traveler_confirmed_at: now };
+  } else if (user.id === booking.guide_id) {
+    patch = { guide_confirmed_at: now };
+  } else {
+    return { ok: false, error: "Нет доступа" };
+  }
+
+  const { error: updateError } = await supabase
+    .from("payment_agreements")
+    .update(patch)
+    .eq("booking_id", bookingId);
+  if (updateError) return { ok: false, error: updateError.message };
+
+  return { ok: true };
+}

--- a/src/lib/supabase/types.ts
+++ b/src/lib/supabase/types.ts
@@ -95,6 +95,8 @@ export type BookingRow = {
   currency: string;
   cancellation_policy_snapshot: unknown;
   meeting_point: string | null;
+  payment_method: string;
+  payment_status: string;
   created_at: string;
   updated_at: string;
 };

--- a/supabase/migrations/20260623120000_c1_payment_agreements.sql
+++ b/supabase/migrations/20260623120000_c1_payment_agreements.sql
@@ -1,0 +1,62 @@
+-- C1 Payment seam (face-to-face, no gateway) — ADDITIVE + reversible.
+-- payment_agreements = written "agreed price + pay-in-person" record per booking.
+-- RLS MIRRORS the proven bookings_select / disputes patterns (booking parties + admin).
+
+-- 1) Additive booking columns (idempotent)
+alter table public.bookings add column if not exists payment_method text not null default 'in_person';
+alter table public.bookings add column if not exists payment_status text not null default 'pending';
+
+-- 2) payment_agreements table
+create table if not exists public.payment_agreements (
+  id uuid primary key default gen_random_uuid(),
+  booking_id uuid not null references public.bookings(id) on delete cascade,
+  agreed_total_minor integer not null,
+  currency text not null default 'RUB',
+  method text not null default 'in_person',
+  traveler_confirmed_at timestamptz,
+  guide_confirmed_at timestamptz,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now()
+);
+
+create index if not exists payment_agreements_booking_idx on public.payment_agreements (booking_id);
+
+alter table public.payment_agreements enable row level security;
+
+-- 3) RLS — booking parties + admin (mirror of bookings_select / disputes_insert participant check)
+drop policy if exists "payment_agreements_select" on public.payment_agreements;
+create policy "payment_agreements_select" on public.payment_agreements for select
+  using (
+    exists (
+      select 1 from public.bookings b
+      where b.id = booking_id
+        and ( b.traveler_id = (select auth.uid()::uuid) or b.guide_id = (select auth.uid()::uuid) )
+    )
+    or public.is_admin()
+  );
+
+drop policy if exists "payment_agreements_insert" on public.payment_agreements;
+create policy "payment_agreements_insert" on public.payment_agreements for insert
+  with check (
+    exists (
+      select 1 from public.bookings b
+      where b.id = booking_id
+        and ( b.traveler_id = (select auth.uid()::uuid) or b.guide_id = (select auth.uid()::uuid) )
+    )
+    or public.is_admin()
+  );
+
+drop policy if exists "payment_agreements_update" on public.payment_agreements;
+create policy "payment_agreements_update" on public.payment_agreements for update
+  using (
+    exists (
+      select 1 from public.bookings b
+      where b.id = booking_id
+        and ( b.traveler_id = (select auth.uid()::uuid) or b.guide_id = (select auth.uid()::uuid) )
+    )
+    or public.is_admin()
+  );
+
+drop trigger if exists set_payment_agreements_updated_at on public.payment_agreements;
+create trigger set_payment_agreements_updated_at before update on public.payment_agreements
+  for each row execute procedure public.set_updated_at();


### PR DESCRIPTION
Face-to-face payment agreement (no gateway): payment_agreements table seeded on booking accept; both parties confirm agreed price + pay-in-person; booking-party RLS (visible IFF parent booking visible — mirrors prod-proven bookings_select; anon→[] verified). booking-detail «Договорённость об оплате» card + traveler confirm.