### PR TITLE
feat(homepage): redesign / to canonical mockup + shared Open-Group card on /requests

### DIFF
--- a/src/app/(home)/page.tsx
+++ b/src/app/(home)/page.tsx
@@ -29,7 +29,7 @@ export default async function HomePage() {
   return (
     <>
       <SiteHeaderServer />
-      <main className="pt-nav-h">
+      <main>
         <HomePageShell2Classic destinations={destinations} requests={requests} />
       </main>
     </>

--- a/src/components/shared/destination-tile.tsx
+++ b/src/components/shared/destination-tile.tsx
@@ -1,0 +1,52 @@
+import Image from "next/image";
+import Link from "next/link";
+
+interface DestinationTileProps {
+  href: string;
+  name: string;
+  imageUrl: string;
+  guidesCount: number;
+  /** e.g. "от 2 900 ₽" — omitted when no price data is available. */
+  fromPrice?: string;
+  priority?: boolean;
+}
+
+/**
+ * Popular-destinations card (homepage). 172px photo with a bottom gradient,
+ * city name + "{N} гидов · от {price}" caption. Image comes from the existing
+ * city-image pipeline.
+ */
+export function DestinationTile({
+  href,
+  name,
+  imageUrl,
+  guidesCount,
+  fromPrice,
+  priority,
+}: DestinationTileProps) {
+  return (
+    <Link
+      href={href}
+      className="relative block h-[172px] overflow-hidden rounded-2xl border border-border no-underline text-inherit transition-transform hover:-translate-y-[3px]"
+    >
+      <Image
+        src={imageUrl}
+        alt={name}
+        fill
+        priority={priority}
+        sizes="(max-width: 768px) 100vw, (max-width: 1200px) 50vw, 33vw"
+        className="object-cover"
+      />
+      <div
+        className="absolute inset-0 bg-gradient-to-b from-[rgba(8,14,24,0.1)] via-transparent to-[rgba(8,14,24,0.68)]"
+        aria-hidden="true"
+      />
+      <div className="absolute bottom-3.5 left-4 right-4 text-white">
+        <div className="text-xl font-bold leading-tight tracking-[-0.02em]">{name}</div>
+        <div className="mt-0.5 text-[12.5px] font-medium text-white/85">
+          {guidesCount} гидов{fromPrice ? ` · от ${fromPrice}` : ""}
+        </div>
+      </div>
+    </Link>
+  );
+}

--- a/src/components/shared/open-group-card.tsx
+++ b/src/components/shared/open-group-card.tsx
@@ -1,0 +1,204 @@
+import Image from "next/image";
+import Link from "next/link";
+import {
+  Calendar,
+  CheckCircle2,
+  Clock,
+  MapPin,
+  Star,
+  Users,
+} from "lucide-react";
+
+import { THEMES, type ThemeSlug } from "@/data/themes";
+
+const THEME_BY_SLUG = new Map(THEMES.map((t) => [t.slug, t] as const));
+
+export interface OpenGroupCardProps {
+  href: string;
+  city: string;
+  region?: string;
+  imageUrl: string;
+  /** "selected" = a guide is chosen (booked); "waiting" = still open. */
+  status: "selected" | "waiting";
+  /** e.g. "от 6 чел." */
+  minPeople?: string;
+  date?: string;
+  datesFlexible?: boolean;
+  /** e.g. "10:00–18:00" */
+  time?: string;
+  /** theme slugs — resolved to icon + label */
+  interests?: string[];
+  avatarUrl?: string | null;
+  avatarInitials?: string;
+  /** shown next to the avatar when present (e.g. a chosen guide's name) */
+  personName?: string;
+  /** shown after the name when present */
+  personRating?: number | string;
+  /** shown instead of a name (e.g. "4 отклика") */
+  footerText?: string;
+  joinHref?: string;
+  joinLabel?: string;
+  priority?: boolean;
+}
+
+/**
+ * Open-group card (homepage "Открытые группы" + /requests marketplace).
+ * Photo + region pill, city title with a status badge (Гид выбран / Ждёт гида),
+ * Сборная-группа pill, date/flex/time, interest tags, an organizer/guide row,
+ * and a "Присоединиться" CTA. Intentionally has NO per-person price and NO
+ * seats progress bar (mockup spec).
+ */
+export function OpenGroupCard({
+  href,
+  city,
+  region,
+  imageUrl,
+  status,
+  minPeople,
+  date,
+  datesFlexible,
+  time,
+  interests,
+  avatarUrl,
+  avatarInitials = "П",
+  personName,
+  personRating,
+  footerText,
+  joinHref,
+  joinLabel = "Присоединиться",
+  priority,
+}: OpenGroupCardProps) {
+  const themes = (interests ?? [])
+    .map((slug) => THEME_BY_SLUG.get(slug as ThemeSlug))
+    .filter((t): t is (typeof THEMES)[number] => Boolean(t))
+    .slice(0, 3);
+
+  return (
+    <div className="flex flex-col overflow-hidden rounded-2xl border border-border bg-card shadow-sm">
+      <div className="relative h-[148px] bg-surface-low">
+        <Image
+          src={imageUrl}
+          alt={city}
+          fill
+          priority={priority}
+          sizes="(max-width: 768px) 100vw, (max-width: 1200px) 50vw, 33vw"
+          className="object-cover"
+        />
+        <div
+          className="absolute inset-0 bg-gradient-to-b from-[rgba(8,14,24,0.28)] via-transparent to-[rgba(8,14,24,0.4)]"
+          aria-hidden="true"
+        />
+        {region ? (
+          <span className="absolute left-2.5 top-2.5 inline-flex h-[25px] items-center gap-1.5 rounded-full bg-[rgba(8,14,24,0.55)] px-2.5 text-[11px] font-semibold text-white">
+            <MapPin className="h-[11px] w-[11px]" aria-hidden="true" />
+            {region}
+          </span>
+        ) : null}
+      </div>
+
+      <div className="flex flex-1 flex-col px-4 pb-4 pt-3.5">
+        <div className="flex items-start justify-between gap-2">
+          <div className="text-[18px] font-bold leading-tight tracking-[-0.02em] text-foreground">
+            {city}
+          </div>
+          {status === "selected" ? (
+            <span className="inline-flex shrink-0 items-center gap-1 whitespace-nowrap text-xs font-bold text-[#2F8F66]">
+              <CheckCircle2 className="h-[14px] w-[14px]" aria-hidden="true" />
+              Гид выбран
+            </span>
+          ) : (
+            <span className="inline-flex h-6 shrink-0 items-center gap-1.5 whitespace-nowrap rounded-full bg-[rgba(212,135,43,0.14)] px-2.5 text-[11.5px] font-bold text-[#9A5712]">
+              <Clock className="h-3 w-3" aria-hidden="true" />
+              Ждёт гида
+            </span>
+          )}
+        </div>
+
+        <div className="mt-2 flex items-center gap-1.5">
+          <span className="inline-flex h-6 items-center gap-1.5 rounded-full bg-[#EAF1FA] px-2.5 text-[11.5px] font-semibold text-primary">
+            <Users className="h-3 w-3" aria-hidden="true" />
+            Сборная группа
+          </span>
+          {minPeople ? (
+            <span className="text-xs font-semibold text-muted-foreground">· {minPeople}</span>
+          ) : null}
+        </div>
+
+        <div className="mt-2.5 flex flex-wrap items-center gap-2 text-[12.5px] font-medium text-ink-2">
+          {date ? (
+            <span className="inline-flex items-center gap-1.5">
+              <Calendar className="h-[13px] w-[13px] text-muted-foreground" aria-hidden="true" />
+              {date}
+            </span>
+          ) : null}
+          {datesFlexible ? (
+            <span className="inline-flex h-[22px] items-center rounded-full bg-[rgba(47,143,102,0.12)] px-2 text-[11px] font-bold text-[#1F7A52]">
+              Гибкие даты
+            </span>
+          ) : null}
+          {time ? (
+            <span className="inline-flex items-center gap-1.5">
+              <Clock className="h-[13px] w-[13px] text-muted-foreground" aria-hidden="true" />
+              {time}
+            </span>
+          ) : null}
+        </div>
+
+        {themes.length > 0 ? (
+          <div className="mt-2.5 flex flex-wrap gap-1.5">
+            {themes.map((theme) => {
+              const Icon = theme.Icon;
+              return (
+                <span
+                  key={theme.slug}
+                  className="inline-flex h-[26px] items-center gap-1.5 rounded-full border border-border px-2.5 text-xs font-semibold text-ink-2"
+                >
+                  <Icon className="h-[13px] w-[13px] text-muted-foreground" aria-hidden="true" />
+                  {theme.label}
+                </span>
+              );
+            })}
+          </div>
+        ) : null}
+
+        <div className="mt-auto flex items-end justify-between gap-2.5 pt-3.5">
+          <div className="flex items-center gap-2">
+            {avatarUrl ? (
+              <Image
+                src={avatarUrl}
+                alt={personName ?? "Организатор"}
+                width={30}
+                height={30}
+                className="h-[30px] w-[30px] rounded-full object-cover"
+              />
+            ) : (
+              <span className="grid h-[30px] w-[30px] place-items-center rounded-full border border-border bg-surface-low text-xs font-bold text-muted-foreground">
+                {avatarInitials}
+              </span>
+            )}
+            {personName ? (
+              <div className="leading-tight">
+                <div className="text-[12.5px] font-bold text-foreground">{personName}</div>
+                {personRating != null ? (
+                  <div className="flex items-center gap-1 text-[11.5px] font-semibold text-muted-foreground">
+                    <Star className="h-3 w-3 fill-[#D4872B] text-[#D4872B]" aria-hidden="true" />
+                    {personRating}
+                  </div>
+                ) : null}
+              </div>
+            ) : footerText ? (
+              <span className="text-xs font-semibold text-muted-foreground">{footerText}</span>
+            ) : null}
+          </div>
+        </div>
+
+        <Link
+          href={joinHref ?? href}
+          className="mt-3 inline-flex h-[42px] w-full items-center justify-center rounded-[11px] bg-primary text-sm font-bold text-primary-foreground transition-colors hover:bg-primary/90"
+        >
+          {joinLabel}
+        </Link>
+      </div>
+    </div>
+  );
+}

--- a/src/components/shared/section-heading.tsx
+++ b/src/components/shared/section-heading.tsx
@@ -1,0 +1,40 @@
+import Link from "next/link";
+import { ChevronRight } from "lucide-react";
+
+interface Props {
+  title: string;
+  subtitle?: string;
+  action?: { label: string; href: string };
+  className?: string;
+}
+
+/**
+ * Section heading used across the homepage (Open Groups, Popular Destinations,
+ * How it works). Title + optional subtitle on the left, optional "see all" link
+ * on the right. Mockup: h2 30px/800/-.03em, navy "see" link with chevron.
+ */
+export function SectionHeading({ title, subtitle, action, className }: Props) {
+  return (
+    <div
+      className={`mb-6 flex items-end justify-between gap-4${className ? ` ${className}` : ""}`}
+    >
+      <div>
+        <h2 className="text-[clamp(24px,3vw,30px)] font-extrabold leading-tight tracking-[-0.03em] text-foreground">
+          {title}
+        </h2>
+        {subtitle ? (
+          <p className="mt-1.5 text-sm font-medium text-muted-foreground">{subtitle}</p>
+        ) : null}
+      </div>
+      {action ? (
+        <Link
+          href={action.href}
+          className="inline-flex shrink-0 items-center gap-1 whitespace-nowrap text-sm font-semibold text-primary transition-colors hover:text-primary/80"
+        >
+          {action.label}
+          <ChevronRight className="h-[15px] w-[15px]" aria-hidden="true" />
+        </Link>
+      ) : null}
+    </div>
+  );
+}

--- a/src/features/homepage-classic/components/homepage-hero-form-classic.tsx
+++ b/src/features/homepage-classic/components/homepage-hero-form-classic.tsx
@@ -1,4 +1,8 @@
+import Image from "next/image";
+import { ArrowDown } from "lucide-react";
+
 import type { DestinationOption } from "@/data/supabase/queries";
+import { cityImage } from "@/lib/city-image";
 
 import { HomepageRequestFormClassic } from "./homepage-request-form-classic";
 
@@ -7,15 +11,40 @@ interface Props {
 }
 
 export function HomepageHeroFormClassic({ destinations }: Props) {
+  const heroImage = cityImage(destinations[0]?.name ?? "Байкал");
+
   return (
-    <section className="py-16">
-      <div className="mx-auto w-full max-w-page px-[clamp(20px,4vw,48px)]">
-        <div className="mx-auto max-w-2xl">
-          <h1 className="mb-8 text-center font-display text-[clamp(1.75rem,3vw,2.25rem)] leading-[1.15] text-foreground">
-            Местный гид под ваш запрос
-          </h1>
+    <section className="relative flex min-h-[100svh] flex-col overflow-hidden bg-[#0c1622]">
+      <Image
+        src={heroImage}
+        alt=""
+        fill
+        priority
+        sizes="100vw"
+        className="object-cover object-[center_44%]"
+      />
+      <div
+        className="absolute inset-0 bg-[linear-gradient(180deg,rgba(8,14,22,0.66)_0%,rgba(8,14,22,0.22)_28%,rgba(8,14,22,0.3)_58%,rgba(8,14,22,0.82)_100%)]"
+        aria-hidden="true"
+      />
+
+      <div className="relative z-[2] flex flex-1 flex-col items-center justify-center px-[clamp(20px,4vw,44px)] pb-24 pt-32 text-center">
+        <h1 className="mb-7 font-display text-[clamp(46px,6vw,68px)] font-extrabold leading-none tracking-[-0.04em] text-white">
+          Куда отправимся?
+        </h1>
+
+        <div className="w-full max-w-[440px] rounded-[22px] bg-surface p-5 text-left shadow-[0_30px_64px_-24px_rgba(8,14,24,0.55)]">
           <HomepageRequestFormClassic destinations={destinations} />
         </div>
+
+        <p className="mt-4 text-[13px] font-medium text-white/80">
+          Бесплатно · без регистрации · гиды обычно отвечают в течение дня
+        </p>
+      </div>
+
+      <div className="absolute bottom-6 left-1/2 z-[2] flex -translate-x-1/2 flex-col items-center gap-1.5 text-xs font-semibold tracking-[0.04em] text-white/75">
+        <span>Открытые группы</span>
+        <ArrowDown className="h-[18px] w-[18px] motion-safe:animate-bounce" aria-hidden="true" />
       </div>
     </section>
   );

--- a/src/features/homepage-classic/components/homepage-request-form-classic.tsx
+++ b/src/features/homepage-classic/components/homepage-request-form-classic.tsx
@@ -1,16 +1,23 @@
 "use client";
 
 import * as React from "react";
-import { ChevronDown, Lock, LockOpen } from "lucide-react";
+import {
+  Calendar,
+  ChevronDown,
+  Clock,
+  Lock,
+  LockOpen,
+  MapPin,
+  Send,
+  Users,
+  Wallet,
+} from "lucide-react";
 
 import { LANGUAGES } from "@/data/languages";
 import { THEMES } from "@/data/themes";
 import { LanguageMultiSelect } from "@/components/shared/language-multi-select";
-import { Button } from "@/components/ui/button";
-import { Input } from "@/components/ui/input";
 import { Textarea } from "@/components/ui/textarea";
-import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip";
-import { cn, pluralizePeopleGenitive } from "@/lib/utils";
+import { cn } from "@/lib/utils";
 import { todayMoscowISODate } from "@/lib/dates";
 import type { DestinationOption } from "@/data/supabase/queries";
 import { HomepageAuthGate } from "./homepage-auth-gate";
@@ -20,20 +27,25 @@ interface Props {
   destinations: DestinationOption[];
 }
 
+const FBX =
+  "flex items-center gap-[11px] rounded-[13px] border border-border bg-surface px-[13px] py-[9px] transition-[border-color,box-shadow] focus-within:border-primary focus-within:shadow-[0_0_0_3px_rgba(26,86,164,0.12)]";
+const KIN =
+  "mb-[3px] block text-[9.5px] font-bold uppercase leading-none tracking-[0.07em] text-muted-foreground";
+const FIN =
+  "w-full border-0 bg-transparent p-0 text-[15.5px] font-bold leading-tight text-foreground outline-none placeholder:font-semibold placeholder:text-[#C2C9D3]";
+
 export function HomepageRequestFormClassic({ destinations }: Props) {
   const [showAllThemes, setShowAllThemes] = React.useState(false);
+  const [detailsOpen, setDetailsOpen] = React.useState(false);
   const {
     form,
     register,
     handleSubmit,
-    setValue,
     errors,
     interestsField,
     requestedLanguagesField,
     isAssembly,
     dateFlexibility,
-    watchedGroupSize,
-    watchedBudgetPerPerson,
     selectedInterests,
     submit,
     authGateOpen,
@@ -42,186 +54,163 @@ export function HomepageRequestFormClassic({ destinations }: Props) {
     serverError,
     isLoading,
   } = useRequestForm();
-  const visibleThemes = showAllThemes ? THEMES : THEMES.slice(0, 3);
+  const visibleThemes = showAllThemes ? THEMES : THEMES.slice(0, 4);
 
   return (
-    <TooltipProvider>
-      <form
-        className="grid gap-5 pb-28 sm:pb-0"
-        onSubmit={handleSubmit(submit)}
-        aria-label="Создать запрос"
-        noValidate
-      >
-      {/* 2. Куда хотите поехать? */}
-      <div className="grid gap-2">
-        <FieldLabel htmlFor="destination">Куда хотите поехать?</FieldLabel>
-        <Input
-          id="destination"
-          list="destination-options"
-          placeholder="Москва, Санкт-Петербург…"
-          autoComplete="off"
-          aria-invalid={Boolean(errors.destination)}
-          aria-describedby={errors.destination ? "destination-error" : undefined}
-          {...register("destination")}
-        />
-        <datalist id="destination-options">
-          {destinations.map((d) => (
-            <option key={d.name} value={d.name} />
-          ))}
-        </datalist>
-        <FieldError id="destination-error" message={errors.destination?.message} />
-      </div>
-
-      {/* 3. Даты и время */}
-      <div className="grid gap-3 sm:grid-cols-3 sm:items-start sm:gap-2">
-        <div className="grid gap-2">
-          <div className="flex min-h-7 items-center gap-1.5">
-            <FieldLabel htmlFor="startDate">Дата</FieldLabel>
-            <Tooltip>
-              <TooltipTrigger asChild>
-                <button
-                  type="button"
-                  onClick={() => {
-                    const current = form.getValues("dateFlexibility");
-                    setValue("dateFlexibility", current === "exact" ? "few_days" : "exact", {
-                      shouldDirty: true,
-                    });
-                  }}
-                  className={cn(
-                    "flex h-7 w-7 shrink-0 cursor-pointer select-none items-center justify-center rounded-md border text-sm font-bold leading-none transition-colors",
-                    dateFlexibility !== "exact"
-                      ? "border-primary bg-primary/10 text-primary"
-                      : "border-border bg-surface text-on-surface-muted hover:border-primary/40 hover:text-on-surface",
-                  )}
-                >
-                  ≈
-                </button>
-              </TooltipTrigger>
-              <TooltipContent className="text-sm">
-                <p>Гибкая дата (±2–3 дня)</p>
-              </TooltipContent>
-            </Tooltip>
-          </div>
-          <Input
-            id="startDate"
-            type="date"
-            min={todayMoscowISODate()}
-            aria-invalid={Boolean(errors.startDate)}
-            aria-describedby={errors.startDate ? "startDate-error" : undefined}
-            {...register("startDate")}
+    <form
+      className="flex flex-col gap-2.5"
+      onSubmit={handleSubmit(submit)}
+      aria-label="Создать запрос"
+      noValidate
+    >
+      {/* Направление */}
+      <div className={cn(FBX, "px-[15px] py-[11px]")}>
+        <MapPin className="h-[21px] w-[21px] shrink-0 text-primary" aria-hidden="true" />
+        <div className="min-w-0 flex-1">
+          <span className={KIN} aria-hidden="true">Направление</span>
+          <input
+            className={cn(FIN, "text-[18px]")}
+            list="destination-options"
+            placeholder="Куда едете?"
+            autoComplete="off"
+            aria-label="Направление"
+            aria-invalid={Boolean(errors.destination)}
+            {...register("destination")}
           />
-          <FieldError id="startDate-error" message={errors.startDate?.message} />
-        </div>
-        <div className="grid gap-2">
-          <div className="flex min-h-7 items-center">
-            <FieldLabel htmlFor="startTime">Начало</FieldLabel>
-          </div>
-          <Input
-            id="startTime"
-            type="time"
-            defaultValue="10:00"
-            aria-invalid={Boolean(errors.startTime)}
-            {...register("startTime")}
-          />
-          <FieldError id="startTime-error" message={errors.startTime?.message} />
-        </div>
-        <div className="grid gap-2">
-          <div className="flex min-h-7 items-center">
-            <FieldLabel htmlFor="endTime">Конец <span className="font-normal text-on-surface-muted">(необязательно)</span></FieldLabel>
-          </div>
-          <Input
-            id="endTime"
-            type="time"
-            defaultValue="12:00"
-            aria-invalid={Boolean(errors.endTime)}
-            {...register("endTime")}
-          />
-          <FieldError id="endTime-error" message={errors.endTime?.message} />
+          <datalist id="destination-options">
+            {destinations.map((d) => (
+              <option key={d.name} value={d.name} />
+            ))}
+          </datalist>
         </div>
       </div>
+      <FieldError message={errors.destination?.message} />
 
-      {/* 4. Сколько вас (замок: открытая/закрытая группа) */}
-      <div className="grid gap-3">
-        <div className="grid gap-2">
-          <FieldLabel htmlFor="groupSize">Сколько вас</FieldLabel>
-          <div className="relative flex items-center">
-            <Input
-              id="groupSize"
-              type="text"
+      {/* Когда + гибкость · Гостей + замок */}
+      <div className="grid grid-cols-2 gap-2.5">
+        <div className={FBX}>
+          <Calendar className="h-[18px] w-[18px] shrink-0 text-muted-foreground" aria-hidden="true" />
+          <div className="min-w-0 flex-1">
+            <span className={KIN} aria-hidden="true">Когда</span>
+            <input
+              className={FIN}
+              type="date"
+              min={todayMoscowISODate()}
+              aria-label="Когда"
+              aria-invalid={Boolean(errors.startDate)}
+              {...register("startDate")}
+            />
+          </div>
+          <button
+            type="button"
+            onClick={() => {
+              const current = form.getValues("dateFlexibility");
+              form.setValue("dateFlexibility", current === "exact" ? "few_days" : "exact", {
+                shouldDirty: true,
+              });
+            }}
+            title="Гибкие даты (±2–3 дня)"
+            aria-label="Переключить гибкие даты"
+            aria-pressed={dateFlexibility !== "exact"}
+            className={cn(
+              "grid h-[30px] w-[30px] shrink-0 cursor-pointer select-none place-items-center rounded-lg border text-sm font-bold leading-none transition",
+              dateFlexibility !== "exact"
+                ? "border-primary bg-primary text-white shadow-[0_0_0_3px_rgba(26,86,164,0.18)] hover:bg-primary/90"
+                : "border-primary/40 bg-primary/10 text-primary hover:bg-primary/20",
+            )}
+          >
+            ≈
+          </button>
+        </div>
+
+        <div className={FBX}>
+          <Users className="h-[18px] w-[18px] shrink-0 text-muted-foreground" aria-hidden="true" />
+          <div className="min-w-0 flex-1">
+            <span className={KIN} aria-hidden="true">Гостей</span>
+            <input
+              className={FIN}
               inputMode="numeric"
               placeholder="2"
-              className="pr-10"
+              aria-label="Гостей"
               aria-invalid={Boolean(errors.groupSize)}
               {...register("groupSize", { valueAsNumber: true })}
             />
-            <Tooltip>
-              <TooltipTrigger asChild>
-                <button
-                  type="button"
-                  onClick={() => {
-                    const current = form.getValues("mode");
-                    form.setValue("mode", current === "assembly" ? "private" : "assembly", {
-                      shouldValidate: false,
-                      shouldDirty: true,
-                    });
-                  }}
-                  aria-label={
-                    isAssembly
-                      ? "Открытая группа — нажмите, чтобы сделать закрытой"
-                      : "Закрытая группа — нажмите, чтобы сделать открытой"
-                  }
-                  className={cn(
-                    "absolute right-2 flex h-7 w-7 cursor-pointer select-none items-center justify-center rounded-md transition-colors",
-                    isAssembly
-                      ? "text-on-surface-muted hover:text-on-surface"
-                      : "text-primary",
-                  )}
-                >
-                  {isAssembly ? (
-                    <LockOpen className="h-4 w-4" aria-hidden="true" />
-                  ) : (
-                    <Lock className="h-4 w-4" aria-hidden="true" />
-                  )}
-                </button>
-              </TooltipTrigger>
-              <TooltipContent className="text-sm">
-                <p>{isAssembly ? "Открытая группа (сборная)" : "Закрытая группа (своя)"}</p>
-              </TooltipContent>
-            </Tooltip>
           </div>
-          <FieldError id="groupSize-error" message={errors.groupSize?.message} />
+          <button
+            type="button"
+            onClick={() => {
+              const current = form.getValues("mode");
+              form.setValue("mode", current === "assembly" ? "private" : "assembly", {
+                shouldValidate: false,
+                shouldDirty: true,
+              });
+            }}
+            title={isAssembly ? "Открытая группа (сборная)" : "Закрытая группа (своя)"}
+            aria-label={
+              isAssembly
+                ? "Открытая группа — нажмите, чтобы сделать закрытой"
+                : "Закрытая группа — нажмите, чтобы сделать открытой"
+            }
+            aria-pressed={!isAssembly}
+            className={cn(
+              "grid h-[30px] w-[30px] shrink-0 cursor-pointer select-none place-items-center rounded-lg border transition",
+              !isAssembly
+                ? "border-primary bg-primary text-white shadow-[0_0_0_3px_rgba(26,86,164,0.18)] hover:bg-primary/90"
+                : "border-primary/40 bg-primary/10 text-primary hover:bg-primary/20",
+            )}
+          >
+            {isAssembly ? (
+              <LockOpen className="h-[14px] w-[14px]" aria-hidden="true" />
+            ) : (
+              <Lock className="h-[14px] w-[14px]" aria-hidden="true" />
+            )}
+          </button>
         </div>
-
-        <div className="grid gap-2">
-          <FieldLabel htmlFor="budgetPerPersonRub">
-            Бюджет на человека (₽)
-          </FieldLabel>
-          <Input
-            id="budgetPerPersonRub"
-            type="number"
-            inputMode="numeric"
-            min={1000}
-            max={2000000}
-            aria-invalid={Boolean(errors.budgetPerPersonRub)}
-            aria-describedby="budgetPerPersonRub-total"
-            {...register("budgetPerPersonRub", { valueAsNumber: true })}
-          />
-          <FieldError
-            id="budgetPerPersonRub-error"
-            message={errors.budgetPerPersonRub?.message}
-          />
-        </div>
-        <TotalBudgetHint
-          id="budgetPerPersonRub-total"
-          perPerson={watchedBudgetPerPerson}
-          groupSize={watchedGroupSize}
-        />
       </div>
 
-      {/* 7. Темы */}
-      <div className="grid gap-2">
-        <FieldLabel>Темы</FieldLabel>
-        <div className="grid grid-cols-3 gap-2">
+      {/* Время · Бюджет */}
+      <div className="grid grid-cols-2 gap-2.5">
+        <div className={FBX}>
+          <Clock className="h-[18px] w-[18px] shrink-0 text-muted-foreground" aria-hidden="true" />
+          <div className="min-w-0 flex-1">
+            <span className={KIN} aria-hidden="true">Время</span>
+            <span className="flex items-center gap-1.5">
+              <input
+                className={cn(FIN, "w-[58px]")}
+                type="time"
+                aria-label="Время начала"
+                {...register("startTime")}
+              />
+              <span className="font-bold text-muted-foreground">–</span>
+              <input
+                className={cn(FIN, "w-[58px]")}
+                type="time"
+                aria-label="Время окончания"
+                {...register("endTime")}
+              />
+            </span>
+          </div>
+        </div>
+
+        <div className={FBX}>
+          <Wallet className="h-[18px] w-[18px] shrink-0 text-muted-foreground" aria-hidden="true" />
+          <div className="min-w-0 flex-1">
+            <span className={KIN} aria-hidden="true">Бюджет ₽/чел</span>
+            <input
+              className={FIN}
+              inputMode="numeric"
+              aria-label="Бюджет на человека"
+              aria-invalid={Boolean(errors.budgetPerPersonRub)}
+              {...register("budgetPerPersonRub", { valueAsNumber: true })}
+            />
+          </div>
+        </div>
+      </div>
+      <FieldError message={errors.groupSize?.message ?? errors.budgetPerPersonRub?.message} />
+
+      {/* Темы (чипы) + Детали */}
+      <div className="mt-0.5 flex flex-wrap items-center justify-between gap-2.5">
+        <div className="flex flex-wrap items-center gap-1.5">
           {visibleThemes.map((theme) => {
             const selected = selectedInterests.includes(theme.slug);
             const Icon = theme.Icon;
@@ -232,20 +221,19 @@ export function HomepageRequestFormClassic({ destinations }: Props) {
                 aria-pressed={selected}
                 onClick={() => {
                   const current = interestsField.value;
-                  const next = selected
-                    ? current.filter((s) => s !== theme.slug)
-                    : [...current, theme.slug];
-                  interestsField.onChange(next);
+                  interestsField.onChange(
+                    selected ? current.filter((s) => s !== theme.slug) : [...current, theme.slug],
+                  );
                 }}
                 className={cn(
-                  "flex w-full flex-row items-center gap-2 rounded-xl border px-3 py-2.5 text-left text-xs transition-colors",
+                  "inline-flex h-6 items-center gap-1.5 rounded-full border px-2.5 text-[11px] font-semibold transition",
                   selected
-                    ? "border-primary bg-primary/10 text-primary ring-2 ring-primary/40"
-                    : "border-border bg-surface text-on-surface-muted hover:border-primary/40 hover:text-on-surface",
+                    ? "border-primary bg-primary/10 text-primary shadow-[0_0_0_3px_rgba(26,86,164,0.12)]"
+                    : "border-border bg-surface text-muted-foreground hover:border-primary/40 hover:text-foreground",
                 )}
               >
-                <Icon className="h-5 w-5 shrink-0" />
-                <span className="leading-tight">{theme.label}</span>
+                <Icon className="h-2.5 w-2.5" aria-hidden="true" />
+                {theme.label}
               </button>
             );
           })}
@@ -253,42 +241,50 @@ export function HomepageRequestFormClassic({ destinations }: Props) {
             <button
               type="button"
               onClick={() => setShowAllThemes(true)}
-              className="col-span-3 py-1 text-sm text-on-surface-muted transition-colors hover:text-on-surface"
+              className="inline-flex h-6 items-center rounded-full border border-primary/30 px-2.5 text-[11px] font-semibold text-primary transition hover:bg-primary/10"
             >
-              Ещё темы →
+              Ещё
             </button>
           )}
         </div>
-        <FieldError id="interests-error" message={errors.interests?.message} />
+        <button
+          type="button"
+          onClick={() => setDetailsOpen((open) => !open)}
+          aria-expanded={detailsOpen}
+          className="inline-flex items-center gap-1.5 whitespace-nowrap text-[11px] font-semibold text-ink-2"
+        >
+          <ChevronDown
+            className={cn("h-[11px] w-[11px] transition-transform", detailsOpen && "rotate-180")}
+            aria-hidden="true"
+          />
+          Детали
+        </button>
       </div>
+      <FieldError message={errors.interests?.message} />
 
-      {/* 8. Пожелания — expandable «+ Добавить детали», collapsed by default */}
-      <details className="group rounded-xl border border-border bg-surface open:bg-surface-low">
-        <summary className="flex cursor-pointer list-none items-center gap-1.5 px-3 py-2.5 text-sm font-medium text-on-surface select-none [&::-webkit-details-marker]:hidden">
-          <ChevronDown aria-hidden="true" className="h-4 w-4 shrink-0 transition-transform group-open:rotate-180" />
-          <span>Добавить детали</span>
-          <span className="text-on-surface-muted font-normal">(выбрать язык, написать пожелания)</span>
-        </summary>
-        <div className="grid gap-3 px-3 pb-3 pt-1">
-          <div className="grid gap-2">
-            <FieldLabel>Языки экскурсии</FieldLabel>
+      {/* Детали */}
+      {detailsOpen && (
+        <div className="flex flex-col gap-3">
+          <div>
+            <span className={cn(KIN, "mb-1.5")} aria-hidden="true">Языки экскурсии</span>
             <LanguageMultiSelect
               options={LANGUAGES}
               value={requestedLanguagesField.value ?? []}
               onChange={requestedLanguagesField.onChange}
             />
           </div>
-          <Textarea
-            id="notes"
-            placeholder="Особые пожелания, ограничения по здоровью или другие детали."
-            aria-invalid={Boolean(errors.notes)}
-            {...register("notes")}
-          />
-          <FieldError id="notes-error" message={errors.notes?.message} />
+          <div>
+            <span className={cn(KIN, "mb-1.5")} aria-hidden="true">Пожелания</span>
+            <Textarea
+              id="notes"
+              aria-label="Пожелания"
+              placeholder="Особые пожелания, ограничения по здоровью или другие детали."
+              {...register("notes")}
+            />
+          </div>
         </div>
-      </details>
+      )}
 
-      {/* Server error */}
       {serverError && (
         <div
           role="alert"
@@ -304,68 +300,19 @@ export function HomepageRequestFormClassic({ destinations }: Props) {
         onAuthSuccess={handleAuthSuccess}
       />
 
-      {/* 9. Sticky submit button */}
-      <div className="fixed inset-x-0 bottom-0 z-10 border-t border-border bg-background p-4 pb-[calc(1rem+env(safe-area-inset-bottom))] sm:relative sm:bottom-auto sm:inset-x-auto sm:border-t-0 sm:bg-transparent sm:p-0 sm:pt-8">
-        <Button type="submit" disabled={isLoading} className="w-full">
-          {isLoading ? "Отправляем…" : "Отправить запрос гидам"}
-        </Button>
-      </div>
-      </form>
-    </TooltipProvider>
+      <button
+        type="submit"
+        disabled={isLoading}
+        className="mt-0.5 inline-flex h-[50px] w-full items-center justify-center gap-2 rounded-[13px] bg-primary text-[15px] font-bold text-primary-foreground transition hover:bg-primary/90 disabled:cursor-not-allowed disabled:opacity-60"
+      >
+        <Send className="h-[18px] w-[18px]" aria-hidden="true" strokeWidth={2.2} />
+        {isLoading ? "Отправляем…" : "Найти гида"}
+      </button>
+    </form>
   );
 }
 
-function FieldLabel(props: React.ComponentProps<"label">) {
-  return (
-    <label
-      {...props}
-      className={cn("text-sm font-medium text-on-surface", props.className)}
-    />
-  );
-}
-
-function FieldError({ id, message }: { id: string; message?: string }) {
+function FieldError({ message }: { message?: string }) {
   if (!message) return null;
-  return (
-    <p id={id} className="text-xs font-medium text-destructive">
-      {message}
-    </p>
-  );
-}
-
-function TotalBudgetHint({
-  id,
-  perPerson,
-  groupSize,
-}: {
-  id: string;
-  perPerson: number | undefined;
-  groupSize: number | undefined;
-}) {
-  const safePer =
-    typeof perPerson === "number" && Number.isFinite(perPerson) && perPerson > 0
-      ? perPerson
-      : 0;
-  const safeCount =
-    typeof groupSize === "number" && Number.isFinite(groupSize) && groupSize > 0
-      ? Math.floor(groupSize)
-      : 0;
-  if (safePer === 0 || safeCount === 0) {
-    return (
-      <p id={id} className="text-xs text-on-surface-muted">
-        Укажите бюджет и размер группы, чтобы увидеть итоговую сумму.
-      </p>
-    );
-  }
-  const total = safePer * safeCount;
-  return (
-    <p
-      id={id}
-      className="text-xs text-on-surface-muted"
-      aria-live="polite"
-    >
-      Итого: <span className="font-medium text-on-surface">{total.toLocaleString("ru-RU")} ₽</span>
-      {" "}за группу из {safeCount} {pluralizePeopleGenitive(safeCount)}.
-    </p>
-  );
+  return <p className="text-xs font-medium text-destructive">{message}</p>;
 }

--- a/src/features/homepage-classic/components/homepage-request-form.test.tsx
+++ b/src/features/homepage-classic/components/homepage-request-form.test.tsx
@@ -419,42 +419,41 @@ describe("HomepageRequestForm UI affordances", () => {
   });
 });
 
-describe("HomepageRequestFormClassic repaired layout", () => {
-  it("keeps the approved group, budget, details, and topic expansion layout", () => {
+describe("HomepageRequestFormClassic inset-label layout", () => {
+  it("renders the inset-label brief fields with the mode toggle and topic expansion", () => {
     render(<HomepageRequestFormClassic destinations={[]} />);
 
-    const groupSizeInput = screen.getByLabelText("Сколько вас");
-    const wrapper = groupSizeInput.closest("div");
-    expect(wrapper).toHaveClass("relative", "flex", "items-center");
+    // Inset-label fields, addressed by their accessible labels.
+    expect(screen.getByLabelText("Направление")).toBeInTheDocument();
+    expect(screen.getByLabelText("Когда")).toBeInTheDocument();
+    expect(screen.getByLabelText("Гостей")).toBeInTheDocument();
+    expect(screen.getByLabelText("Бюджет на человека")).toBeInTheDocument();
     expect(
-      within(wrapper!).getByRole("button", { name: /сделать (закрытой|открытой)/i }),
+      screen.getByRole("button", { name: /сделать (закрытой|открытой)/i }),
     ).toBeInTheDocument();
-    expect(screen.queryByText("Сборная группа")).toBeNull();
 
-    expect(within(wrapper!).queryByLabelText("Бюджет на человека (₽)")).toBeNull();
-    expect(screen.getByLabelText("Бюджет на человека (₽)")).toBeInTheDocument();
+    // «Детали» disclosure is collapsed by default; languages appear once opened.
+    expect(screen.queryByText("Языки экскурсии")).toBeNull();
+    fireEvent.click(screen.getByRole("button", { name: "Детали" }));
+    expect(screen.getByText("Языки экскурсии")).toBeInTheDocument();
 
-    const details = screen.getByText("Добавить детали").closest("details");
-    expect(details).not.toBeNull();
-    expect(within(details!).getByText("Языки экскурсии")).toBeInTheDocument();
-
+    // First four themes are shown inline; the rest sit behind «Ещё».
     expect(screen.getByRole("button", { name: /история и культура/i })).toBeInTheDocument();
-    expect(screen.getByRole("button", { name: /природа/i })).toBeInTheDocument();
-    expect(screen.getByRole("button", { name: /гастрономия/i })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /искусство/i })).toBeInTheDocument();
     expect(screen.queryByRole("button", { name: /религия и духовность/i })).toBeNull();
 
-    fireEvent.click(screen.getByRole("button", { name: "Ещё темы →" }));
+    fireEvent.click(screen.getByRole("button", { name: "Ещё" }));
 
     expect(screen.getByRole("button", { name: /религия и духовность/i })).toBeInTheDocument();
   });
 
-  it("renders an opaque mobile sticky CTA bar with bottom clearance", () => {
+  it("uses the «Найти гида» submit with no sticky mobile bar", () => {
     render(<HomepageRequestFormClassic destinations={[]} />);
-    const submit = screen.getByRole("button", { name: /отправить запрос/i });
-    const bar = submit.parentElement!;
-    expect(bar).toHaveClass("bg-background");
-    expect(bar).not.toHaveClass("bg-background/95");
+    const submit = screen.getByRole("button", { name: /найти гида/i });
+    expect(submit.getAttribute("type")).toBe("submit");
     const form = submit.closest("form");
-    expect(form).toHaveClass("pb-28", "sm:pb-0");
+    expect(form).not.toHaveClass("pb-28");
+    // Submit sits directly in the form flow, not inside a fixed sticky bar.
+    expect(submit.parentElement).toBe(form);
   });
 });

--- a/src/features/homepage-classic/components/homepage-shell2-classic.tsx
+++ b/src/features/homepage-classic/components/homepage-shell2-classic.tsx
@@ -1,36 +1,124 @@
-import Link from "next/link";
-
-import { PageHeader } from "@/components/shared/page-header";
+import { DestinationTile } from "@/components/shared/destination-tile";
+import { OpenGroupCard } from "@/components/shared/open-group-card";
+import { SectionHeading } from "@/components/shared/section-heading";
 import { SiteFooter } from "@/components/shared/site-footer";
 import type { DestinationOption, RequestRecord } from "@/data/supabase/queries";
+import { cityImage } from "@/lib/city-image";
+import { pluralize } from "@/lib/utils";
 
-import { HomepageRequestFormClassic } from "./homepage-request-form-classic";
+import { HomepageHeroFormClassic } from "./homepage-hero-form-classic";
 
 interface Props {
   destinations: DestinationOption[];
   requests: RequestRecord[];
 }
 
-export function HomePageShell2Classic({ destinations }: Props) {
+const HOW_IT_WORKS = [
+  { title: "Опишите поездку", body: "Город, даты, бюджет и интересы" },
+  { title: "Гиды откликнутся", body: "Местные гиды предложат маршрут и цену" },
+  {
+    title: "Выберите гида",
+    body: "Сравните отклики, отзывы, цены и выберите гида, прошедшего государственную аккредитацию",
+  },
+] as const;
+
+const SECTION = "mx-auto w-full max-w-[1180px] px-[clamp(20px,4vw,44px)]";
+
+function offersFooter(offerCount: number): string {
+  if (offerCount <= 0) return "Пока нет откликов";
+  return `${offerCount} ${pluralize(offerCount, "отклик", "отклика", "откликов")}`;
+}
+
+export function HomePageShell2Classic({ destinations, requests }: Props) {
+  const openGroups = requests.slice(0, 3);
+  const popularDestinations = destinations.slice(0, 6);
+
   return (
     <>
-      <div className="mx-auto w-full max-w-2xl px-5 py-10 md:px-8">
-        <PageHeader
-          title="Заполните заявку вручную"
-          subtitle="Опишите поездку — местные гиды предложат варианты."
-        />
-        <div className="mt-8 rounded-[16px] border border-border bg-surface-lowest p-6 md:p-8">
-          <HomepageRequestFormClassic destinations={destinations} />
+      <HomepageHeroFormClassic destinations={destinations} />
+
+      {openGroups.length > 0 && (
+        <section className={`${SECTION} pb-6 pt-[clamp(40px,6vw,62px)]`} aria-label="Открытые группы">
+          <SectionHeading
+            title="Открытые группы"
+            subtitle="Займите место рядом с местным гидом"
+            action={{ label: "Все группы", href: "/requests" }}
+          />
+          <div className="grid gap-[18px] sm:grid-cols-2 lg:grid-cols-3">
+            {openGroups.map((req, index) => {
+              const city = req.destination.split(",")[0].trim();
+              const selected = req.status === "booked";
+              return (
+                <OpenGroupCard
+                  key={req.id}
+                  href={`/requests/${req.id}`}
+                  city={city}
+                  region={req.destinationRegion}
+                  imageUrl={req.imageUrl || cityImage(city)}
+                  status={selected ? "selected" : "waiting"}
+                  minPeople={`от ${req.capacity ?? req.groupSize} чел.`}
+                  date={req.dateLabel}
+                  datesFlexible={req.dateFlexibility === "few_days"}
+                  time={
+                    req.startTime
+                      ? `${req.startTime}${req.endTime ? `–${req.endTime}` : ""}`
+                      : undefined
+                  }
+                  interests={req.interests}
+                  avatarUrl={req.requesterAvatarUrl}
+                  avatarInitials={req.requesterInitials}
+                  footerText={selected ? "Гид найден" : offersFooter(req.offerCount)}
+                  priority={index === 0}
+                />
+              );
+            })}
+          </div>
+        </section>
+      )}
+
+      {popularDestinations.length > 0 && (
+        <section className={`${SECTION} pb-6 pt-[30px]`} aria-label="Популярные направления">
+          <SectionHeading
+            title="Популярные направления"
+            action={{ label: "Все направления", href: "/destinations" }}
+          />
+          <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+            {popularDestinations.map((d) => (
+              <DestinationTile
+                key={`${d.name}-${d.region}`}
+                href={`/listings?q=${encodeURIComponent(d.name)}`}
+                name={d.name}
+                imageUrl={cityImage(d.name)}
+                guidesCount={d.guideCount}
+              />
+            ))}
+          </div>
+        </section>
+      )}
+
+      <section className="mt-[30px] border-y border-border bg-surface">
+        <div className={`${SECTION} py-[54px]`}>
+          <div className="mb-9 text-center">
+            <h2 className="text-[clamp(24px,3vw,30px)] font-extrabold tracking-[-0.03em] text-foreground">
+              Как это работает
+            </h2>
+          </div>
+          <div className="grid gap-6 sm:grid-cols-3">
+            {HOW_IT_WORKS.map((step, index) => (
+              <div key={step.title} className="flex flex-col items-center gap-2.5 text-center">
+                <span className="grid h-12 w-12 place-items-center rounded-[14px] bg-primary/10 text-[19px] font-extrabold text-primary">
+                  {index + 1}
+                </span>
+                <div className="text-[17px] font-bold text-foreground">{step.title}</div>
+                <p className="m-0 max-w-[26ch] text-sm font-medium leading-relaxed text-muted-foreground">
+                  {step.body}
+                </p>
+              </div>
+            ))}
+          </div>
         </div>
-        <div className="mt-6 text-center">
-          <Link
-            href="/ai"
-            className="text-sm text-on-surface-muted transition-colors hover:text-on-surface"
-          >
-            Быстрый подбор через вопросы →
-          </Link>
-        </div>
-      </div>
+      </section>
+
       <SiteFooter />
     </>
   );

--- a/src/features/requests/components/public-requests-marketplace-screen.tsx
+++ b/src/features/requests/components/public-requests-marketplace-screen.tsx
@@ -8,8 +8,7 @@ import { ChevronDown, Compass, X } from "lucide-react";
 
 import { EmptyState } from "@/components/shared/empty-state";
 import { ListHero } from "@/components/shared/list-hero";
-import { RequestCardFinal } from "@/components/shared/request-card-final";
-import { formatRubNumber } from "@/data/money";
+import { OpenGroupCard } from "@/components/shared/open-group-card";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Calendar } from "@/components/ui/calendar";
@@ -32,8 +31,9 @@ import {
 } from "@/components/ui/sheet";
 import type { OpenRequestRecord } from "@/data/open-requests/types";
 import { THEMES } from "@/data/themes";
-import { brandGradient } from "@/lib/city-image";
+import { brandGradient, cityImage } from "@/lib/city-image";
 import { todayMoscowISODate } from "@/lib/dates";
+import { pluralize } from "@/lib/utils";
 
 type CategoryFilter = (typeof THEMES)[number]["label"];
 
@@ -80,15 +80,6 @@ function deriveMonthsFromDateLabel(label: string): number[] {
     if (lower.includes(m)) matched.push(idx);
   });
   return matched;
-}
-
-function derivePrice(budgetPerPersonRub?: number): string {
-  if (!budgetPerPersonRub) return "По договоренности";
-  return `${formatRubNumber(budgetPerPersonRub)} ₽ / чел`;
-}
-
-function deriveGuideState(status: OpenRequestRecord["status"]) {
-  return status === "matched" ? "found" : "waiting";
 }
 
 function getSearchText(request: OpenRequestRecord): string {
@@ -518,26 +509,33 @@ export function PublicRequestsMarketplaceScreen({ initialData }: Props) {
           {filteredRequests.length > 0 ? (
             <div className="mx-auto max-w-2xl">
             <div className="grid grid-cols-1 gap-4 md:grid-cols-2">
-              {filteredRequests.map((request) => {
+              {filteredRequests.map((request, index) => {
                 const location = request.destinationLabel.split(",")[0].trim();
+                const matched = request.status === "matched";
+                const sizeCurrent = request.group.sizeCurrent;
+                const organizer = request.members?.[0];
 
                 return (
-                  <RequestCardFinal
+                  <OpenGroupCard
                     key={request.id}
                     href={`/requests/${request.id}`}
-                    location={location}
+                    city={location}
+                    region={request.regionLabel}
+                    imageUrl={request.cityImageUrl || request.imageUrl || cityImage(location)}
+                    status={matched ? "selected" : "waiting"}
+                    minPeople={`от ${request.group.sizeTarget} чел.`}
                     date={request.dateRangeLabel}
-                    time={request.timeLabel}
-                    groupType={request.group.openToMoreMembers ? "assembly" : "private"}
                     datesFlexible={request.datesFlexible}
-                    guideState={deriveGuideState(request.status)}
+                    time={request.timeLabel}
                     interests={request.interests}
-                    members={request.members}
-                    participantCount={request.group.sizeCurrent}
-                    price={derivePrice(request.budgetPerPersonRub)}
-                    groupPrice={request.budgetPerPersonRub != null
-                      ? `~${formatRubNumber(Math.round(request.budgetPerPersonRub * request.group.sizeCurrent))} ₽ за группу`
-                      : undefined}
+                    avatarUrl={organizer?.avatarUrl ?? null}
+                    avatarInitials={organizer?.initials}
+                    footerText={
+                      matched
+                        ? "Гид найден"
+                        : `${sizeCurrent} ${pluralize(sizeCurrent, "участник", "участника", "участников")}`
+                    }
+                    priority={index < 3}
                   />
                 );
               })}


### PR DESCRIPTION
## What
Makes the **`/` homepage** match the approved *Homepage Classic* mockup and propagates its sections to **`/requests`**.

### Homepage (`/`)
- Full-bleed photographic hero (via the `city-image` pipeline) with the existing **frosted floating nav overlaid** (nav untouched); H1 «Куда отправимся?» + scroll cue.
- Brief request form re-skinned to the **inset-label** treatment (Направление → Когда/≈ · Гостей/lock → Время · Бюджет → interest chips/Ещё → Детали → «Найти гида»). **Every react-hook-form binding + the server action are unchanged** (`use-request-form.ts` not touched). Fixes the lock-active icon to white-on-primary.
- New sections: Открытые группы → Популярные направления → Как это работает → footer (uses the `requests` prop that was previously passed-but-unused).

### Reusable modules (new)
`SectionHeading`, `OpenGroupCard`, `DestinationTile`.

### /requests
- Marketplace adopts the shared **`OpenGroupCard`** (no per-person price, no seats bar — mockup intent). Hero, filters, and data flow preserved.

## Scope / behavior
- Strictly presentation + composition; data/validation/submission logic unchanged.
- 2 obsolete `-classic` layout tests rewritten to assert the new canon (test count unchanged).
- Destination tiles link to `/listings?q={city}` (always resolves; pre-fills search).
- Deferred (no mockup): `/requests/new` multi-step form; per-destination from-price (needs a query change).

## Verification
- `tsc` 0 · `eslint` 0 · full suite **1065/1065** (== baseline) · `build` EXIT 0
- Browser smoke at 1280 + 375 on `/` and `/requests`: matches mockup, nav frosted+floating, no console errors.