### PR TITLE
fix(homepage): align «Направление» icon + text with the other fields

### DIFF
--- a/src/features/homepage-classic/components/homepage-request-form-classic.tsx
+++ b/src/features/homepage-classic/components/homepage-request-form-classic.tsx
@@ -162,8 +162,8 @@ export function HomepageRequestFormClassic({ destinations }: Props) {
         noValidate
       >
         {/* Направление */}
-        <div className={cn(FBX, "px-[15px]")}>
-          <FieldIcon icon={MapPin} label="Направление" className="h-[21px] w-[21px] text-primary" />
+        <div className={FBX}>
+          <FieldIcon icon={MapPin} label="Направление" className="text-primary" />
           <div className="min-w-0 flex-1">
             <input
               className={cn(FIN, "text-[18px]")}


### PR DESCRIPTION
The «Направление» field used px-[15px] (vs px-[13px]) and a 21px pin (vs 18px), pushing its icon + text a few px right of the other fields. Removed the padding override and set the pin to 18px (kept text-primary) → clean icon/text columns. tc 0, lint 0.