### PR TITLE
feat(homepage): minimalist icon-only form + restore Open-Group card detail

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -257,3 +257,18 @@
   mix-blend-mode: overlay;
   background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='120' height='120'%3E%3Cfilter id='n'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.85' numOctaves='2' stitchTiles='stitch'/%3E%3C/filter%3E%3Crect width='100%25' height='100%25' filter='url(%23n)'/%3E%3C/svg%3E");
 }
+
+/* Hide the browser's native date/time picker indicator (the black calendar /
+   clock glyph) on form fields that already render a custom leading icon. The
+   field stays fully functional — the picker opens via showPicker() on click. */
+.native-picker-hidden::-webkit-calendar-picker-indicator {
+  display: none;
+  -webkit-appearance: none;
+  appearance: none;
+}
+.native-picker-hidden::-webkit-inner-spin-button,
+.native-picker-hidden::-webkit-clear-button {
+  display: none;
+  -webkit-appearance: none;
+  appearance: none;
+}

--- a/src/components/shared/language-multi-select.test.tsx
+++ b/src/components/shared/language-multi-select.test.tsx
@@ -24,7 +24,7 @@ describe("LanguageMultiSelect", () => {
     expect(screen.getByText("Любой язык")).toBeInTheDocument();
   });
 
-  it("renders selected languages as chips", () => {
+  it("renders selected languages compactly with a +N overflow", () => {
     render(
       <LanguageMultiSelect
         options={LANGUAGES}
@@ -33,8 +33,8 @@ describe("LanguageMultiSelect", () => {
       />,
     );
 
-    expect(screen.getByText("Русский")).toBeInTheDocument();
-    expect(screen.getByText("Хинди")).toBeInTheDocument();
+    // Fixed single line: the first selection shows as a chip; the rest collapse into "+N".
+    expect(screen.getByText("+1")).toBeInTheDocument();
   });
 
   it("toggles an option without dropping the prior selection", () => {
@@ -89,37 +89,38 @@ describe("LanguageMultiSelect", () => {
     expect(onChange).toHaveBeenCalledWith([]);
   });
 
-  it("removes a chip without opening the dropdown", () => {
+  it("removes a selected language by unchecking it in the dropdown", () => {
     const onChange = vi.fn();
     render(
       <LanguageMultiSelect
         options={LANGUAGES}
-        value={["Русский"]}
+        value={["Русский", "Хинди"]}
         onChange={onChange}
       />,
     );
 
-    fireEvent.click(screen.getByLabelText("Убрать Русский"));
+    fireEvent.click(
+      screen.getByRole("button", { name: "Выбрать языки экскурсии" }),
+    );
+    // "Хинди" is in the "+1" overflow (not a visible chip), so this targets the menu item.
+    fireEvent.click(screen.getByText("Хинди"));
 
-    expect(onChange).toHaveBeenCalledWith([]);
-    expect(screen.queryByPlaceholderText("Поиск языка…")).not.toBeInTheDocument();
+    expect(onChange).toHaveBeenCalledWith(["Русский"]);
   });
 
-  it("exposes selected language removal as a keyboard-operable button", () => {
-    const onChange = vi.fn();
+  it("opens the dropdown from a keyboard-operable trigger button", () => {
     render(
       <LanguageMultiSelect
         options={LANGUAGES}
         value={["Русский"]}
-        onChange={onChange}
+        onChange={vi.fn()}
       />,
     );
 
-    const removeButton = screen.getByRole("button", { name: "Убрать Русский" });
-    removeButton.focus();
-    fireEvent.click(removeButton);
+    const trigger = screen.getByRole("button", { name: "Выбрать языки экскурсии" });
+    expect(trigger.tagName).toBe("BUTTON");
+    fireEvent.click(trigger);
 
-    expect(removeButton.tagName).toBe("BUTTON");
-    expect(onChange).toHaveBeenCalledWith([]);
+    expect(screen.getByPlaceholderText("Поиск языка…")).toBeInTheDocument();
   });
 });

--- a/src/components/shared/language-multi-select.tsx
+++ b/src/components/shared/language-multi-select.tsx
@@ -1,14 +1,15 @@
 "use client";
 
-import type { JSX } from "react";
+import type { JSX, ReactNode } from "react";
 
-import { TagMultiSelect } from "./tag-multi-select";
+import { TagMultiSelect, type TagOption } from "./tag-multi-select";
 
 type LanguageMultiSelectProps = {
   value: string[];
   onChange: (next: string[]) => void;
   options: readonly string[];
   placeholder?: string;
+  leading?: ReactNode;
 };
 
 export function LanguageMultiSelect({
@@ -16,16 +17,20 @@ export function LanguageMultiSelect({
   onChange,
   options,
   placeholder = "Любой язык",
+  leading,
 }: LanguageMultiSelectProps): JSX.Element {
+  const opts: TagOption[] = options.map((l) => ({ value: l, label: l }));
   return (
     <TagMultiSelect
       value={value}
       onChange={onChange}
-      options={options}
+      options={opts}
       placeholder={placeholder}
       ariaLabel="Выбрать языки экскурсии"
       searchPlaceholder="Поиск языка…"
       emptyLabel="Ничего не найдено"
+      leading={leading}
+      maxVisibleChips={1}
     />
   );
 }

--- a/src/components/shared/open-group-card.tsx
+++ b/src/components/shared/open-group-card.tsx
@@ -1,17 +1,20 @@
 import Image from "next/image";
 import Link from "next/link";
-import {
-  Calendar,
-  CheckCircle2,
-  Clock,
-  MapPin,
-  Star,
-  Users,
-} from "lucide-react";
+import { Calendar, CheckCircle2, Clock, MapPin, Users } from "lucide-react";
 
+import { AvatarStack, type AvatarStackMember } from "@/components/shared/avatar-stack";
 import { THEMES, type ThemeSlug } from "@/data/themes";
 
 const THEME_BY_SLUG = new Map(THEMES.map((t) => [t.slug, t] as const));
+
+function pluralOffers(n: number): string {
+  const mod10 = n % 10;
+  const mod100 = n % 100;
+  if (mod100 >= 11 && mod100 <= 14) return `${n} откликов`;
+  if (mod10 === 1) return `${n} отклик`;
+  if (mod10 >= 2 && mod10 <= 4) return `${n} отклика`;
+  return `${n} откликов`;
+}
 
 export interface OpenGroupCardProps {
   href: string;
@@ -20,6 +23,8 @@ export interface OpenGroupCardProps {
   imageUrl: string;
   /** "selected" = a guide is chosen (booked); "waiting" = still open. */
   status: "selected" | "waiting";
+  /** open offers count — drives the "N откликов" badge when waiting. */
+  offerCount?: number;
   /** e.g. "от 6 чел." */
   minPeople?: string;
   date?: string;
@@ -28,14 +33,16 @@ export interface OpenGroupCardProps {
   time?: string;
   /** theme slugs — resolved to icon + label */
   interests?: string[];
-  avatarUrl?: string | null;
-  avatarInitials?: string;
-  /** shown next to the avatar when present (e.g. a chosen guide's name) */
-  personName?: string;
-  /** shown after the name when present */
-  personRating?: number | string;
-  /** shown instead of a name (e.g. "4 отклика") */
-  footerText?: string;
+  /** traveller avatars (overlap stack + "+N") */
+  members?: readonly AvatarStackMember[];
+  /** total participant count (for the "+N" overflow) */
+  participantCount?: number;
+  /** e.g. "Опубликован: 30 июня" */
+  publishedAt?: string;
+  /** group total budget, e.g. "~19 200 ₽ за группу" */
+  groupPrice?: string;
+  /** unread offers → left accent border */
+  unread?: boolean;
   joinHref?: string;
   joinLabel?: string;
   priority?: boolean;
@@ -43,10 +50,10 @@ export interface OpenGroupCardProps {
 
 /**
  * Open-group card (homepage "Открытые группы" + /requests marketplace).
- * Photo + region pill, city title with a status badge (Гид выбран / Ждёт гида),
- * Сборная-группа pill, date/flex/time, interest tags, an organizer/guide row,
- * and a "Присоединиться" CTA. Intentionally has NO per-person price and NO
- * seats progress bar (mockup spec).
+ * Photo + region pill, status badge (Гид выбран / N откликов / Ждёт гида),
+ * Сборная-группа pill, date/flex/time, interest tags, traveller avatar stack +
+ * publish date, the group total budget, and a "Присоединиться" CTA. No
+ * per-person price (intentionally).
  */
 export function OpenGroupCard({
   href,
@@ -54,16 +61,17 @@ export function OpenGroupCard({
   region,
   imageUrl,
   status,
+  offerCount = 0,
   minPeople,
   date,
   datesFlexible,
   time,
   interests,
-  avatarUrl,
-  avatarInitials = "П",
-  personName,
-  personRating,
-  footerText,
+  members,
+  participantCount,
+  publishedAt,
+  groupPrice,
+  unread,
   joinHref,
   joinLabel = "Присоединиться",
   priority,
@@ -72,9 +80,14 @@ export function OpenGroupCard({
     .map((slug) => THEME_BY_SLUG.get(slug as ThemeSlug))
     .filter((t): t is (typeof THEMES)[number] => Boolean(t))
     .slice(0, 3);
+  const memberList = members ?? [];
 
   return (
-    <div className="flex flex-col overflow-hidden rounded-2xl border border-border bg-card shadow-sm">
+    <div
+      className={`flex flex-col overflow-hidden rounded-2xl border border-border bg-card shadow-sm${
+        unread ? " border-l-4 border-l-primary" : ""
+      }`}
+    >
       <div className="relative h-[148px] bg-surface-low">
         <Image
           src={imageUrl}
@@ -102,9 +115,13 @@ export function OpenGroupCard({
             {city}
           </div>
           {status === "selected" ? (
-            <span className="inline-flex shrink-0 items-center gap-1 whitespace-nowrap text-xs font-bold text-[#2F8F66]">
+            <span className="inline-flex h-6 shrink-0 items-center gap-1 whitespace-nowrap text-xs font-bold text-[#2F8F66]">
               <CheckCircle2 className="h-[14px] w-[14px]" aria-hidden="true" />
               Гид выбран
+            </span>
+          ) : offerCount > 0 ? (
+            <span className="inline-flex h-6 shrink-0 items-center whitespace-nowrap rounded-full bg-primary/10 px-2.5 text-[11.5px] font-bold text-primary">
+              {pluralOffers(offerCount)}
             </span>
           ) : (
             <span className="inline-flex h-6 shrink-0 items-center gap-1.5 whitespace-nowrap rounded-full bg-[rgba(212,135,43,0.14)] px-2.5 text-[11.5px] font-bold text-[#9A5712]">
@@ -162,34 +179,21 @@ export function OpenGroupCard({
         ) : null}
 
         <div className="mt-auto flex items-end justify-between gap-2.5 pt-3.5">
-          <div className="flex items-center gap-2">
-            {avatarUrl ? (
-              <Image
-                src={avatarUrl}
-                alt={personName ?? "Организатор"}
-                width={30}
-                height={30}
-                className="h-[30px] w-[30px] rounded-full object-cover"
-              />
+          <div className="flex min-w-0 flex-col gap-1">
+            {memberList.length > 0 ? (
+              <AvatarStack members={memberList} size={26} overlap={9} totalCount={participantCount} />
             ) : (
               <span className="grid h-[30px] w-[30px] place-items-center rounded-full border border-border bg-surface-low text-xs font-bold text-muted-foreground">
-                {avatarInitials}
+                П
               </span>
             )}
-            {personName ? (
-              <div className="leading-tight">
-                <div className="text-[12.5px] font-bold text-foreground">{personName}</div>
-                {personRating != null ? (
-                  <div className="flex items-center gap-1 text-[11.5px] font-semibold text-muted-foreground">
-                    <Star className="h-3 w-3 fill-[#D4872B] text-[#D4872B]" aria-hidden="true" />
-                    {personRating}
-                  </div>
-                ) : null}
-              </div>
-            ) : footerText ? (
-              <span className="text-xs font-semibold text-muted-foreground">{footerText}</span>
+            {publishedAt ? (
+              <span className="truncate text-[11px] font-medium text-muted-foreground">{publishedAt}</span>
             ) : null}
           </div>
+          {groupPrice ? (
+            <span className="shrink-0 whitespace-nowrap text-xs font-semibold text-ink-2">{groupPrice}</span>
+          ) : null}
         </div>
 
         <Link

--- a/src/components/shared/tag-multi-select.tsx
+++ b/src/components/shared/tag-multi-select.tsx
@@ -1,7 +1,7 @@
 "use client";
 
-import { useState, type JSX } from "react";
-import { Check, ChevronsUpDown, X } from "lucide-react";
+import { useState, type JSX, type ReactNode } from "react";
+import { ChevronsUpDown } from "lucide-react";
 
 import {
   Command,
@@ -18,20 +18,32 @@ import {
 } from "@/components/ui/popover";
 import { cn } from "@/lib/utils";
 
+export type TagOption = {
+  value: string;
+  label: string;
+  /** Optional compact icon shown inside the selected chip. */
+  icon?: ReactNode;
+};
+
 type TagMultiSelectProps = {
   value: string[];
   onChange: (next: string[]) => void;
-  options: readonly string[];
+  options: readonly TagOption[];
   placeholder?: string;
   ariaLabel?: string;
   searchPlaceholder?: string;
   emptyLabel?: string;
+  /** Leading field icon (already wrapped with a tooltip by the caller). */
+  leading?: ReactNode;
+  /** How many chips to show before collapsing the rest into "+N". */
+  maxVisibleChips?: number;
 };
 
 /**
- * Generic searchable multi-select. Shows selected values as removable chips and
- * opens a searchable popover menu for the rest. Domain-specific wrappers
- * (LanguageMultiSelect, ThemeMultiSelect) set the labels.
+ * Generic searchable multi-select with a FIXED single-line trigger: selected
+ * items render as compact chips, and anything beyond `maxVisibleChips`
+ * collapses into a "+N" pill (so the control never grows or jumps). The popover
+ * menu shows a single right-aligned tick per item (from CommandItem).
  */
 export function TagMultiSelect({
   value,
@@ -41,6 +53,8 @@ export function TagMultiSelect({
   ariaLabel = "Выбрать значения",
   searchPlaceholder = "Поиск…",
   emptyLabel = "Ничего не найдено",
+  leading,
+  maxVisibleChips = 2,
 }: TagMultiSelectProps): JSX.Element {
   const [open, setOpen] = useState(false);
 
@@ -52,63 +66,52 @@ export function TagMultiSelect({
     );
   };
 
+  const selected = options.filter((o) => value.includes(o.value));
+  const visible = selected.slice(0, maxVisibleChips);
+  const overflow = selected.length - visible.length;
+
   return (
     <Popover open={open} onOpenChange={setOpen}>
-      <div className="flex min-h-11 w-full flex-wrap items-center gap-1.5 rounded-lg border border-border bg-background px-3 py-2 text-left text-sm transition-colors hover:bg-muted/40 focus-within:border-ring focus-within:ring-3 focus-within:ring-ring/50">
-        {value.length === 0 ? (
-          <PopoverTrigger asChild>
-            <button
-              type="button"
-              aria-label={ariaLabel}
-              className="flex min-h-6 flex-1 cursor-pointer items-center justify-between gap-2 text-left focus-visible:outline-none"
-            >
-              <span className="text-muted-foreground">{placeholder}</span>
-              <ChevronsUpDown
-                aria-hidden="true"
-                className={cn(
-                  "size-4 shrink-0 text-muted-foreground transition-transform",
-                  open && "rotate-180",
-                )}
-              />
-            </button>
-          </PopoverTrigger>
-        ) : (
-          <>
-            {value.map((item) => (
-              <span
-                key={item}
-                className="flex items-center gap-1 rounded-full bg-primary/10 py-0.5 pl-2 pr-1 text-xs text-primary"
-              >
-                {item}
-                <button
-                  type="button"
-                  aria-label={`Убрать ${item}`}
-                  className="inline-flex min-h-6 min-w-6 items-center justify-center rounded-full text-primary transition-colors hover:bg-primary/10 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/50"
-                  onClick={(event) => {
-                    event.preventDefault();
-                    event.stopPropagation();
-                    toggle(item);
-                  }}
-                >
-                  <X aria-hidden="true" className="size-3" />
-                </button>
+      <PopoverTrigger asChild>
+        <button
+          type="button"
+          aria-label={ariaLabel}
+          className="flex h-[46px] w-full items-center gap-[11px] overflow-hidden rounded-[13px] border border-border bg-surface px-[13px] text-left transition-[border-color,box-shadow] focus:border-primary focus:shadow-[0_0_0_3px_rgba(26,86,164,0.12)] focus:outline-none"
+        >
+          {leading}
+          <span className="flex min-w-0 flex-1 items-center gap-1.5 overflow-hidden">
+            {selected.length === 0 ? (
+              <span className="truncate text-[15px] font-semibold text-[#C2C9D3]">
+                {placeholder}
               </span>
-            ))}
-            <PopoverTrigger asChild>
-              <button
-                type="button"
-                aria-label={ariaLabel}
-                className="ml-auto flex min-h-6 min-w-6 flex-1 cursor-pointer items-center justify-end rounded-full text-muted-foreground transition-colors hover:bg-muted focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/50"
-              >
-                <ChevronsUpDown
-                  aria-hidden="true"
-                  className={cn("size-4 transition-transform", open && "rotate-180")}
-                />
-              </button>
-            </PopoverTrigger>
-          </>
-        )}
-      </div>
+            ) : (
+              <>
+                {visible.map((o) => (
+                  <span
+                    key={o.value}
+                    className="inline-flex h-6 max-w-[110px] shrink-0 items-center gap-1 rounded-full bg-primary/10 px-2 text-[11px] font-semibold text-primary"
+                  >
+                    {o.icon}
+                    <span className="truncate">{o.label}</span>
+                  </span>
+                ))}
+                {overflow > 0 ? (
+                  <span className="inline-flex h-6 shrink-0 items-center rounded-full bg-primary/10 px-2 text-[11px] font-bold text-primary">
+                    +{overflow}
+                  </span>
+                ) : null}
+              </>
+            )}
+          </span>
+          <ChevronsUpDown
+            aria-hidden="true"
+            className={cn(
+              "size-4 shrink-0 text-muted-foreground transition-transform",
+              open && "rotate-180",
+            )}
+          />
+        </button>
+      </PopoverTrigger>
       <PopoverContent
         align="start"
         className="min-w-64 w-[var(--radix-popover-trigger-width)] p-0"
@@ -124,27 +127,17 @@ export function TagMultiSelect({
           <CommandList>
             <CommandEmpty>{emptyLabel}</CommandEmpty>
             <CommandGroup>
-              {options.map((item) => {
-                const selected = value.includes(item);
-
-                return (
-                  <CommandItem
-                    key={item}
-                    value={item}
-                    data-checked={selected}
-                    onSelect={() => toggle(item)}
-                  >
-                    <Check
-                      aria-hidden="true"
-                      className={cn(
-                        "mr-2 size-4",
-                        selected ? "opacity-100" : "opacity-0",
-                      )}
-                    />
-                    {item}
-                  </CommandItem>
-                );
-              })}
+              {options.map((o) => (
+                <CommandItem
+                  key={o.value}
+                  value={o.label}
+                  data-checked={value.includes(o.value)}
+                  onSelect={() => toggle(o.value)}
+                >
+                  {o.icon}
+                  {o.label}
+                </CommandItem>
+              ))}
             </CommandGroup>
           </CommandList>
           <div className="flex items-center justify-between border-t border-border px-3 py-2 text-xs text-muted-foreground">

--- a/src/components/shared/theme-multi-select.tsx
+++ b/src/components/shared/theme-multi-select.tsx
@@ -1,51 +1,44 @@
 "use client";
 
-import type { JSX } from "react";
+import type { JSX, ReactNode } from "react";
 
 import { THEMES } from "@/data/themes";
 
-import { TagMultiSelect } from "./tag-multi-select";
+import { TagMultiSelect, type TagOption } from "./tag-multi-select";
 
-const LABEL_BY_SLUG = new Map<string, string>(THEMES.map((t) => [t.slug, t.label]));
-const SLUG_BY_LABEL = new Map<string, string>(THEMES.map((t) => [t.label, t.slug]));
-const OPTIONS: string[] = THEMES.map((t) => t.label);
+const OPTIONS: TagOption[] = THEMES.map((t) => {
+  const Icon = t.Icon;
+  return {
+    value: t.slug,
+    label: t.label,
+    icon: <Icon className="h-3 w-3 shrink-0" aria-hidden="true" />,
+  };
+});
 
 type ThemeMultiSelectProps = {
   /** selected theme slugs */
   value: string[];
   onChange: (next: string[]) => void;
-  placeholder?: string;
+  leading?: ReactNode;
 };
 
-/**
- * Theme/interest multi-select, behaving exactly like the language selector
- * (searchable popover + removable chips). Works in slug-space externally but
- * displays human labels.
- */
+/** Theme/interest multi-select — fixed single line, compact chips + "+N". */
 export function ThemeMultiSelect({
   value,
   onChange,
-  placeholder = "Любая тема",
+  leading,
 }: ThemeMultiSelectProps): JSX.Element {
-  const labels = value
-    .map((slug) => LABEL_BY_SLUG.get(slug))
-    .filter((label): label is string => Boolean(label));
-
   return (
     <TagMultiSelect
-      value={labels}
+      value={value}
+      onChange={onChange}
       options={OPTIONS}
-      placeholder={placeholder}
+      placeholder="Темы"
       ariaLabel="Выбрать темы"
       searchPlaceholder="Поиск темы…"
       emptyLabel="Тема не найдена"
-      onChange={(nextLabels) =>
-        onChange(
-          nextLabels
-            .map((label) => SLUG_BY_LABEL.get(label))
-            .filter((slug): slug is string => Boolean(slug)),
-        )
-      }
+      leading={leading}
+      maxVisibleChips={1}
     />
   );
 }

--- a/src/features/homepage-classic/components/homepage-request-form-classic.tsx
+++ b/src/features/homepage-classic/components/homepage-request-form-classic.tsx
@@ -5,18 +5,27 @@ import {
   Calendar,
   ChevronDown,
   Clock,
+  Languages,
   Lock,
   LockOpen,
   MapPin,
   Send,
+  Tag,
   Users,
   Wallet,
 } from "lucide-react";
+import type { LucideIcon } from "lucide-react";
 
 import { LANGUAGES } from "@/data/languages";
 import { LanguageMultiSelect } from "@/components/shared/language-multi-select";
 import { ThemeMultiSelect } from "@/components/shared/theme-multi-select";
 import { Textarea } from "@/components/ui/textarea";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
 import { cn } from "@/lib/utils";
 import { todayMoscowISODate } from "@/lib/dates";
 import type { DestinationOption } from "@/data/supabase/queries";
@@ -28,12 +37,36 @@ interface Props {
 }
 
 const FBX =
-  "flex items-center gap-[11px] rounded-[13px] border border-border bg-surface px-[13px] py-[9px] transition-[border-color,box-shadow] focus-within:border-primary focus-within:shadow-[0_0_0_3px_rgba(26,86,164,0.12)]";
-const KIN =
-  "mb-[3px] block text-[9.5px] font-bold uppercase leading-none tracking-[0.07em] text-muted-foreground";
+  "flex items-center gap-[11px] rounded-[13px] border border-border bg-surface px-[13px] py-[11px] transition-[border-color,box-shadow] focus-within:border-primary focus-within:shadow-[0_0_0_3px_rgba(26,86,164,0.12)]";
 const FIN_BASE =
   "border-0 bg-transparent p-0 text-[15.5px] font-bold leading-tight text-foreground outline-none placeholder:font-semibold placeholder:text-[#C2C9D3]";
 const FIN = cn(FIN_BASE, "w-full");
+
+/** Field icon + hover tooltip (labels are otherwise hidden for a clean look). */
+function FieldIcon({
+  icon: Icon,
+  label,
+  className,
+}: {
+  icon: LucideIcon;
+  label: string;
+  className?: string;
+}) {
+  return (
+    <Tooltip>
+      <TooltipTrigger asChild>
+        <span className="flex shrink-0 cursor-default items-center" aria-hidden="true">
+          <Icon className={cn("h-[18px] w-[18px] text-muted-foreground", className)} />
+        </span>
+      </TooltipTrigger>
+      <TooltipContent className="text-xs">{label}</TooltipContent>
+    </Tooltip>
+  );
+}
+
+function openPicker(e: React.MouseEvent<HTMLInputElement>) {
+  e.currentTarget.showPicker?.();
+}
 
 export function HomepageRequestFormClassic({ destinations }: Props) {
   const [detailsOpen, setDetailsOpen] = React.useState(false);
@@ -56,228 +89,224 @@ export function HomepageRequestFormClassic({ destinations }: Props) {
   } = useRequestForm();
 
   return (
-    <form
-      className="flex flex-col gap-2.5"
-      onSubmit={handleSubmit(submit)}
-      aria-label="Создать запрос"
-      noValidate
-    >
-      {/* Направление */}
-      <div className={cn(FBX, "px-[15px] py-[11px]")}>
-        <MapPin className="h-[21px] w-[21px] shrink-0 text-primary" aria-hidden="true" />
-        <div className="min-w-0 flex-1">
-          <span className={KIN} aria-hidden="true">Направление</span>
-          <input
-            className={cn(FIN, "text-[18px]")}
-            list="destination-options"
-            placeholder="Куда едете?"
-            autoComplete="off"
-            aria-label="Направление"
-            aria-invalid={Boolean(errors.destination)}
-            {...register("destination")}
+    <TooltipProvider delayDuration={150}>
+      <form
+        className="flex flex-col gap-2.5"
+        onSubmit={handleSubmit(submit)}
+        aria-label="Создать запрос"
+        noValidate
+      >
+        {/* Направление */}
+        <div className={cn(FBX, "px-[15px]")}>
+          <FieldIcon icon={MapPin} label="Направление" className="h-[21px] w-[21px] text-primary" />
+          <div className="min-w-0 flex-1">
+            <input
+              className={cn(FIN, "text-[18px]")}
+              list="destination-options"
+              placeholder="Куда едете?"
+              autoComplete="off"
+              aria-label="Направление"
+              aria-invalid={Boolean(errors.destination)}
+              {...register("destination")}
+            />
+            <datalist id="destination-options">
+              {destinations.map((d) => (
+                <option key={d.name} value={d.name} />
+              ))}
+            </datalist>
+          </div>
+        </div>
+        <FieldError message={errors.destination?.message} />
+
+        {/* Когда · Гостей */}
+        <div className="grid gap-2.5" style={{ gridTemplateColumns: "1fr 163px" }}>
+          <div className={FBX}>
+            <FieldIcon icon={Calendar} label="Когда" />
+            <div className="min-w-0 flex-1">
+              <input
+                className={cn(FIN, "native-picker-hidden")}
+                type="date"
+                min={todayMoscowISODate()}
+                aria-label="Когда"
+                aria-invalid={Boolean(errors.startDate)}
+                onClick={openPicker}
+                {...register("startDate")}
+              />
+            </div>
+            <button
+              type="button"
+              onClick={() => {
+                const current = form.getValues("dateFlexibility");
+                form.setValue("dateFlexibility", current === "exact" ? "few_days" : "exact", {
+                  shouldDirty: true,
+                });
+              }}
+              title="Гибкие даты (±2–3 дня)"
+              aria-label="Переключить гибкие даты"
+              aria-pressed={dateFlexibility !== "exact"}
+              className={cn(
+                "grid h-[30px] w-[30px] shrink-0 cursor-pointer select-none place-items-center rounded-lg border text-sm font-bold leading-none transition",
+                dateFlexibility !== "exact"
+                  ? "border-primary bg-primary text-white shadow-[0_0_0_3px_rgba(26,86,164,0.18)] hover:bg-primary/90"
+                  : "border-primary/40 bg-primary/10 text-primary hover:bg-primary/20",
+              )}
+            >
+              ≈
+            </button>
+          </div>
+
+          <div className={FBX}>
+            <FieldIcon icon={Users} label="Гостей" />
+            <div className="min-w-0 flex-1">
+              <input
+                className={FIN}
+                inputMode="numeric"
+                placeholder="2"
+                aria-label="Гостей"
+                aria-invalid={Boolean(errors.groupSize)}
+                {...register("groupSize", { valueAsNumber: true })}
+              />
+            </div>
+            <button
+              type="button"
+              onClick={() => {
+                const current = form.getValues("mode");
+                form.setValue("mode", current === "assembly" ? "private" : "assembly", {
+                  shouldValidate: false,
+                  shouldDirty: true,
+                });
+              }}
+              title={isAssembly ? "Открытая группа (сборная)" : "Закрытая группа (своя)"}
+              aria-label={
+                isAssembly
+                  ? "Открытая группа — нажмите, чтобы сделать закрытой"
+                  : "Закрытая группа — нажмите, чтобы сделать открытой"
+              }
+              aria-pressed={!isAssembly}
+              className={cn(
+                "grid h-[30px] w-[30px] shrink-0 cursor-pointer select-none place-items-center rounded-lg border transition",
+                !isAssembly
+                  ? "border-primary bg-primary text-white shadow-[0_0_0_3px_rgba(26,86,164,0.18)] hover:bg-primary/90"
+                  : "border-primary/40 bg-primary/10 text-primary hover:bg-primary/20",
+              )}
+            >
+              {isAssembly ? (
+                <LockOpen className="h-[14px] w-[14px]" aria-hidden="true" />
+              ) : (
+                <Lock className="h-[14px] w-[14px]" aria-hidden="true" />
+              )}
+            </button>
+          </div>
+        </div>
+
+        {/* Время · Бюджет */}
+        <div className="grid gap-2.5" style={{ gridTemplateColumns: "1fr 163px" }}>
+          <div className={FBX}>
+            <FieldIcon icon={Clock} label="Время" />
+            <div className="min-w-0 flex-1">
+              <span className="flex items-center gap-1.5">
+                <input
+                  className={cn(FIN_BASE, "native-picker-hidden min-w-0 flex-1")}
+                  type="time"
+                  aria-label="Время начала"
+                  onClick={openPicker}
+                  {...register("startTime")}
+                />
+                <span className="font-bold text-muted-foreground">–</span>
+                <input
+                  className={cn(FIN_BASE, "native-picker-hidden min-w-0 flex-1")}
+                  type="time"
+                  aria-label="Время окончания"
+                  onClick={openPicker}
+                  {...register("endTime")}
+                />
+              </span>
+            </div>
+          </div>
+
+          <div className={FBX}>
+            <FieldIcon icon={Wallet} label="Бюджет ₽/чел" />
+            <div className="min-w-0 flex-1">
+              <input
+                className={FIN}
+                inputMode="numeric"
+                aria-label="Бюджет на человека"
+                aria-invalid={Boolean(errors.budgetPerPersonRub)}
+                {...register("budgetPerPersonRub", { valueAsNumber: true })}
+              />
+            </div>
+          </div>
+        </div>
+        <FieldError
+          message={
+            errors.startDate?.message ?? errors.groupSize?.message ?? errors.budgetPerPersonRub?.message
+          }
+        />
+
+        {/* Темы · Языки */}
+        <div className="grid grid-cols-2 gap-2.5">
+          <ThemeMultiSelect
+            value={selectedInterests}
+            onChange={interestsField.onChange}
+            leading={<FieldIcon icon={Tag} label="Темы" />}
           />
-          <datalist id="destination-options">
-            {destinations.map((d) => (
-              <option key={d.name} value={d.name} />
-            ))}
-          </datalist>
+          <LanguageMultiSelect
+            options={LANGUAGES}
+            value={requestedLanguagesField.value ?? []}
+            onChange={requestedLanguagesField.onChange}
+            placeholder="Языки"
+            leading={<FieldIcon icon={Languages} label="Языки экскурсии" />}
+          />
         </div>
-      </div>
-      <FieldError message={errors.destination?.message} />
+        <FieldError message={errors.interests?.message} />
 
-      {/* Когда + гибкость · Гостей + замок */}
-      <div className="grid gap-2.5" style={{ gridTemplateColumns: "1fr 163px" }}>
-        <div className={FBX}>
-          <Calendar className="h-[18px] w-[18px] shrink-0 text-muted-foreground" aria-hidden="true" />
-          <div className="min-w-0 flex-1">
-            <span className={KIN} aria-hidden="true">Когда</span>
-            <input
-              className={FIN}
-              type="date"
-              min={todayMoscowISODate()}
-              aria-label="Когда"
-              aria-invalid={Boolean(errors.startDate)}
-              {...register("startDate")}
-            />
-          </div>
-          <button
-            type="button"
-            onClick={() => {
-              const current = form.getValues("dateFlexibility");
-              form.setValue("dateFlexibility", current === "exact" ? "few_days" : "exact", {
-                shouldDirty: true,
-              });
-            }}
-            title="Гибкие даты (±2–3 дня)"
-            aria-label="Переключить гибкие даты"
-            aria-pressed={dateFlexibility !== "exact"}
-            className={cn(
-              "grid h-[30px] w-[30px] shrink-0 cursor-pointer select-none place-items-center rounded-lg border text-sm font-bold leading-none transition",
-              dateFlexibility !== "exact"
-                ? "border-primary bg-primary text-white shadow-[0_0_0_3px_rgba(26,86,164,0.18)] hover:bg-primary/90"
-                : "border-primary/40 bg-primary/10 text-primary hover:bg-primary/20",
-            )}
-          >
-            ≈
-          </button>
-        </div>
-
-        <div className={FBX}>
-          <Users className="h-[18px] w-[18px] shrink-0 text-muted-foreground" aria-hidden="true" />
-          <div className="min-w-0 flex-1">
-            <span className={KIN} aria-hidden="true">Гостей</span>
-            <input
-              className={FIN}
-              inputMode="numeric"
-              placeholder="2"
-              aria-label="Гостей"
-              aria-invalid={Boolean(errors.groupSize)}
-              {...register("groupSize", { valueAsNumber: true })}
-            />
-          </div>
-          <button
-            type="button"
-            onClick={() => {
-              const current = form.getValues("mode");
-              form.setValue("mode", current === "assembly" ? "private" : "assembly", {
-                shouldValidate: false,
-                shouldDirty: true,
-              });
-            }}
-            title={isAssembly ? "Открытая группа (сборная)" : "Закрытая группа (своя)"}
-            aria-label={
-              isAssembly
-                ? "Открытая группа — нажмите, чтобы сделать закрытой"
-                : "Закрытая группа — нажмите, чтобы сделать открытой"
-            }
-            aria-pressed={!isAssembly}
-            className={cn(
-              "grid h-[30px] w-[30px] shrink-0 cursor-pointer select-none place-items-center rounded-lg border transition",
-              !isAssembly
-                ? "border-primary bg-primary text-white shadow-[0_0_0_3px_rgba(26,86,164,0.18)] hover:bg-primary/90"
-                : "border-primary/40 bg-primary/10 text-primary hover:bg-primary/20",
-            )}
-          >
-            {isAssembly ? (
-              <LockOpen className="h-[14px] w-[14px]" aria-hidden="true" />
-            ) : (
-              <Lock className="h-[14px] w-[14px]" aria-hidden="true" />
-            )}
-          </button>
-        </div>
-      </div>
-
-      {/* Время · Бюджет */}
-      <div className="grid gap-2.5" style={{ gridTemplateColumns: "1fr 163px" }}>
-        <div className={FBX}>
-          <Clock className="h-[18px] w-[18px] shrink-0 text-muted-foreground" aria-hidden="true" />
-          <div className="min-w-0 flex-1">
-            <span className={KIN} aria-hidden="true">Время</span>
-            <span className="flex items-center gap-1.5">
-              <input
-                className={cn(FIN_BASE, "min-w-0 flex-1")}
-                type="time"
-                aria-label="Время начала"
-                {...register("startTime")}
-              />
-              <span className="font-bold text-muted-foreground">–</span>
-              <input
-                className={cn(FIN_BASE, "min-w-0 flex-1")}
-                type="time"
-                aria-label="Время окончания"
-                {...register("endTime")}
-              />
-            </span>
-          </div>
-        </div>
-
-        <div className={FBX}>
-          <Wallet className="h-[18px] w-[18px] shrink-0 text-muted-foreground" aria-hidden="true" />
-          <div className="min-w-0 flex-1">
-            <span className={KIN} aria-hidden="true">Бюджет ₽/чел</span>
-            <input
-              className={FIN}
-              inputMode="numeric"
-              aria-label="Бюджет на человека"
-              aria-invalid={Boolean(errors.budgetPerPersonRub)}
-              {...register("budgetPerPersonRub", { valueAsNumber: true })}
-            />
-          </div>
-        </div>
-      </div>
-      <FieldError message={errors.startDate?.message ?? errors.groupSize?.message ?? errors.budgetPerPersonRub?.message} />
-
-      {/* Темы */}
-      <div>
-        <span className={cn(KIN, "mb-1.5")} aria-hidden="true">Темы</span>
-        <ThemeMultiSelect
-          value={selectedInterests}
-          onChange={interestsField.onChange}
-        />
-      </div>
-      <FieldError message={errors.interests?.message} />
-
-      {/* Детали */}
-      <button
-        type="button"
-        onClick={() => setDetailsOpen((open) => !open)}
-        aria-expanded={detailsOpen}
-        className="inline-flex items-center gap-1.5 self-start whitespace-nowrap text-[11px] font-semibold text-ink-2"
-      >
-        <ChevronDown
-          className={cn("h-[11px] w-[11px] transition-transform", detailsOpen && "rotate-180")}
-          aria-hidden="true"
-        />
-        Детали
-      </button>
-
-      {/* Детали */}
-      {detailsOpen && (
-        <div className="flex flex-col gap-3">
-          <div>
-            <span className={cn(KIN, "mb-1.5")} aria-hidden="true">Языки экскурсии</span>
-            <LanguageMultiSelect
-              options={LANGUAGES}
-              value={requestedLanguagesField.value ?? []}
-              onChange={requestedLanguagesField.onChange}
-            />
-          </div>
-          <div>
-            <span className={cn(KIN, "mb-1.5")} aria-hidden="true">Пожелания</span>
-            <Textarea
-              id="notes"
-              aria-label="Пожелания"
-              placeholder="Особые пожелания, ограничения по здоровью или другие детали."
-              {...register("notes")}
-            />
-          </div>
-        </div>
-      )}
-
-      {serverError && (
-        <div
-          role="alert"
-          className="rounded-lg border border-destructive/50 bg-destructive/10 px-4 py-3 text-sm text-destructive"
+        {/* Детали → пожелания */}
+        <button
+          type="button"
+          onClick={() => setDetailsOpen((o) => !o)}
+          aria-expanded={detailsOpen}
+          className="inline-flex items-center gap-1.5 self-start whitespace-nowrap text-[11px] font-semibold text-ink-2"
         >
-          {serverError}
-        </div>
-      )}
+          <ChevronDown
+            className={cn("h-[11px] w-[11px] transition-transform", detailsOpen && "rotate-180")}
+            aria-hidden="true"
+          />
+          Детали
+        </button>
+        {detailsOpen && (
+          <Textarea
+            id="notes"
+            aria-label="Пожелания"
+            placeholder="Особые пожелания, ограничения по здоровью или другие детали."
+            {...register("notes")}
+          />
+        )}
 
-      <HomepageAuthGate
-        open={authGateOpen}
-        onOpenChange={setAuthGateOpen}
-        onAuthSuccess={handleAuthSuccess}
-      />
+        {serverError && (
+          <div
+            role="alert"
+            className="rounded-lg border border-destructive/50 bg-destructive/10 px-4 py-3 text-sm text-destructive"
+          >
+            {serverError}
+          </div>
+        )}
 
-      <button
-        type="submit"
-        disabled={isLoading}
-        className="mt-0.5 inline-flex h-[50px] w-full items-center justify-center gap-2 rounded-[13px] bg-primary text-[15px] font-bold text-primary-foreground transition hover:bg-primary/90 disabled:cursor-not-allowed disabled:opacity-60"
-      >
-        <Send className="h-[18px] w-[18px]" aria-hidden="true" strokeWidth={2.2} />
-        {isLoading ? "Отправляем…" : "Найти гида"}
-      </button>
-    </form>
+        <HomepageAuthGate
+          open={authGateOpen}
+          onOpenChange={setAuthGateOpen}
+          onAuthSuccess={handleAuthSuccess}
+        />
+
+        <button
+          type="submit"
+          disabled={isLoading}
+          className="mt-0.5 inline-flex h-[50px] w-full items-center justify-center gap-2 rounded-[13px] bg-primary text-[15px] font-bold text-primary-foreground transition hover:bg-primary/90 disabled:cursor-not-allowed disabled:opacity-60"
+        >
+          <Send className="h-[18px] w-[18px]" aria-hidden="true" strokeWidth={2.2} />
+          {isLoading ? "Отправляем…" : "Найти гида"}
+        </button>
+      </form>
+    </TooltipProvider>
   );
 }
 

--- a/src/features/homepage-classic/components/homepage-request-form.test.tsx
+++ b/src/features/homepage-classic/components/homepage-request-form.test.tsx
@@ -172,10 +172,10 @@ describe("HomepageRequestForm UI affordances", () => {
     expect(createRequestAction).not.toHaveBeenCalled();
   });
 
-  it("defaults the destination input to «Москва» on first render", () => {
+  it("leaves the destination input empty on first render (no default city)", () => {
     render(<HomepageRequestForm destinations={[]} />);
     const input = screen.getByLabelText(/куда хотите/i) as HTMLInputElement;
-    expect(input.value).toBe("Москва");
+    expect(input.value).toBe("");
   });
 
   it("does not render the umbrella «Когда» label above the date/time fields", () => {
@@ -420,10 +420,10 @@ describe("HomepageRequestForm UI affordances", () => {
 });
 
 describe("HomepageRequestFormClassic inset-label layout", () => {
-  it("renders the inset-label brief fields with the mode toggle, themes dropdown and details", () => {
+  it("renders the icon-only brief fields with the mode toggle, themes & languages selects", () => {
     render(<HomepageRequestFormClassic destinations={[]} />);
 
-    // Inset-label fields, addressed by their accessible labels.
+    // Fields have no visible labels — addressed by their accessible (aria) labels.
     expect(screen.getByLabelText("Направление")).toBeInTheDocument();
     expect(screen.getByLabelText("Когда")).toBeInTheDocument();
     expect(screen.getByLabelText("Гостей")).toBeInTheDocument();
@@ -432,14 +432,17 @@ describe("HomepageRequestFormClassic inset-label layout", () => {
       screen.getByRole("button", { name: /сделать (закрытой|открытой)/i }),
     ).toBeInTheDocument();
 
-    // Themes use the same dropdown control as languages — no inline chip grid / «Ещё».
+    // Themes and languages are side-by-side multi-selects (no inline chips / «Ещё»).
     expect(screen.getByRole("button", { name: "Выбрать темы" })).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: "Выбрать языки экскурсии" }),
+    ).toBeInTheDocument();
     expect(screen.queryByRole("button", { name: "Ещё" })).toBeNull();
 
-    // «Детали» disclosure is collapsed by default; languages appear once opened.
-    expect(screen.queryByText("Языки экскурсии")).toBeNull();
+    // «Детали» disclosure is collapsed by default; the notes field appears once opened.
+    expect(screen.queryByLabelText("Пожелания")).toBeNull();
     fireEvent.click(screen.getByRole("button", { name: "Детали" }));
-    expect(screen.getByText("Языки экскурсии")).toBeInTheDocument();
+    expect(screen.getByLabelText("Пожелания")).toBeInTheDocument();
   });
 
   it("uses the «Найти гида» submit with no sticky mobile bar", () => {

--- a/src/features/homepage-classic/components/homepage-shell2-classic.tsx
+++ b/src/features/homepage-classic/components/homepage-shell2-classic.tsx
@@ -2,9 +2,9 @@ import { DestinationTile } from "@/components/shared/destination-tile";
 import { OpenGroupCard } from "@/components/shared/open-group-card";
 import { SectionHeading } from "@/components/shared/section-heading";
 import { SiteFooter } from "@/components/shared/site-footer";
+import { formatRubNumber } from "@/data/money";
 import type { DestinationOption, RequestRecord } from "@/data/supabase/queries";
 import { cityImage } from "@/lib/city-image";
-import { pluralize } from "@/lib/utils";
 
 import { HomepageHeroFormClassic } from "./homepage-hero-form-classic";
 
@@ -24,11 +24,6 @@ const HOW_IT_WORKS = [
 
 const SECTION = "mx-auto w-full max-w-[1180px] px-[clamp(20px,4vw,44px)]";
 
-function offersFooter(offerCount: number): string {
-  if (offerCount <= 0) return "Пока нет откликов";
-  return `${offerCount} ${pluralize(offerCount, "отклик", "отклика", "откликов")}`;
-}
-
 export function HomePageShell2Classic({ destinations, requests }: Props) {
   const openGroups = requests.slice(0, 3);
   const popularDestinations = destinations.slice(0, 6);
@@ -41,7 +36,6 @@ export function HomePageShell2Classic({ destinations, requests }: Props) {
         <section className={`${SECTION} pb-6 pt-[clamp(40px,6vw,62px)]`} aria-label="Открытые группы">
           <SectionHeading
             title="Открытые группы"
-            subtitle="Займите место рядом с местным гидом"
             action={{ label: "Все группы", href: "/requests" }}
           />
           <div className="grid gap-[18px] sm:grid-cols-2 lg:grid-cols-3">
@@ -65,9 +59,14 @@ export function HomePageShell2Classic({ destinations, requests }: Props) {
                       : undefined
                   }
                   interests={req.interests}
-                  avatarUrl={req.requesterAvatarUrl}
-                  avatarInitials={req.requesterInitials}
-                  footerText={selected ? "Гид найден" : offersFooter(req.offerCount)}
+                  offerCount={req.offerCount}
+                  members={req.members}
+                  participantCount={req.groupSize}
+                  groupPrice={
+                    req.budgetRub
+                      ? `~${formatRubNumber(Math.round(req.budgetRub * req.groupSize))} ₽ за группу`
+                      : undefined
+                  }
                   priority={index === 0}
                 />
               );

--- a/src/features/homepage-classic/components/use-request-form.ts
+++ b/src/features/homepage-classic/components/use-request-form.ts
@@ -28,7 +28,7 @@ export function useRequestForm() {
       mode: "assembly",
       interests: [] as TravelerRequest["interests"],
       requestedLanguages: ["Русский"],
-      destination: process.env.NEXT_PUBLIC_PHASE_A_CITY ?? "Москва",
+      destination: "",
       startDate: "",
       dateFlexibility: "exact",
       startTime: "10:00",

--- a/src/features/requests/components/public-requests-marketplace-screen.tsx
+++ b/src/features/requests/components/public-requests-marketplace-screen.tsx
@@ -33,7 +33,7 @@ import type { OpenRequestRecord } from "@/data/open-requests/types";
 import { THEMES } from "@/data/themes";
 import { brandGradient, cityImage } from "@/lib/city-image";
 import { todayMoscowISODate } from "@/lib/dates";
-import { pluralize } from "@/lib/utils";
+import { formatRubNumber } from "@/data/money";
 
 type CategoryFilter = (typeof THEMES)[number]["label"];
 
@@ -513,7 +513,6 @@ export function PublicRequestsMarketplaceScreen({ initialData }: Props) {
                 const location = request.destinationLabel.split(",")[0].trim();
                 const matched = request.status === "matched";
                 const sizeCurrent = request.group.sizeCurrent;
-                const organizer = request.members?.[0];
 
                 return (
                   <OpenGroupCard
@@ -528,12 +527,12 @@ export function PublicRequestsMarketplaceScreen({ initialData }: Props) {
                     datesFlexible={request.datesFlexible}
                     time={request.timeLabel}
                     interests={request.interests}
-                    avatarUrl={organizer?.avatarUrl ?? null}
-                    avatarInitials={organizer?.initials}
-                    footerText={
-                      matched
-                        ? "Гид найден"
-                        : `${sizeCurrent} ${pluralize(sizeCurrent, "участник", "участника", "участников")}`
+                    members={request.members}
+                    participantCount={sizeCurrent}
+                    groupPrice={
+                      request.budgetPerPersonRub
+                        ? `~${formatRubNumber(Math.round(request.budgetPerPersonRub * sizeCurrent))} ₽ за группу`
+                        : undefined
                     }
                     priority={index < 3}
                   />


### PR DESCRIPTION
## Form (minimalist)
- All field labels removed; each icon gets a hover tooltip (aria-labels kept).
- No default «Москва» destination.
- Native date/time picker indicators hidden (CSS) — pickers still open on click.
- **Темы + Языки** now side-by-side 50/50.

## Multi-select (shared TagMultiSelect)
- **Fixed single-line** trigger (no more jumping); selections collapse to compact chips + **«+N»**.
- **Single tick** — removed the redundant left check that produced double ticks on both Темы and Языки.

## Cards (home + /requests)
- Restored: traveller **avatar stack** (max-fit + «+N»), 3-state badge (incl. «N откликов»), unread accent, and the **group total** («~X ₽ за группу»). Per-person price stays removed (intentional).
- Removed the «Открытые группы» subtitle.

Verification: tsc 0 · eslint 0 · suite **1065/1065** · build 0 · dev-verified (form, multiselect single-tick, restored cards).