### PR TITLE
feat(homepage): branded hero + curated city plates (Москва/Элиста/Казань/Сочи) + form polish

### DIFF
--- a/src/features/homepage-classic/components/homepage-hero-form-classic.tsx
+++ b/src/features/homepage-classic/components/homepage-hero-form-classic.tsx
@@ -2,21 +2,21 @@ import Image from "next/image";
 import { ArrowDown } from "lucide-react";
 
 import type { DestinationOption } from "@/data/supabase/queries";
-import { cityImage } from "@/lib/city-image";
 
 import { HomepageRequestFormClassic } from "./homepage-request-form-classic";
+
+const HERO_IMAGE =
+  "https://yjzpshutgmhxizosbeef.supabase.co/storage/v1/object/public/listing-media/site/hero-provodnik.png";
 
 interface Props {
   destinations: DestinationOption[];
 }
 
 export function HomepageHeroFormClassic({ destinations }: Props) {
-  const heroImage = cityImage(destinations[0]?.name ?? "Байкал");
-
   return (
     <section className="relative flex min-h-[100svh] flex-col overflow-hidden bg-[#0c1622]">
       <Image
-        src={heroImage}
+        src={HERO_IMAGE}
         alt=""
         fill
         priority
@@ -33,7 +33,7 @@ export function HomepageHeroFormClassic({ destinations }: Props) {
           Куда отправимся?
         </h1>
 
-        <div className="w-full max-w-[480px] rounded-[22px] bg-surface p-5 text-left shadow-[0_30px_64px_-24px_rgba(8,14,24,0.55)]">
+        <div className="w-full max-w-[540px] rounded-[22px] bg-surface p-5 text-left shadow-[0_30px_64px_-24px_rgba(8,14,24,0.55)]">
           <HomepageRequestFormClassic destinations={destinations} />
         </div>
 

--- a/src/features/homepage-classic/components/homepage-request-form-classic.tsx
+++ b/src/features/homepage-classic/components/homepage-request-form-classic.tsx
@@ -85,68 +85,43 @@ export function HomepageRequestFormClassic({ destinations }: Props) {
       </div>
       <FieldError message={errors.destination?.message} />
 
-      {/* Когда + гибкость (full width — native date control needs room) */}
-      <div className={FBX}>
-        <Calendar className="h-[18px] w-[18px] shrink-0 text-muted-foreground" aria-hidden="true" />
-        <div className="min-w-0 flex-1">
-          <span className={KIN} aria-hidden="true">Когда</span>
-          <input
-            className={FIN}
-            type="date"
-            min={todayMoscowISODate()}
-            aria-label="Когда"
-            aria-invalid={Boolean(errors.startDate)}
-            {...register("startDate")}
-          />
-        </div>
-        <button
-          type="button"
-          onClick={() => {
-            const current = form.getValues("dateFlexibility");
-            form.setValue("dateFlexibility", current === "exact" ? "few_days" : "exact", {
-              shouldDirty: true,
-            });
-          }}
-          title="Гибкие даты (±2–3 дня)"
-          aria-label="Переключить гибкие даты"
-          aria-pressed={dateFlexibility !== "exact"}
-          className={cn(
-            "grid h-[30px] w-[30px] shrink-0 cursor-pointer select-none place-items-center rounded-lg border text-sm font-bold leading-none transition",
-            dateFlexibility !== "exact"
-              ? "border-primary bg-primary text-white shadow-[0_0_0_3px_rgba(26,86,164,0.18)] hover:bg-primary/90"
-              : "border-primary/40 bg-primary/10 text-primary hover:bg-primary/20",
-          )}
-        >
-          ≈
-        </button>
-      </div>
-      <FieldError message={errors.startDate?.message} />
-
-      {/* Время (full width — two native time pickers need room) */}
-      <div className={FBX}>
-        <Clock className="h-[18px] w-[18px] shrink-0 text-muted-foreground" aria-hidden="true" />
-        <div className="min-w-0 flex-1">
-          <span className={KIN} aria-hidden="true">Время</span>
-          <span className="flex items-center gap-2">
+      {/* Когда + гибкость · Гостей + замок */}
+      <div className="grid gap-2.5" style={{ gridTemplateColumns: "1fr 163px" }}>
+        <div className={FBX}>
+          <Calendar className="h-[18px] w-[18px] shrink-0 text-muted-foreground" aria-hidden="true" />
+          <div className="min-w-0 flex-1">
+            <span className={KIN} aria-hidden="true">Когда</span>
             <input
-              className={cn(FIN_BASE, "w-[124px]")}
-              type="time"
-              aria-label="Время начала"
-              {...register("startTime")}
+              className={FIN}
+              type="date"
+              min={todayMoscowISODate()}
+              aria-label="Когда"
+              aria-invalid={Boolean(errors.startDate)}
+              {...register("startDate")}
             />
-            <span className="font-bold text-muted-foreground">–</span>
-            <input
-              className={cn(FIN_BASE, "w-[124px]")}
-              type="time"
-              aria-label="Время окончания"
-              {...register("endTime")}
-            />
-          </span>
+          </div>
+          <button
+            type="button"
+            onClick={() => {
+              const current = form.getValues("dateFlexibility");
+              form.setValue("dateFlexibility", current === "exact" ? "few_days" : "exact", {
+                shouldDirty: true,
+              });
+            }}
+            title="Гибкие даты (±2–3 дня)"
+            aria-label="Переключить гибкие даты"
+            aria-pressed={dateFlexibility !== "exact"}
+            className={cn(
+              "grid h-[30px] w-[30px] shrink-0 cursor-pointer select-none place-items-center rounded-lg border text-sm font-bold leading-none transition",
+              dateFlexibility !== "exact"
+                ? "border-primary bg-primary text-white shadow-[0_0_0_3px_rgba(26,86,164,0.18)] hover:bg-primary/90"
+                : "border-primary/40 bg-primary/10 text-primary hover:bg-primary/20",
+            )}
+          >
+            ≈
+          </button>
         </div>
-      </div>
 
-      {/* Гостей + замок · Бюджет (short fields — 2 columns) */}
-      <div className="grid grid-cols-2 gap-2.5">
         <div className={FBX}>
           <Users className="h-[18px] w-[18px] shrink-0 text-muted-foreground" aria-hidden="true" />
           <div className="min-w-0 flex-1">
@@ -190,6 +165,31 @@ export function HomepageRequestFormClassic({ destinations }: Props) {
             )}
           </button>
         </div>
+      </div>
+
+      {/* Время · Бюджет */}
+      <div className="grid gap-2.5" style={{ gridTemplateColumns: "1fr 163px" }}>
+        <div className={FBX}>
+          <Clock className="h-[18px] w-[18px] shrink-0 text-muted-foreground" aria-hidden="true" />
+          <div className="min-w-0 flex-1">
+            <span className={KIN} aria-hidden="true">Время</span>
+            <span className="flex items-center gap-1.5">
+              <input
+                className={cn(FIN_BASE, "min-w-0 flex-1")}
+                type="time"
+                aria-label="Время начала"
+                {...register("startTime")}
+              />
+              <span className="font-bold text-muted-foreground">–</span>
+              <input
+                className={cn(FIN_BASE, "min-w-0 flex-1")}
+                type="time"
+                aria-label="Время окончания"
+                {...register("endTime")}
+              />
+            </span>
+          </div>
+        </div>
 
         <div className={FBX}>
           <Wallet className="h-[18px] w-[18px] shrink-0 text-muted-foreground" aria-hidden="true" />
@@ -205,7 +205,7 @@ export function HomepageRequestFormClassic({ destinations }: Props) {
           </div>
         </div>
       </div>
-      <FieldError message={errors.groupSize?.message ?? errors.budgetPerPersonRub?.message} />
+      <FieldError message={errors.startDate?.message ?? errors.groupSize?.message ?? errors.budgetPerPersonRub?.message} />
 
       {/* Темы */}
       <div>

--- a/src/features/homepage-classic/components/homepage-shell2-classic.tsx
+++ b/src/features/homepage-classic/components/homepage-shell2-classic.tsx
@@ -54,7 +54,7 @@ export function HomePageShell2Classic({ destinations, requests }: Props) {
                   href={`/requests/${req.id}`}
                   city={city}
                   region={req.destinationRegion}
-                  imageUrl={req.imageUrl || cityImage(city)}
+                  imageUrl={cityImage(city)}
                   status={selected ? "selected" : "waiting"}
                   minPeople={`от ${req.capacity ?? req.groupSize} чел.`}
                   date={req.dateLabel}

--- a/src/lib/city-image.test.ts
+++ b/src/lib/city-image.test.ts
@@ -32,16 +32,18 @@ describe("brandGradient", () => {
 });
 
 describe("cityImage", () => {
-  it("returns curated real on-place photography for known cities", () => {
+  it("returns curated real on-place city imagery for known cities", () => {
     const result = cityImage("Элиста");
 
-    // Curated Golden Abode photo — a real, correct local image, not foreign stock.
+    // Curated branded city plate hosted in Supabase Storage — a real, correct
+    // local image, not a gradient and not foreign stock.
     expect(result).not.toMatch(/^data:image\/svg/);
-    expect(result).toContain("images.unsplash.com");
+    expect(result).toContain("/site/cities/elista.png");
+    expect(result).not.toContain("unsplash.com");
   });
 
   it("falls back to an on-canon SVG gradient for cities without curated imagery", () => {
-    const result = cityImage("Казань");
+    const result = cityImage("Дербент");
 
     expect(result).toMatch(/^data:image\/svg\+xml,/);
     expect(result).not.toContain("unsplash.com");
@@ -56,7 +58,7 @@ describe("cityImage", () => {
   });
 
   it("varies the gradient across different destinations", () => {
-    expect(cityImage("Элиста")).not.toBe(cityImage("Казань"));
+    expect(cityImage("Дербент")).not.toBe(cityImage("Мурманск"));
   });
 
   it("stays on the canon navy/amber palette (no off-palette colors)", () => {

--- a/src/lib/city-image.ts
+++ b/src/lib/city-image.ts
@@ -52,10 +52,16 @@ export function brandGradient(seed = "provodnik"): string {
  * verified-correct local imagery goes here. Keys are normalized (lowercase, ru-RU)
  * and matched by substring, so "Элиста" and "Элиста, Калмыкия" both resolve.
  */
+const SUPABASE_CITY_BASE =
+  "https://yjzpshutgmhxizosbeef.supabase.co/storage/v1/object/public/listing-media/site/cities";
+
 const CURATED_CITY_IMAGES: Record<string, string> = {
-  // Элиста — Золотая обитель Будды Шакьямуни (Golden Abode), the city's landmark.
-  "элиста":
-    "https://images.unsplash.com/photo-1657293493705-557ab000afe1?auto=format&fit=crop&w=1600&h=900&q=80",
+  // Branded architectural-typography city plates (the city name built from its
+  // own landmarks), hosted in Supabase Storage (listing-media/site/cities).
+  "москва": `${SUPABASE_CITY_BASE}/moscow.png`,
+  "элиста": `${SUPABASE_CITY_BASE}/elista.png`,
+  "казань": `${SUPABASE_CITY_BASE}/kazan.png`,
+  "сочи": `${SUPABASE_CITY_BASE}/sochi.png`,
 };
 
 function normalizeCity(s: string): string {


### PR DESCRIPTION
## What
- **Hero**: branded mountain-lake hero image (uploaded to Supabase `listing-media/site`).
- **City images**: `cityImage()` now serves curated architectural-typography plates for **Москва / Элиста / Казань / Сочи** (Supabase `listing-media/site/cities`); all other cities keep the on-canon gradient. This flows to homepage **destination tiles**, the **/requests marketplace** cards, and **request-detail** heroes.
- **Open Groups cards**: switched to `cityImage(city)` (previously shadowed by the gradient fallback in `req.imageUrl`) so they show the curated city photos — consistent with the marketplace.
- **Brief form polish**: 3 rows; Гостей + Бюджет equal fixed width (163px) with «Бюджет ₽/чел» on one line; Когда/Время wider; card 540px.

## Verification
- `tsc` 0 · `eslint` 0 · full suite **1065/1065** · `build` EXIT 0
- Dev-verified: hero + all four city plates render in Open Groups and Destinations.