### PR TITLE
feat(homepage): widen brief form + themes-as-dropdown (like languages)

### DIFF
--- a/src/components/shared/language-multi-select.tsx
+++ b/src/components/shared/language-multi-select.tsx
@@ -1,22 +1,8 @@
 "use client";
 
-import { useState, type JSX } from "react";
-import { Check, ChevronsUpDown, X } from "lucide-react";
+import type { JSX } from "react";
 
-import {
-  Command,
-  CommandEmpty,
-  CommandGroup,
-  CommandInput,
-  CommandItem,
-  CommandList,
-} from "@/components/ui/command";
-import {
-  Popover,
-  PopoverContent,
-  PopoverTrigger,
-} from "@/components/ui/popover";
-import { cn } from "@/lib/utils";
+import { TagMultiSelect } from "./tag-multi-select";
 
 type LanguageMultiSelectProps = {
   value: string[];
@@ -31,124 +17,16 @@ export function LanguageMultiSelect({
   options,
   placeholder = "Любой язык",
 }: LanguageMultiSelectProps): JSX.Element {
-  const [open, setOpen] = useState(false);
-
-  const toggle = (language: string) => {
-    onChange(
-      value.includes(language)
-        ? value.filter((item) => item !== language)
-        : [...value, language],
-    );
-  };
-
   return (
-    <Popover open={open} onOpenChange={setOpen}>
-      <div className="flex min-h-11 w-full flex-wrap items-center gap-1.5 rounded-lg border border-border bg-background px-3 py-2 text-left text-sm transition-colors hover:bg-muted/40 focus-within:border-ring focus-within:ring-3 focus-within:ring-ring/50">
-        {value.length === 0 ? (
-          <PopoverTrigger asChild>
-            <button
-              type="button"
-              aria-label="Выбрать языки экскурсии"
-              className="flex min-h-6 flex-1 cursor-pointer items-center justify-between gap-2 text-left focus-visible:outline-none"
-            >
-              <span className="text-muted-foreground">{placeholder}</span>
-              <ChevronsUpDown
-                aria-hidden="true"
-                className={cn(
-                  "size-4 shrink-0 text-muted-foreground transition-transform",
-                  open && "rotate-180",
-                )}
-              />
-            </button>
-          </PopoverTrigger>
-        ) : (
-          <>
-            {value.map((language) => (
-              <span
-                key={language}
-                className="flex items-center gap-1 rounded-full bg-primary/10 py-0.5 pl-2 pr-1 text-xs text-primary"
-              >
-                {language}
-                <button
-                  type="button"
-                  aria-label={`Убрать ${language}`}
-                  className="inline-flex min-h-6 min-w-6 items-center justify-center rounded-full text-primary transition-colors hover:bg-primary/10 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/50"
-                  onClick={(event) => {
-                    event.preventDefault();
-                    event.stopPropagation();
-                    toggle(language);
-                  }}
-                >
-                  <X aria-hidden="true" className="size-3" />
-                </button>
-              </span>
-            ))}
-            <PopoverTrigger asChild>
-              <button
-                type="button"
-                aria-label="Выбрать языки экскурсии"
-                className="ml-auto flex min-h-6 min-w-6 flex-1 cursor-pointer items-center justify-end rounded-full text-muted-foreground transition-colors hover:bg-muted focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/50"
-              >
-                <ChevronsUpDown
-                  aria-hidden="true"
-                  className={cn("size-4 transition-transform", open && "rotate-180")}
-                />
-              </button>
-            </PopoverTrigger>
-          </>
-        )}
-      </div>
-      <PopoverContent
-        align="start"
-        className="min-w-64 w-[var(--radix-popover-trigger-width)] p-0"
-      >
-        <Command
-          filter={(itemValue, search) =>
-            itemValue.toLocaleLowerCase("ru").includes(search.toLocaleLowerCase("ru"))
-              ? 1
-              : 0
-          }
-        >
-          <CommandInput placeholder="Поиск языка…" autoFocus />
-          <CommandList>
-            <CommandEmpty>Ничего не найдено</CommandEmpty>
-            <CommandGroup>
-              {options.map((language) => {
-                const selected = value.includes(language);
-
-                return (
-                  <CommandItem
-                    key={language}
-                    value={language}
-                    data-checked={selected}
-                    onSelect={() => toggle(language)}
-                  >
-                    <Check
-                      aria-hidden="true"
-                      className={cn(
-                        "mr-2 size-4",
-                        selected ? "opacity-100" : "opacity-0",
-                      )}
-                    />
-                    {language}
-                  </CommandItem>
-                );
-              })}
-            </CommandGroup>
-          </CommandList>
-          <div className="flex items-center justify-between border-t border-border px-3 py-2 text-xs text-muted-foreground">
-            <button
-              type="button"
-              className="cursor-pointer text-primary hover:underline"
-              onClick={() => onChange([])}
-            >
-              Очистить
-            </button>
-            <span>Выбрано: {value.length}</span>
-          </div>
-        </Command>
-      </PopoverContent>
-    </Popover>
+    <TagMultiSelect
+      value={value}
+      onChange={onChange}
+      options={options}
+      placeholder={placeholder}
+      ariaLabel="Выбрать языки экскурсии"
+      searchPlaceholder="Поиск языка…"
+      emptyLabel="Ничего не найдено"
+    />
   );
 }
 

--- a/src/components/shared/tag-multi-select.tsx
+++ b/src/components/shared/tag-multi-select.tsx
@@ -1,0 +1,166 @@
+"use client";
+
+import { useState, type JSX } from "react";
+import { Check, ChevronsUpDown, X } from "lucide-react";
+
+import {
+  Command,
+  CommandEmpty,
+  CommandGroup,
+  CommandInput,
+  CommandItem,
+  CommandList,
+} from "@/components/ui/command";
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from "@/components/ui/popover";
+import { cn } from "@/lib/utils";
+
+type TagMultiSelectProps = {
+  value: string[];
+  onChange: (next: string[]) => void;
+  options: readonly string[];
+  placeholder?: string;
+  ariaLabel?: string;
+  searchPlaceholder?: string;
+  emptyLabel?: string;
+};
+
+/**
+ * Generic searchable multi-select. Shows selected values as removable chips and
+ * opens a searchable popover menu for the rest. Domain-specific wrappers
+ * (LanguageMultiSelect, ThemeMultiSelect) set the labels.
+ */
+export function TagMultiSelect({
+  value,
+  onChange,
+  options,
+  placeholder = "Выбрать",
+  ariaLabel = "Выбрать значения",
+  searchPlaceholder = "Поиск…",
+  emptyLabel = "Ничего не найдено",
+}: TagMultiSelectProps): JSX.Element {
+  const [open, setOpen] = useState(false);
+
+  const toggle = (item: string) => {
+    onChange(
+      value.includes(item)
+        ? value.filter((entry) => entry !== item)
+        : [...value, item],
+    );
+  };
+
+  return (
+    <Popover open={open} onOpenChange={setOpen}>
+      <div className="flex min-h-11 w-full flex-wrap items-center gap-1.5 rounded-lg border border-border bg-background px-3 py-2 text-left text-sm transition-colors hover:bg-muted/40 focus-within:border-ring focus-within:ring-3 focus-within:ring-ring/50">
+        {value.length === 0 ? (
+          <PopoverTrigger asChild>
+            <button
+              type="button"
+              aria-label={ariaLabel}
+              className="flex min-h-6 flex-1 cursor-pointer items-center justify-between gap-2 text-left focus-visible:outline-none"
+            >
+              <span className="text-muted-foreground">{placeholder}</span>
+              <ChevronsUpDown
+                aria-hidden="true"
+                className={cn(
+                  "size-4 shrink-0 text-muted-foreground transition-transform",
+                  open && "rotate-180",
+                )}
+              />
+            </button>
+          </PopoverTrigger>
+        ) : (
+          <>
+            {value.map((item) => (
+              <span
+                key={item}
+                className="flex items-center gap-1 rounded-full bg-primary/10 py-0.5 pl-2 pr-1 text-xs text-primary"
+              >
+                {item}
+                <button
+                  type="button"
+                  aria-label={`Убрать ${item}`}
+                  className="inline-flex min-h-6 min-w-6 items-center justify-center rounded-full text-primary transition-colors hover:bg-primary/10 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/50"
+                  onClick={(event) => {
+                    event.preventDefault();
+                    event.stopPropagation();
+                    toggle(item);
+                  }}
+                >
+                  <X aria-hidden="true" className="size-3" />
+                </button>
+              </span>
+            ))}
+            <PopoverTrigger asChild>
+              <button
+                type="button"
+                aria-label={ariaLabel}
+                className="ml-auto flex min-h-6 min-w-6 flex-1 cursor-pointer items-center justify-end rounded-full text-muted-foreground transition-colors hover:bg-muted focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/50"
+              >
+                <ChevronsUpDown
+                  aria-hidden="true"
+                  className={cn("size-4 transition-transform", open && "rotate-180")}
+                />
+              </button>
+            </PopoverTrigger>
+          </>
+        )}
+      </div>
+      <PopoverContent
+        align="start"
+        className="min-w-64 w-[var(--radix-popover-trigger-width)] p-0"
+      >
+        <Command
+          filter={(itemValue, search) =>
+            itemValue.toLocaleLowerCase("ru").includes(search.toLocaleLowerCase("ru"))
+              ? 1
+              : 0
+          }
+        >
+          <CommandInput placeholder={searchPlaceholder} autoFocus />
+          <CommandList>
+            <CommandEmpty>{emptyLabel}</CommandEmpty>
+            <CommandGroup>
+              {options.map((item) => {
+                const selected = value.includes(item);
+
+                return (
+                  <CommandItem
+                    key={item}
+                    value={item}
+                    data-checked={selected}
+                    onSelect={() => toggle(item)}
+                  >
+                    <Check
+                      aria-hidden="true"
+                      className={cn(
+                        "mr-2 size-4",
+                        selected ? "opacity-100" : "opacity-0",
+                      )}
+                    />
+                    {item}
+                  </CommandItem>
+                );
+              })}
+            </CommandGroup>
+          </CommandList>
+          <div className="flex items-center justify-between border-t border-border px-3 py-2 text-xs text-muted-foreground">
+            <button
+              type="button"
+              className="cursor-pointer text-primary hover:underline"
+              onClick={() => onChange([])}
+            >
+              Очистить
+            </button>
+            <span>Выбрано: {value.length}</span>
+          </div>
+        </Command>
+      </PopoverContent>
+    </Popover>
+  );
+}
+
+export type { TagMultiSelectProps };

--- a/src/components/shared/theme-multi-select.tsx
+++ b/src/components/shared/theme-multi-select.tsx
@@ -1,0 +1,53 @@
+"use client";
+
+import type { JSX } from "react";
+
+import { THEMES } from "@/data/themes";
+
+import { TagMultiSelect } from "./tag-multi-select";
+
+const LABEL_BY_SLUG = new Map<string, string>(THEMES.map((t) => [t.slug, t.label]));
+const SLUG_BY_LABEL = new Map<string, string>(THEMES.map((t) => [t.label, t.slug]));
+const OPTIONS: string[] = THEMES.map((t) => t.label);
+
+type ThemeMultiSelectProps = {
+  /** selected theme slugs */
+  value: string[];
+  onChange: (next: string[]) => void;
+  placeholder?: string;
+};
+
+/**
+ * Theme/interest multi-select, behaving exactly like the language selector
+ * (searchable popover + removable chips). Works in slug-space externally but
+ * displays human labels.
+ */
+export function ThemeMultiSelect({
+  value,
+  onChange,
+  placeholder = "Любая тема",
+}: ThemeMultiSelectProps): JSX.Element {
+  const labels = value
+    .map((slug) => LABEL_BY_SLUG.get(slug))
+    .filter((label): label is string => Boolean(label));
+
+  return (
+    <TagMultiSelect
+      value={labels}
+      options={OPTIONS}
+      placeholder={placeholder}
+      ariaLabel="Выбрать темы"
+      searchPlaceholder="Поиск темы…"
+      emptyLabel="Тема не найдена"
+      onChange={(nextLabels) =>
+        onChange(
+          nextLabels
+            .map((label) => SLUG_BY_LABEL.get(label))
+            .filter((slug): slug is string => Boolean(slug)),
+        )
+      }
+    />
+  );
+}
+
+export type { ThemeMultiSelectProps };

--- a/src/features/homepage-classic/components/homepage-hero-form-classic.tsx
+++ b/src/features/homepage-classic/components/homepage-hero-form-classic.tsx
@@ -33,7 +33,7 @@ export function HomepageHeroFormClassic({ destinations }: Props) {
           Куда отправимся?
         </h1>
 
-        <div className="w-full max-w-[440px] rounded-[22px] bg-surface p-5 text-left shadow-[0_30px_64px_-24px_rgba(8,14,24,0.55)]">
+        <div className="w-full max-w-[480px] rounded-[22px] bg-surface p-5 text-left shadow-[0_30px_64px_-24px_rgba(8,14,24,0.55)]">
           <HomepageRequestFormClassic destinations={destinations} />
         </div>
 

--- a/src/features/homepage-classic/components/homepage-request-form-classic.tsx
+++ b/src/features/homepage-classic/components/homepage-request-form-classic.tsx
@@ -14,8 +14,8 @@ import {
 } from "lucide-react";
 
 import { LANGUAGES } from "@/data/languages";
-import { THEMES } from "@/data/themes";
 import { LanguageMultiSelect } from "@/components/shared/language-multi-select";
+import { ThemeMultiSelect } from "@/components/shared/theme-multi-select";
 import { Textarea } from "@/components/ui/textarea";
 import { cn } from "@/lib/utils";
 import { todayMoscowISODate } from "@/lib/dates";
@@ -35,7 +35,6 @@ const FIN =
   "w-full border-0 bg-transparent p-0 text-[15.5px] font-bold leading-tight text-foreground outline-none placeholder:font-semibold placeholder:text-[#C2C9D3]";
 
 export function HomepageRequestFormClassic({ destinations }: Props) {
-  const [showAllThemes, setShowAllThemes] = React.useState(false);
   const [detailsOpen, setDetailsOpen] = React.useState(false);
   const {
     form,
@@ -54,7 +53,6 @@ export function HomepageRequestFormClassic({ destinations }: Props) {
     serverError,
     isLoading,
   } = useRequestForm();
-  const visibleThemes = showAllThemes ? THEMES : THEMES.slice(0, 4);
 
   return (
     <form
@@ -176,14 +174,14 @@ export function HomepageRequestFormClassic({ destinations }: Props) {
             <span className={KIN} aria-hidden="true">Время</span>
             <span className="flex items-center gap-1.5">
               <input
-                className={cn(FIN, "w-[58px]")}
+                className={cn(FIN, "min-w-0 flex-1")}
                 type="time"
                 aria-label="Время начала"
                 {...register("startTime")}
               />
               <span className="font-bold text-muted-foreground">–</span>
               <input
-                className={cn(FIN, "w-[58px]")}
+                className={cn(FIN, "min-w-0 flex-1")}
                 type="time"
                 aria-label="Время окончания"
                 {...register("endTime")}
@@ -208,59 +206,29 @@ export function HomepageRequestFormClassic({ destinations }: Props) {
       </div>
       <FieldError message={errors.groupSize?.message ?? errors.budgetPerPersonRub?.message} />
 
-      {/* Темы (чипы) + Детали */}
-      <div className="mt-0.5 flex flex-wrap items-center justify-between gap-2.5">
-        <div className="flex flex-wrap items-center gap-1.5">
-          {visibleThemes.map((theme) => {
-            const selected = selectedInterests.includes(theme.slug);
-            const Icon = theme.Icon;
-            return (
-              <button
-                key={theme.slug}
-                type="button"
-                aria-pressed={selected}
-                onClick={() => {
-                  const current = interestsField.value;
-                  interestsField.onChange(
-                    selected ? current.filter((s) => s !== theme.slug) : [...current, theme.slug],
-                  );
-                }}
-                className={cn(
-                  "inline-flex h-6 items-center gap-1.5 rounded-full border px-2.5 text-[11px] font-semibold transition",
-                  selected
-                    ? "border-primary bg-primary/10 text-primary shadow-[0_0_0_3px_rgba(26,86,164,0.12)]"
-                    : "border-border bg-surface text-muted-foreground hover:border-primary/40 hover:text-foreground",
-                )}
-              >
-                <Icon className="h-2.5 w-2.5" aria-hidden="true" />
-                {theme.label}
-              </button>
-            );
-          })}
-          {!showAllThemes && (
-            <button
-              type="button"
-              onClick={() => setShowAllThemes(true)}
-              className="inline-flex h-6 items-center rounded-full border border-primary/30 px-2.5 text-[11px] font-semibold text-primary transition hover:bg-primary/10"
-            >
-              Ещё
-            </button>
-          )}
-        </div>
-        <button
-          type="button"
-          onClick={() => setDetailsOpen((open) => !open)}
-          aria-expanded={detailsOpen}
-          className="inline-flex items-center gap-1.5 whitespace-nowrap text-[11px] font-semibold text-ink-2"
-        >
-          <ChevronDown
-            className={cn("h-[11px] w-[11px] transition-transform", detailsOpen && "rotate-180")}
-            aria-hidden="true"
-          />
-          Детали
-        </button>
+      {/* Темы */}
+      <div>
+        <span className={cn(KIN, "mb-1.5")} aria-hidden="true">Темы</span>
+        <ThemeMultiSelect
+          value={selectedInterests}
+          onChange={interestsField.onChange}
+        />
       </div>
       <FieldError message={errors.interests?.message} />
+
+      {/* Детали */}
+      <button
+        type="button"
+        onClick={() => setDetailsOpen((open) => !open)}
+        aria-expanded={detailsOpen}
+        className="inline-flex items-center gap-1.5 self-start whitespace-nowrap text-[11px] font-semibold text-ink-2"
+      >
+        <ChevronDown
+          className={cn("h-[11px] w-[11px] transition-transform", detailsOpen && "rotate-180")}
+          aria-hidden="true"
+        />
+        Детали
+      </button>
 
       {/* Детали */}
       {detailsOpen && (

--- a/src/features/homepage-classic/components/homepage-request-form.test.tsx
+++ b/src/features/homepage-classic/components/homepage-request-form.test.tsx
@@ -420,7 +420,7 @@ describe("HomepageRequestForm UI affordances", () => {
 });
 
 describe("HomepageRequestFormClassic inset-label layout", () => {
-  it("renders the inset-label brief fields with the mode toggle and topic expansion", () => {
+  it("renders the inset-label brief fields with the mode toggle, themes dropdown and details", () => {
     render(<HomepageRequestFormClassic destinations={[]} />);
 
     // Inset-label fields, addressed by their accessible labels.
@@ -432,19 +432,14 @@ describe("HomepageRequestFormClassic inset-label layout", () => {
       screen.getByRole("button", { name: /сделать (закрытой|открытой)/i }),
     ).toBeInTheDocument();
 
+    // Themes use the same dropdown control as languages — no inline chip grid / «Ещё».
+    expect(screen.getByRole("button", { name: "Выбрать темы" })).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "Ещё" })).toBeNull();
+
     // «Детали» disclosure is collapsed by default; languages appear once opened.
     expect(screen.queryByText("Языки экскурсии")).toBeNull();
     fireEvent.click(screen.getByRole("button", { name: "Детали" }));
     expect(screen.getByText("Языки экскурсии")).toBeInTheDocument();
-
-    // First four themes are shown inline; the rest sit behind «Ещё».
-    expect(screen.getByRole("button", { name: /история и культура/i })).toBeInTheDocument();
-    expect(screen.getByRole("button", { name: /искусство/i })).toBeInTheDocument();
-    expect(screen.queryByRole("button", { name: /религия и духовность/i })).toBeNull();
-
-    fireEvent.click(screen.getByRole("button", { name: "Ещё" }));
-
-    expect(screen.getByRole("button", { name: /религия и духовность/i })).toBeInTheDocument();
   });
 
   it("uses the «Найти гида» submit with no sticky mobile bar", () => {


### PR DESCRIPTION
Follow-up polish on the homepage brief form.

- **Widen** the hero card 440→480px and flex the «Время» inputs so the start–end time range fits naturally (was cramped at `w-[58px]`).
- **Themes → dropdown**: replace the inline interest-chip grid + «Ещё» with a «Темы» multi-select that behaves exactly like the **Languages** field (searchable popover + removable chips). Extracted a shared generic `TagMultiSelect`; `LanguageMultiSelect` is now a thin wrapper (DOM/API unchanged), `ThemeMultiSelect` maps theme slug↔label. Form bindings (interests controller) unchanged.

Verification: tsc 0 · eslint 0 · suite **1065/1065** · build EXIT 0 · browser-verified (themes menu opens like languages, time range fits).