### PR TITLE
Stage 7 (C4): two-way dispute thread

### DIFF
--- a/src/features/disputes/components/DisputeThread.test.tsx
+++ b/src/features/disputes/components/DisputeThread.test.tsx
@@ -13,6 +13,10 @@ vi.mock("@/features/disputes/components/dispute-admin-resolve", () => ({
   DisputeAdminResolve: () => <div>Resolve</div>,
 }));
 
+vi.mock("@/features/disputes/dispute-message-actions", () => ({
+  postDisputeMessage: vi.fn(),
+}));
+
 import { DisputeThread } from "./DisputeThread";
 
 const dispute = {
@@ -94,14 +98,62 @@ describe("DisputeThread event labels", () => {
     expect(screen.getByText("weird_unknown_event")).toBeInTheDocument();
   });
 
-  it("shows the read-only addition notice for the traveler view", async () => {
+  it("renders a comment event as a message bubble with body and role label", async () => {
+    mockClient([
+      {
+        id: "event-comment",
+        event_type: "comment",
+        payload: { body: "Подскажите статус возврата", role: "traveler" },
+        created_at: "2026-06-10T12:00:00.000Z",
+        actor_id: "traveler-1",
+      },
+    ]);
+
+    const ui = await DisputeThread({ disputeId: "dispute-1" });
+    render(ui);
+
+    expect(screen.getByText("Подскажите статус возврата")).toBeInTheDocument();
+    expect(screen.getByText("Путешественник")).toBeInTheDocument();
+  });
+
+  it("renders a support comment with the «Поддержка» role label", async () => {
+    mockClient([
+      {
+        id: "event-comment-admin",
+        event_type: "comment",
+        payload: { body: "Мы проверяем вашу жалобу", role: "admin" },
+        created_at: "2026-06-10T12:30:00.000Z",
+        actor_id: "admin-1",
+      },
+    ]);
+
+    const ui = await DisputeThread({ disputeId: "dispute-1" });
+    render(ui);
+
+    expect(screen.getByText("Мы проверяем вашу жалобу")).toBeInTheDocument();
+    expect(screen.getByText("Поддержка")).toBeInTheDocument();
+  });
+
+  it("renders the composer (textarea + «Отправить») for an open dispute", async () => {
+    mockClient([eventOf("dispute_opened")]);
+
+    const ui = await DisputeThread({ disputeId: "dispute-1" });
+    render(ui);
+
+    expect(screen.getByRole("button", { name: "Отправить" })).toBeInTheDocument();
+    expect(
+      screen.getByLabelText("Сообщение по спору"),
+    ).toBeInTheDocument();
+  });
+
+  it("replaces the read-only «недоступно» notice with the composer", async () => {
     mockClient([eventOf("dispute_opened")]);
 
     const ui = await DisputeThread({ disputeId: "dispute-1" });
     render(ui);
 
     expect(
-      screen.getByText(/Дополнение к спору временно недоступно/),
-    ).toBeInTheDocument();
+      screen.queryByText(/Дополнение к спору временно недоступно/),
+    ).not.toBeInTheDocument();
   });
 });

--- a/src/features/disputes/components/DisputeThread.tsx
+++ b/src/features/disputes/components/DisputeThread.tsx
@@ -1,13 +1,17 @@
 import { DisputeAdminResolve } from "@/features/disputes/components/dispute-admin-resolve";
+import { postDisputeMessage } from "@/features/disputes/dispute-message-actions";
 import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
 import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Textarea } from "@/components/ui/textarea";
 import { EmptyState } from "@/components/shared/empty-state";
 import { PageHeader } from "@/components/shared/page-header";
 import { formatRussianDateTime } from "@/lib/dates";
 import { maskPii } from "@/lib/pii/mask";
+import { cn } from "@/lib/utils";
 import { createSupabaseServerClient } from "@/lib/supabase/server";
-import { CheckCircle2, Circle, Clock } from "lucide-react";
+import { CheckCircle2, Circle, Clock, MessageCircle } from "lucide-react";
 
 const STATUS_LABEL: Record<string, string> = {
   open: "Открыт",
@@ -45,6 +49,22 @@ const EVENT_LABELS: Record<string, string> = {
 function formatEventLabel(eventType: string | null): string {
   if (!eventType) return "Событие";
   return EVENT_LABELS[eventType] ?? eventType;
+}
+
+const COMMENT_ROLE_LABELS: Record<string, string> = {
+  traveler: "Путешественник",
+  guide: "Гид",
+  admin: "Поддержка",
+};
+
+function readComment(
+  payload: unknown,
+): { body: string; role: string } | null {
+  if (!payload || typeof payload !== "object") return null;
+  const candidate = payload as { body?: unknown; role?: unknown };
+  if (typeof candidate.body !== "string" || !candidate.body.trim()) return null;
+  const role = typeof candidate.role === "string" ? candidate.role : "";
+  return { body: candidate.body, role };
 }
 
 export async function DisputeThread({
@@ -120,20 +140,12 @@ export async function DisputeThread({
       />
 
       {!adminView ? (
-        <>
-          <Alert>
-            <AlertTitle>Статус</AlertTitle>
-            <AlertDescription>
-              Спор рассматривается администрацией. Текущий статус: {statusLabel}.
-            </AlertDescription>
-          </Alert>
-          <Alert variant="info">
-            <AlertDescription>
-              Дополнение к спору временно недоступно — наша команда рассматривает вашу
-              жалобу.
-            </AlertDescription>
-          </Alert>
-        </>
+        <Alert>
+          <AlertTitle>Статус</AlertTitle>
+          <AlertDescription>
+            Спор рассматривается администрацией. Текущий статус: {statusLabel}.
+          </AlertDescription>
+        </Alert>
       ) : null}
 
       {dispute.resolution_summary ? (
@@ -163,6 +175,41 @@ export async function DisputeThread({
           <ol className="relative flex flex-col gap-0 border-l-2 border-border/50 pl-6">
             {timeline.map((ev, index) => {
               const isLatest = index === timeline.length - 1;
+              if (ev.event_type === "comment") {
+                const comment = readComment(ev.payload);
+                if (!comment) return null;
+                const isSupport = comment.role === "admin";
+                return (
+                  <li key={ev.id} className="relative pb-6 last:pb-0">
+                    <span className="absolute -left-[31px] top-0 flex size-4 items-center justify-center rounded-full bg-background">
+                      <MessageCircle
+                        className={cn(
+                          "size-4",
+                          isSupport ? "text-primary" : "text-muted-foreground",
+                        )}
+                      />
+                    </span>
+                    <div
+                      className={cn(
+                        "rounded-card border px-4 py-3",
+                        isSupport
+                          ? "border-primary/30 bg-primary-tint"
+                          : "border-border/70 bg-card",
+                      )}
+                    >
+                      <p className="text-xs font-medium text-muted-foreground">
+                        {COMMENT_ROLE_LABELS[comment.role] ?? "Участник"}
+                      </p>
+                      <p className="mt-1 whitespace-pre-wrap text-sm text-foreground">
+                        {maskPii(comment.body)}
+                      </p>
+                      <p className="mt-2 text-xs text-muted-foreground">
+                        {formatRussianDateTime(ev.created_at)}
+                      </p>
+                    </div>
+                  </li>
+                );
+              }
               const reason =
                 ev.event_type === "dispute_opened" &&
                 ev.payload &&
@@ -195,6 +242,37 @@ export async function DisputeThread({
           </ol>
         )}
       </div>
+
+      {resolvedLike ? (
+        <Alert>
+          <AlertTitle>Спор закрыт</AlertTitle>
+          <AlertDescription>
+            Добавить новое сообщение нельзя — спор завершён.
+          </AlertDescription>
+        </Alert>
+      ) : (
+        <form
+          action={async (formData: FormData) => {
+            "use server";
+            await postDisputeMessage(
+              disputeId,
+              String(formData.get("body") ?? ""),
+            );
+          }}
+          className="flex flex-col gap-3"
+        >
+          <Textarea
+            name="body"
+            required
+            maxLength={2000}
+            aria-label="Сообщение по спору"
+            placeholder="Напишите сообщение второй стороне или поддержке…"
+          />
+          <Button type="submit" className="min-h-11 self-end">
+            Отправить
+          </Button>
+        </form>
+      )}
     </div>
   );
 }

--- a/src/features/disputes/dispute-message-actions.ts
+++ b/src/features/disputes/dispute-message-actions.ts
@@ -1,0 +1,85 @@
+"use server";
+
+import { revalidatePath } from "next/cache";
+
+import { flags } from "@/lib/flags";
+import { createSupabaseServerClient } from "@/lib/supabase/server";
+
+type PostDisputeMessageResult = { ok: true } | { ok: false; error: string };
+
+const MAX_BODY = 2000;
+
+export async function postDisputeMessage(
+  disputeId: string,
+  body: string,
+): Promise<PostDisputeMessageResult> {
+  if (!flags.FEATURE_TR_DISPUTES) {
+    return { ok: false, error: "Споры временно недоступны." };
+  }
+
+  const trimmed = body.trim();
+  if (!trimmed) {
+    return { ok: false, error: "Введите текст сообщения." };
+  }
+  if (trimmed.length > MAX_BODY) {
+    return { ok: false, error: "Сообщение слишком длинное." };
+  }
+
+  const supabase = await createSupabaseServerClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+  if (!user) {
+    return { ok: false, error: "Войдите, чтобы отправить сообщение." };
+  }
+
+  // Re-verify the caller is a party to this dispute's booking (or admin) before acting.
+  const { data: dispute, error: disputeError } = await supabase
+    .from("disputes")
+    .select("id, booking_id")
+    .eq("id", disputeId)
+    .maybeSingle();
+  if (disputeError || !dispute) {
+    return { ok: false, error: "Спор не найден." };
+  }
+
+  const { data: booking } = await supabase
+    .from("bookings")
+    .select("traveler_id, guide_id")
+    .eq("id", dispute.booking_id)
+    .maybeSingle();
+
+  let role: "traveler" | "guide" | "admin" | null = null;
+  if (booking?.traveler_id === user.id) {
+    role = "traveler";
+  } else if (booking?.guide_id === user.id) {
+    role = "guide";
+  } else {
+    const { data: profile } = await supabase
+      .from("profiles")
+      .select("role")
+      .eq("id", user.id)
+      .maybeSingle();
+    if (profile?.role === "admin") {
+      role = "admin";
+    }
+  }
+
+  if (!role) {
+    return { ok: false, error: "Нет доступа к этому спору." };
+  }
+
+  const { error: insertError } = await supabase.from("dispute_events").insert({
+    dispute_id: disputeId,
+    actor_id: user.id,
+    event_type: "comment",
+    payload: { body: trimmed, role },
+  });
+
+  if (insertError) {
+    return { ok: false, error: "Не удалось отправить сообщение." };
+  }
+
+  revalidatePath(`/disputes/${disputeId}`);
+  return { ok: true };
+}

--- a/supabase/migrations/20260623150000_c4_dispute_events_party_rls.sql
+++ b/supabase/migrations/20260623150000_c4_dispute_events_party_rls.sql
@@ -1,0 +1,32 @@
+-- C4 Two-way dispute conversation — widen dispute_events RLS from opener-only to BOTH booking parties (+admin).
+-- The conversation is modeled as dispute_events (event_type='comment'); the existing opener-only RLS
+-- wrongly excluded the other booking party. New policy = the two booking parties (via disputes→bookings) + admin.
+-- SECURITY: still strictly party-scoped (traveler_id/guide_id of the parent booking) + admin; anon blocked.
+
+drop policy if exists "dispute_events_select" on public.dispute_events;
+create policy "dispute_events_select" on public.dispute_events for select
+  using (
+    exists (
+      select 1
+      from public.disputes d
+      join public.bookings b on b.id = d.booking_id
+      where d.id = dispute_id
+        and ( b.traveler_id = (select auth.uid()::uuid) or b.guide_id = (select auth.uid()::uuid) )
+    )
+    or public.is_admin()
+  );
+
+-- INSERT: widen to both booking parties + admin (parity with original opener/admin structure, no new actor constraint
+-- to avoid breaking existing server-side/RPC event inserts). App layer sets actor_id from the session.
+drop policy if exists "dispute_events_insert" on public.dispute_events;
+create policy "dispute_events_insert" on public.dispute_events for insert
+  with check (
+    exists (
+      select 1
+      from public.disputes d
+      join public.bookings b on b.id = d.booking_id
+      where d.id = dispute_id
+        and ( b.traveler_id = (select auth.uid()::uuid) or b.guide_id = (select auth.uid()::uuid) )
+    )
+    or public.is_admin()
+  );


### PR DESCRIPTION
Dispute conversation: widened dispute_events RLS from opener-only to both booking parties + admin (security-corrective; reused existing table, no new dispute_messages); interactive DisputeThread composer + comment messages (replaces J1-T7 read-only).