### PR TITLE
feat(requests): per-person price + require theme & times (no partial cards)

### DIFF
--- a/src/app/(site)/requests/[requestId]/page.test.tsx
+++ b/src/app/(site)/requests/[requestId]/page.test.tsx
@@ -210,6 +210,8 @@ const ownerConfirmRecord: TravelerRequestRecord = {
     destination: "Элиста",
     startDate: "2026-06-10",
     dateFlexibility: "exact",
+    startTime: "10:00",
+    endTime: "18:00",
     groupSizeCurrent: 2,
     groupMax: 5,
     openToJoin: true,

--- a/src/components/shared/open-group-card.tsx
+++ b/src/components/shared/open-group-card.tsx
@@ -39,8 +39,8 @@ export interface OpenGroupCardProps {
   participantCount?: number;
   /** e.g. "Опубликован: 30 июня" */
   publishedAt?: string;
-  /** group total budget, e.g. "~19 200 ₽ за группу" */
-  groupPrice?: string;
+  /** per-person budget, e.g. "3 000 ₽ / чел" */
+  price?: string;
   /** unread offers → left accent border */
   unread?: boolean;
   joinHref?: string;
@@ -70,7 +70,7 @@ export function OpenGroupCard({
   members,
   participantCount,
   publishedAt,
-  groupPrice,
+  price,
   unread,
   joinHref,
   joinLabel = "Присоединиться",
@@ -191,8 +191,8 @@ export function OpenGroupCard({
               <span className="truncate text-[11px] font-medium text-muted-foreground">{publishedAt}</span>
             ) : null}
           </div>
-          {groupPrice ? (
-            <span className="shrink-0 whitespace-nowrap text-xs font-semibold text-ink-2">{groupPrice}</span>
+          {price ? (
+            <span className="shrink-0 whitespace-nowrap text-xs font-semibold text-foreground">{price}</span>
           ) : null}
         </div>
 

--- a/src/data/traveler-request/map.ts
+++ b/src/data/traveler-request/map.ts
@@ -40,8 +40,8 @@ export function mapTravelerRequestRow(row: TravelerRequestRow): TravelerRequestR
       destination: row.destination,
       startDate: row.starts_on,
       dateFlexibility: row.date_flexibility ?? "exact",
-      startTime: row.start_time ? row.start_time.slice(0, 5) : undefined,
-      endTime: row.end_time ? row.end_time.slice(0, 5) : undefined,
+      startTime: row.start_time ? row.start_time.slice(0, 5) : "",
+      endTime: row.end_time ? row.end_time.slice(0, 5) : "",
       ...(mode === "assembly"
         ? { groupSizeCurrent: row.participants_count, groupMax: row.group_capacity ?? undefined }
         : { groupSize: row.participants_count }),

--- a/src/data/traveler-request/schema.test.ts
+++ b/src/data/traveler-request/schema.test.ts
@@ -7,6 +7,8 @@ describe("travelerRequestSchema", () => {
     const parsed = travelerRequestSchema.parse({
       mode: "private",
       interests: ["history_culture"],
+      startTime: "10:00",
+      endTime: "18:00",
       destination: "МоскваМосква placeholder=Москва autocomplete=list",
       startDate: "2026-05-10",
       dateFlexibility: "exact",
@@ -23,6 +25,8 @@ describe("travelerRequestSchema", () => {
     const result = travelerRequestSchema.safeParse({
       mode: "private",
       interests: ["history_culture"],
+      startTime: "10:00",
+      endTime: "18:00",
       destination: "placeholder=Москва autocomplete=list",
       startDate: "2026-05-10",
       dateFlexibility: "exact",
@@ -46,6 +50,8 @@ describe("travelerRequestSchema", () => {
     const parsed = travelerRequestSchema.parse({
       mode: "private",
       interests: ["history_culture"],
+      startTime: "10:00",
+      endTime: "18:00",
       destination: "Москва",
       startDate: "2026-05-10",
       groupSize: 2,
@@ -61,6 +67,8 @@ describe("travelerRequestSchema", () => {
     const result = travelerRequestSchema.safeParse({
       mode: "assembly",
       interests: ["history_culture"],
+      startTime: "10:00",
+      endTime: "18:00",
       destination: "Москва",
       startDate: "2026-05-10",
       dateFlexibility: "exact",
@@ -76,6 +84,8 @@ describe("travelerRequestSchema", () => {
     const result = travelerRequestSchema.safeParse({
       mode: "private",
       interests: ["history_culture"],
+      startTime: "10:00",
+      endTime: "18:00",
       destination: "Москва",
       startDate: "2026-08-01",
       endDate: "2026-08-07",
@@ -92,6 +102,8 @@ describe("travelerRequestSchema", () => {
     const result = travelerRequestSchema.safeParse({
       mode: "private",
       interests: ["history_culture"],
+      startTime: "10:00",
+      endTime: "18:00",
       destination: "Москва",
       startDate: "2026-08-07",
       endDate: "2026-08-01",
@@ -115,6 +127,8 @@ describe("travelerRequestSchema", () => {
     const result = travelerRequestSchema.safeParse({
       mode: "private",
       interests: ["history_culture"],
+      startTime: "10:00",
+      endTime: "18:00",
       destination: "Москва",
       startDate: "2026-08-01",
       dateFlexibility: "exact",

--- a/src/data/traveler-request/schema.ts
+++ b/src/data/traveler-request/schema.ts
@@ -30,16 +30,8 @@ export const travelerRequestSchema = z
     startDate: z.string().min(1, "Укажите дату начала."),
     endDate: z.string().optional().or(z.literal("")),
     dateFlexibility: z.enum(["exact", "few_days"]).default("exact"),
-    startTime: z
-      .string()
-      .regex(timeRegex, "Формат времени: ЧЧ:ММ")
-      .optional()
-      .or(z.literal("")),
-    endTime: z
-      .string()
-      .regex(timeRegex, "Формат времени: ЧЧ:ММ")
-      .optional()
-      .or(z.literal("")),
+    startTime: z.string().regex(timeRegex, "Укажите время начала (ЧЧ:ММ)."),
+    endTime: z.string().regex(timeRegex, "Укажите время окончания (ЧЧ:ММ)."),
     // assembly mode counters
     groupSizeCurrent: z
       .number()

--- a/src/features/homepage-classic/components/homepage-shell2-classic.tsx
+++ b/src/features/homepage-classic/components/homepage-shell2-classic.tsx
@@ -62,11 +62,7 @@ export function HomePageShell2Classic({ destinations, requests }: Props) {
                   offerCount={req.offerCount}
                   members={req.members}
                   participantCount={req.groupSize}
-                  groupPrice={
-                    req.budgetRub
-                      ? `~${formatRubNumber(Math.round(req.budgetRub * req.groupSize))} ₽ за группу`
-                      : undefined
-                  }
+                  price={req.budgetRub ? `${formatRubNumber(req.budgetRub)} ₽ / чел` : undefined}
                   priority={index === 0}
                 />
               );

--- a/src/features/requests/components/public-requests-marketplace-screen.tsx
+++ b/src/features/requests/components/public-requests-marketplace-screen.tsx
@@ -529,9 +529,9 @@ export function PublicRequestsMarketplaceScreen({ initialData }: Props) {
                     interests={request.interests}
                     members={request.members}
                     participantCount={sizeCurrent}
-                    groupPrice={
+                    price={
                       request.budgetPerPersonRub
-                        ? `~${formatRubNumber(Math.round(request.budgetPerPersonRub * sizeCurrent))} ₽ за группу`
+                        ? `${formatRubNumber(request.budgetPerPersonRub)} ₽ / чел`
                         : undefined
                     }
                     priority={index < 3}

--- a/src/features/requests/components/request-detail-screen.test.tsx
+++ b/src/features/requests/components/request-detail-screen.test.tsx
@@ -111,6 +111,8 @@ const travelerRecord: TravelerRequestRecord = {
     destination: "Элиста",
     startDate: "2026-06-10",
     dateFlexibility: "exact",
+    startTime: "10:00",
+    endTime: "18:00",
     groupSizeCurrent: 2,
     groupMax: 5,
     openToJoin: false,


### PR DESCRIPTION
## Price → per person
Card shows **«{budget} ₽ / чел»** (per person) instead of the group total, same bottom-right slot, on home + /requests. (Total grows with the group, so it's not useful — per the product decision; overrides the prior total-only note.)

## Required fields (no partial cards)
The `travelerRequest` schema now requires **≥1 theme** (already enforced) + **start time** + **end time**, so a request can't be submitted incomplete → every card renders full. Read-model defaults legacy null times to empty.

## Data
The sparse demo rows (Казань/Сочи/СПб) had interests stored as Russian *labels* (filtered out by the mapper) + null times — fixed directly in Supabase (labels → valid slugs + times).

tsc 0 · eslint 0 · suite 1065/1065 · build 0 · dev-verified.