### PR TITLE
Fix Wildberries review issues

### DIFF
--- a/docs/qa/wildberries-state/state.json
+++ b/docs/qa/wildberries-state/state.json
@@ -45,16 +45,21 @@
     "owner_decisions": "Product/legal/manual-QA items are not complete until Badma/Alex/legal owner gives a decision. They can be documented but not marked fixed."
   },
   "status_counts": {
-    "done_verified_live_or_db": 23,
-    "done_by_code_or_report_needs_auth_manual_recheck": 4,
-    "not_done_or_partial": 5,
+    "done_verified_live_or_db": 22,
+    "done_by_code_or_report_needs_auth_manual_recheck": 7,
+    "not_done_or_partial": 3,
     "owner_or_legal_decision": 4,
     "info_closed": 1
+  },
+  "pending_branch": {
+    "branch": "wildberries-fix-all-20260702",
+    "note": "Local branch (not pushed) that hides the public catalog behind FEATURE_PUBLIC_CATALOG, removes the homepage fine print, adds the /policies/offer draft, and keeps the guide-auth home link visible on all viewports. WB-001/002/010/017/032 are DONE_BY_CODE and require live VPS re-verification after deploy.",
+    "flag": "FEATURE_PUBLIC_CATALOG must stay unset (off) in prod for the catalog to remain hidden."
   },
   "issue_groups": [
     {
       "group": "Hidden public sections and routes",
-      "status": "NOT_DONE",
+      "status": "DONE_BY_CODE_NEEDS_LIVE_DEPLOY_VERIFICATION",
       "owner": "engineering/product",
       "rule": "Anything hidden must be fully hidden and URL-inaccessible to all users.",
       "issues": [
@@ -62,24 +67,33 @@
           "id": "WB-001",
           "source_ids": ["79806#1", "79816", "80049"],
           "title": "Hide public sections 'Направления' and 'Экскурсии' completely",
-          "status": "NOT_DONE",
-          "current_evidence": [
-            "Live homepage returns 200 but still contains navigation text for Экскурсии / Направления in the header/body extraction.",
-            "Public /destinations and /listings routes exist in the build and should be treated as accessible until disabled/removed.",
-            "Prior audit only proved homepage section hiding, not full URL inaccessibility."
+          "status": "DONE_BY_CODE_NEEDS_LIVE_DEPLOY_VERIFICATION",
+          "how_done": "Added a FEATURE_PUBLIC_CATALOG flag (default off). Removed «Экскурсии»/«Направления» from public/traveler/admin-header nav and the homepage popular-destinations section; repointed the public marketing CTAs (/for-business, /how-it-works, /trust) to /guides. Gated /destinations, /destinations/[slug], /listings, /listings/[id] and the protected /listings/[id]/book path with notFound() when the flag is off. Sitemap no longer emits /destinations* or /listings* when the flag is off.",
+          "evidence": [
+            "src/lib/flags.ts adds FEATURE_PUBLIC_CATALOG (off unless env = '1').",
+            "src/lib/navigation.ts publicPrimaryNav/travelerPrimaryNav/adminHeaderNav drop /listings + /destinations.",
+            "notFound() guards in src/app/(site)/destinations/page.tsx, destinations/[slug]/page.tsx, listings/page.tsx, listings/[id]/page.tsx, and (protected)/listings/[id]/book/page.tsx.",
+            "Tests: src/lib/navigation.test.ts (hidden catalog assertions), src/app/(site)/listings/page.test.tsx, src/app/(site)/destinations/page.test.tsx, (protected)/listings/[id]/book/page.test.tsx prove notFound when hidden.",
+            "src/app/sitemap.ts skips catalog URLs when the flag is off."
           ],
           "required_to_close": [
-            "Remove all nav/menu/footer links to hidden sections.",
-            "Make direct URLs inaccessible: /destinations, /destinations/[slug], /listings, /listings/[id], /listings/[id]/book, or any equivalent excursion/direction route must return 404/redirect to allowed page for every user unless explicitly re-approved.",
-            "Add route or navigation tests proving hidden routes are not public.",
-            "Verify live VPS by HTTP/body after deployment."
+            "Deploy branch wildberries-fix-all-20260702 to live VPS with FEATURE_PUBLIC_CATALOG unset.",
+            "Verify live VPS by HTTP/body: nav has no Экскурсии/Направления, and /destinations + /listings return 404."
           ],
-          "files_likely_involved": [
+          "files_involved": [
+            "src/lib/flags.ts",
             "src/lib/navigation.ts",
-            "src/components/shared/site-header.tsx",
-            "src/components/shared/site-footer.tsx",
-            "src/app/(site)/destinations/*",
-            "src/app/(site)/listings/*"
+            "src/app/(home)/page.tsx",
+            "src/features/homepage-classic/components/homepage-shell2-classic.tsx",
+            "src/app/(site)/destinations/page.tsx",
+            "src/app/(site)/destinations/[slug]/page.tsx",
+            "src/app/(site)/listings/page.tsx",
+            "src/app/(site)/listings/[id]/page.tsx",
+            "src/app/(protected)/listings/[id]/book/page.tsx",
+            "src/app/(site)/for-business/page.tsx",
+            "src/app/(site)/how-it-works/page.tsx",
+            "src/app/(site)/trust/page.tsx",
+            "src/app/sitemap.ts"
           ]
         }
       ]
@@ -92,9 +106,10 @@
           "id": "WB-002",
           "source_ids": ["79806#2", "80052"],
           "title": "Remove fine print under homepage request form",
-          "status": "DONE_REPORTED_NEEDS_VISUAL_RECHECK_AFTER_HIDE_FIX",
-          "how_done": "Homepage copy was changed in prior Wildberries batches; current source/build no longer depends on that old small print as a required line.",
-          "required_to_close": ["Recheck visually after the hidden-route cleanup because the homepage/nav still needs work."]
+          "status": "DONE_BY_CODE_NEEDS_LIVE_DEPLOY_VERIFICATION",
+          "how_done": "Removed the «Бесплатно · без регистрации · гиды обычно отвечают в течение дня» paragraph from the active hero form (src/features/homepage-classic/components/homepage-hero-form-classic.tsx).",
+          "evidence": ["Diff drops the fine-print <p> from homepage-hero-form-classic.tsx; homepage-shell2-classic is the active home shell used by src/app/(home)/page.tsx."],
+          "required_to_close": ["Deploy and visually confirm the fine print is gone on live /."]
         },
         {
           "id": "WB-003",
@@ -160,10 +175,10 @@
           "id": "WB-010",
           "source_ids": ["Excel row 21"],
           "title": "Guide registration form needs explicit Back/Home navigation",
-          "status": "DONE_VERIFIED_LIVE",
-          "how_done": "Current /auth?role=guide shows 'На главную'.",
-          "evidence": ["Current source src/app/(auth)/auth/page.tsx has На главную", "Live text scan found guide form, but earlier probe against stale worktree missed it; current main has it."],
-          "required_to_close": ["Optional: visual screenshot from live after hidden-route cleanup."]
+          "status": "DONE_BY_CODE_NEEDS_LIVE_DEPLOY_VERIFICATION",
+          "how_done": "The «На главную» back link in src/app/(auth)/auth/page.tsx no longer carries lg:hidden, so it is visible on desktop as well as mobile (previously desktop only showed the «Provodnik» aside link). Guide-type options are untouched.",
+          "evidence": ["src/app/(auth)/auth/page.tsx: absolute «На главную» Link has no lg:hidden class.", "WB-007 confirms the three guide-type options remain on /auth?role=guide."],
+          "required_to_close": ["Deploy and confirm «На главную» is visible on /auth?role=guide at 1280px and 375px."]
         }
       ]
     },
@@ -231,9 +246,10 @@
           "id": "WB-017",
           "source_ids": ["79968", "79969", "80045", "80065"],
           "title": "Calendar selectable for anonymous and logged-in traveler",
-          "status": "DONE_BY_REPORT_TESTS",
-          "how_done": "Calendar/date picker fixes were shipped and tested; MVP finish report verified logged-in traveler request submission.",
-          "remaining": "Manual recheck recommended after any hidden-route/nav changes."
+          "status": "DONE_BY_CODE_NEEDS_LIVE_DEPLOY_VERIFICATION",
+          "how_done": "The homepage DateField trigger already renders the picked date via toLocaleDateString('ru-RU') and only falls back to the «Когда» placeholder when empty (src/features/homepage-classic/components/homepage-request-form-classic.tsx). Added a focused unit test proving the trigger shows the formatted Russian date after a value is set and «Когда» only when empty.",
+          "evidence": ["src/features/homepage-classic/components/homepage-request-form-classic.date.test.tsx covers placeholder vs formatted-date display (#9)."],
+          "remaining": "Deploy and confirm on live that selecting a date replaces «Когда» with the formatted date."
         },
         {
           "id": "WB-018",
@@ -370,9 +386,10 @@
           "id": "WB-032",
           "source_ids": ["79865", "79866", "79867", "79868"],
           "title": "Tripster-style offer / liability allocation",
-          "status": "NOT_DONE_CURRENT_MAIN_LIVE",
-          "why_not_done": "Current live /policies/offer returns 404 and current main build route table does not include /policies/offer. Earlier reports described a draft route on a branch, but it is not present in the deployed main audited now.",
-          "required_to_close": ["Restore/add /policies/offer route", "Mark clearly as legal draft if not lawyer-approved", "Add footer/sitemap link if approved", "Verify live 200/body text." ]
+          "status": "DONE_BY_CODE_NEEDS_LIVE_DEPLOY_VERIFICATION",
+          "how_done": "Added src/app/(site)/policies/offer/page.tsx in the existing legal-page style (PageHeader + section nav + Cards). Draft Russian sections cover platform role (marketplace/tech intermediary, not tour operator), direct guide↔traveler contract, guide responsibility, traveler responsibility, payments/refunds, disputes, limitation of liability, data/privacy references, and a status/lawyer-review notice. A prominent «Черновик — требуется финальная юридическая проверка» alert marks it as a draft, and a «Публичная оферта» link was added to the footer legal group.",
+          "evidence": ["src/app/(site)/policies/offer/page.tsx", "src/lib/navigation.ts footerNav.legal includes /policies/offer."],
+          "required_to_close": ["Deploy and verify live /policies/offer returns 200 with the draft marketplace/liability text.", "Final lawyer review before the offer becomes binding / before payments launch."]
         },
         {
           "id": "WB-033",
@@ -421,13 +438,13 @@
   "next_actions_ordered": [
     {
       "priority": 1,
-      "action": "Fix hidden public surfaces",
-      "details": "Fully remove/invalidate public Directions/Excursions surfaces: no nav links and direct URLs inaccessible for every user unless re-approved. This is currently the strongest gap because the user clarified hidden means fully hidden/inaccessible."
+      "action": "Deploy + live-verify hidden public surfaces",
+      "details": "Code-complete on branch wildberries-fix-all-20260702 behind FEATURE_PUBLIC_CATALOG (default off): nav links removed and /destinations + /listings (+ book path) return 404. Deploy with the flag unset and confirm on live VPS by HTTP/body."
     },
     {
       "priority": 2,
-      "action": "Restore/add legal offer route or mark it explicitly out of scope",
-      "details": "/policies/offer is 404 on current live main despite prior reports saying a draft existed."
+      "action": "Deploy + live-verify legal offer route",
+      "details": "/policies/offer draft added on the same branch in the existing legal style with a lawyer-review notice and footer link. Deploy and confirm live 200/body, then route for final lawyer review."
     },
     {
       "priority": 3,

--- a/src/app/(auth)/auth/page.tsx
+++ b/src/app/(auth)/auth/page.tsx
@@ -81,7 +81,7 @@ export default async function AuthPage({ searchParams }: AuthPageProps) {
     <section className="relative flex min-h-screen items-stretch justify-center bg-surface px-[clamp(20px,4vw,48px)] py-16">
       <Link
         href="/"
-        className="absolute left-[clamp(20px,4vw,48px)] top-6 z-10 inline-flex items-center gap-1.5 text-sm font-medium text-muted-foreground transition-colors hover:text-foreground lg:hidden"
+        className="absolute left-[clamp(20px,4vw,48px)] top-6 z-10 inline-flex items-center gap-1.5 text-sm font-medium text-muted-foreground transition-colors hover:text-foreground"
       >
         <ArrowLeft className="size-4" aria-hidden />
         На главную

--- a/src/app/(home)/page.tsx
+++ b/src/app/(home)/page.tsx
@@ -1,6 +1,6 @@
 import type { Metadata } from "next";
 
-import { getActiveGuideDestinations, getDestinations, getHomepageRequests, type DestinationOption, type RequestRecord } from "@/data/supabase/queries";
+import { getActiveGuideDestinations, getHomepageRequests, type DestinationOption, type RequestRecord } from "@/data/supabase/queries";
 import { SiteHeaderServer } from "@/components/shared/site-header-server";
 import { HomePageShell2Classic } from "@/features/homepage-classic/components/homepage-shell2-classic";
 import { createSupabaseServerClient } from "@/lib/supabase/server";
@@ -14,21 +14,14 @@ export const metadata: Metadata = {
 export default async function HomePage() {
   let destinations: DestinationOption[] = [];
   let requests: RequestRecord[] = [];
-  // Maps a destination name to its catalog slug so popular-destination tiles can
-  // deep-link to the rich /destinations/[slug] page instead of a listings search.
-  let destinationSlugs: Record<string, string> = {};
   try {
     const supabase = await createSupabaseServerClient();
-    const [destResult, reqResult, catalogResult] = await Promise.all([
+    const [destResult, reqResult] = await Promise.all([
       getActiveGuideDestinations(supabase),
       getHomepageRequests(supabase),
-      getDestinations(supabase),
     ]);
     destinations = destResult.data ?? [];
     requests = reqResult.data ?? [];
-    destinationSlugs = Object.fromEntries(
-      (catalogResult.data ?? []).map((d) => [d.name.trim().toLowerCase(), d.slug]),
-    );
   } catch {
     // all stay empty
   }
@@ -37,11 +30,7 @@ export default async function HomePage() {
     <>
       <SiteHeaderServer />
       <main>
-        <HomePageShell2Classic
-          destinations={destinations}
-          requests={requests}
-          destinationSlugs={destinationSlugs}
-        />
+        <HomePageShell2Classic destinations={destinations} requests={requests} />
       </main>
     </>
   );

--- a/src/app/(protected)/listings/[id]/book/page.test.tsx
+++ b/src/app/(protected)/listings/[id]/book/page.test.tsx
@@ -1,16 +1,21 @@
 import { render, screen } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-const { createSupabaseServerClientMock, notFoundMock, redirectMock } = vi.hoisted(() => ({
+const { createSupabaseServerClientMock, notFoundMock, redirectMock, flagsMock } = vi.hoisted(() => ({
   createSupabaseServerClientMock: vi.fn(),
-  notFoundMock: vi.fn(),
+  notFoundMock: vi.fn(() => {
+    throw new Error("NEXT_NOT_FOUND");
+  }),
   redirectMock: vi.fn(),
+  flagsMock: { FEATURE_PUBLIC_CATALOG: true },
 }));
 
 vi.mock("next/navigation", () => ({
   notFound: notFoundMock,
   redirect: redirectMock,
 }));
+
+vi.mock("@/lib/flags", () => ({ flags: flagsMock }));
 
 vi.mock("@/lib/supabase/server", () => ({
   createSupabaseServerClient: createSupabaseServerClientMock,
@@ -62,7 +67,21 @@ describe("BookingPage honest title + trust", () => {
   beforeEach(() => {
     createSupabaseServerClientMock.mockReset();
     notFoundMock.mockReset();
+    notFoundMock.mockImplementation(() => {
+      throw new Error("NEXT_NOT_FOUND");
+    });
     redirectMock.mockReset();
+    flagsMock.FEATURE_PUBLIC_CATALOG = true;
+  });
+
+  it("returns notFound when the public catalog is hidden", async () => {
+    flagsMock.FEATURE_PUBLIC_CATALOG = false;
+
+    await expect(
+      BookingPage({ params: Promise.resolve({ id: "listing-1" }) }),
+    ).rejects.toThrow("NEXT_NOT_FOUND");
+    expect(notFoundMock).toHaveBeenCalled();
+    expect(createSupabaseServerClientMock).not.toHaveBeenCalled();
   });
 
   it("uses the honest «Подать заявку» metadata title, not «Оформление»", () => {

--- a/src/app/(protected)/listings/[id]/book/page.tsx
+++ b/src/app/(protected)/listings/[id]/book/page.tsx
@@ -8,6 +8,7 @@ import { MoneyBreakdown } from "@/components/trust/money-breakdown";
 import { Card, CardContent } from "@/components/ui/card";
 import { kopecksToRub } from "@/data/money";
 import { BookingFormTabs } from "@/features/bookings/components/BookingFormTabs";
+import { flags } from "@/lib/flags";
 import { createSupabaseServerClient } from "@/lib/supabase/server";
 
 export const metadata: Metadata = {
@@ -26,6 +27,10 @@ export default async function BookingPage({
 }: {
   params: Promise<{ id: string }>;
 }) {
+  // The public excursions catalog is hidden (Wildberries review); the catalog
+  // booking path is unreachable and returns 404 unless re-approved.
+  if (!flags.FEATURE_PUBLIC_CATALOG) notFound();
+
   const { id } = await params;
   const supabase = await createSupabaseServerClient();
   const {

--- a/src/app/(site)/destinations/[slug]/page.tsx
+++ b/src/app/(site)/destinations/[slug]/page.tsx
@@ -12,6 +12,7 @@ import {
 } from "@/data/supabase/queries";
 import { DestinationDetailScreen } from "@/features/destinations/components/destination-detail-screen";
 import type { DestinationSummary } from "@/data/destinations/types";
+import { flags } from "@/lib/flags";
 import { createSupabaseServerClient } from "@/lib/supabase/server";
 import { serializeJsonLd } from "@/lib/seo/json-ld";
 
@@ -60,6 +61,9 @@ export default async function DestinationDetailPage({
 }: {
   params: Promise<{ slug: string }>;
 }) {
+  // Public destinations catalog is hidden (Wildberries review) unless re-approved.
+  if (!flags.FEATURE_PUBLIC_CATALOG) notFound();
+
   const { slug } = await params;
 
   const { destinationResult, listings, guides, openRequestCount } =

--- a/src/app/(site)/destinations/page.test.tsx
+++ b/src/app/(site)/destinations/page.test.tsx
@@ -1,0 +1,55 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it, beforeEach, vi } from "vitest";
+
+const { notFoundMock, flagsMock } = vi.hoisted(() => ({
+  notFoundMock: vi.fn(() => {
+    throw new Error("NEXT_NOT_FOUND");
+  }),
+  flagsMock: { FEATURE_PUBLIC_CATALOG: true },
+}));
+
+vi.mock("next/navigation", () => ({ notFound: notFoundMock }));
+
+vi.mock("@/lib/flags", () => ({ flags: flagsMock }));
+
+vi.mock("@/lib/supabase/server", () => ({
+  createSupabaseServerClient: vi.fn(async () => ({})),
+}));
+
+const getDestinations = vi.fn();
+vi.mock("@/data/supabase/queries", () => ({
+  getDestinations: (...args: unknown[]) => getDestinations(...args),
+}));
+
+vi.mock("@/features/destinations/components/destinations-discovery-screen", () => ({
+  DestinationsDiscoveryScreen: () => (
+    <section aria-label="discovery">DestinationsDiscoveryScreen</section>
+  ),
+}));
+
+import DestinationsPage from "./page";
+
+describe("DestinationsPage", () => {
+  beforeEach(() => {
+    notFoundMock.mockClear();
+    getDestinations.mockReset();
+    flagsMock.FEATURE_PUBLIC_CATALOG = true;
+  });
+
+  it("returns notFound when the public catalog is hidden (Wildberries review)", async () => {
+    flagsMock.FEATURE_PUBLIC_CATALOG = false;
+
+    await expect(DestinationsPage()).rejects.toThrow("NEXT_NOT_FOUND");
+    expect(notFoundMock).toHaveBeenCalled();
+    expect(getDestinations).not.toHaveBeenCalled();
+  });
+
+  it("renders the discovery screen when the catalog is enabled", async () => {
+    getDestinations.mockResolvedValueOnce({ data: [], error: null });
+
+    render(await DestinationsPage());
+
+    expect(screen.getByLabelText("discovery")).toBeInTheDocument();
+    expect(notFoundMock).not.toHaveBeenCalled();
+  });
+});

--- a/src/app/(site)/destinations/page.tsx
+++ b/src/app/(site)/destinations/page.tsx
@@ -1,7 +1,9 @@
 import type { Metadata } from "next";
+import { notFound } from "next/navigation";
 
 import { DestinationsDiscoveryScreen } from "@/features/destinations/components/destinations-discovery-screen";
 import { getDestinations, type DestinationRecord } from "@/data/supabase/queries";
+import { flags } from "@/lib/flags";
 import { createSupabaseServerClient } from "@/lib/supabase/server";
 
 export function generateMetadata(): Metadata {
@@ -12,6 +14,9 @@ export function generateMetadata(): Metadata {
 }
 
 export default async function DestinationsPage() {
+  // Public destinations catalog is hidden (Wildberries review) unless re-approved.
+  if (!flags.FEATURE_PUBLIC_CATALOG) notFound();
+
   let destinations: DestinationRecord[] = [];
   let loadError = false;
 

--- a/src/app/(site)/for-business/page.tsx
+++ b/src/app/(site)/for-business/page.tsx
@@ -132,7 +132,7 @@ export default function ForBusinessPage() {
             </a>
           </Button>
           <Button asChild size="lg" variant="outline">
-            <Link href="/listings">Смотреть экскурсии</Link>
+            <Link href="/guides">Смотреть гидов</Link>
           </Button>
         </div>
       </div>

--- a/src/app/(site)/how-it-works/page.tsx
+++ b/src/app/(site)/how-it-works/page.tsx
@@ -87,7 +87,7 @@ export default function HowItWorksPage() {
         </div>
         <div className="mt-6">
           <Button asChild variant="outline" className="w-full sm:w-auto">
-            <Link href="/listings">Смотреть экскурсии</Link>
+            <Link href="/guides">Смотреть гидов</Link>
           </Button>
         </div>
       </InfoSection>

--- a/src/app/(site)/listings/[id]/page.tsx
+++ b/src/app/(site)/listings/[id]/page.tsx
@@ -40,6 +40,9 @@ export default async function ListingDetailPage({
 }: {
   params: Promise<{ id: string }>;
 }) {
+  // Public excursions catalog is hidden (Wildberries review) unless re-approved.
+  if (!flags.FEATURE_PUBLIC_CATALOG) notFound();
+
   const { id: ref } = await params;
   const supabase = await createSupabaseServerClient();
 

--- a/src/app/(site)/listings/page.test.tsx
+++ b/src/app/(site)/listings/page.test.tsx
@@ -1,5 +1,16 @@
 import { render, screen } from "@testing-library/react";
-import { describe, expect, it, vi } from "vitest";
+import { describe, expect, it, beforeEach, vi } from "vitest";
+
+const { notFoundMock, flagsMock } = vi.hoisted(() => ({
+  notFoundMock: vi.fn(() => {
+    throw new Error("NEXT_NOT_FOUND");
+  }),
+  flagsMock: { FEATURE_PUBLIC_CATALOG: true },
+}));
+
+vi.mock("next/navigation", () => ({ notFound: notFoundMock }));
+
+vi.mock("@/lib/flags", () => ({ flags: flagsMock }));
 
 vi.mock("@/lib/supabase/server", () => ({
   createSupabaseServerClient: vi.fn(async () => ({})),
@@ -19,6 +30,22 @@ vi.mock("@/features/listings/components/public/public-listing-discovery-screen",
 import PublicListingsPage from "./page";
 
 describe("PublicListingsPage", () => {
+  beforeEach(() => {
+    notFoundMock.mockClear();
+    getActiveListings.mockReset();
+    flagsMock.FEATURE_PUBLIC_CATALOG = true;
+  });
+
+  it("returns notFound when the public catalog is hidden (Wildberries review)", async () => {
+    flagsMock.FEATURE_PUBLIC_CATALOG = false;
+
+    await expect(
+      PublicListingsPage({ searchParams: Promise.resolve({}) }),
+    ).rejects.toThrow("NEXT_NOT_FOUND");
+    expect(notFoundMock).toHaveBeenCalled();
+    expect(getActiveListings).not.toHaveBeenCalled();
+  });
+
   it("renders the error Alert and not the discovery screen when the query errors", async () => {
     getActiveListings.mockResolvedValueOnce({ data: null, error: new Error("boom") });
 

--- a/src/app/(site)/listings/page.tsx
+++ b/src/app/(site)/listings/page.tsx
@@ -1,8 +1,10 @@
 import type { Metadata } from "next";
+import { notFound } from "next/navigation";
 
 import { mapDbCategoryToThemeSlug } from "@/data/public-listings/mapper";
 import type { PublicListing } from "@/data/public-listings/types";
 import { getActiveListings, type ListingRecord } from "@/data/supabase/queries";
+import { flags } from "@/lib/flags";
 import { createSupabaseServerClient } from "@/lib/supabase/server";
 import { Alert, AlertDescription } from "@/components/ui/alert";
 import { PublicListingDiscoveryScreen } from "@/features/listings/components/public/public-listing-discovery-screen";
@@ -50,6 +52,9 @@ export default async function PublicListingsPage({
 }: {
   searchParams: Promise<{ q?: string }>;
 }) {
+  // Public excursions catalog is hidden (Wildberries review) unless re-approved.
+  if (!flags.FEATURE_PUBLIC_CATALOG) notFound();
+
   let listings: PublicListing[] = [];
   let loadError = false;
 

--- a/src/app/(site)/policies/offer/page.tsx
+++ b/src/app/(site)/policies/offer/page.tsx
@@ -1,0 +1,265 @@
+import type { Metadata } from "next";
+
+import { PageHeader } from "@/components/shared/page-header";
+import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+
+export function generateMetadata(): Metadata {
+  return {
+    title: "Публичная оферта (проект)",
+    description:
+      "Проект публичной оферты Provodnik: роль платформы как маркетплейса и технического посредника, распределение ответственности между гидом и путешественником, платежи, споры и ограничение ответственности.",
+  };
+}
+
+const sections = [
+  { id: "role", label: "Роль платформы" },
+  { id: "contract", label: "Договор сторон" },
+  { id: "guide", label: "Ответственность гида" },
+  { id: "traveler", label: "Ответственность путешественника" },
+  { id: "payments", label: "Платежи и возвраты" },
+  { id: "disputes", label: "Споры" },
+  { id: "liability", label: "Ограничение ответственности" },
+  { id: "data", label: "Данные и приватность" },
+  { id: "final", label: "Статус документа" },
+];
+
+const guideResponsibilities = [
+  "Гид самостоятельно и от своего имени оказывает услуги экскурсии или тура: формирует маршрут, определяет программу, обеспечивает безопасность и качество услуги.",
+  "Гид гарантирует, что вправе оказывать соответствующие услуги, и при необходимости имеет требуемые разрешения, аккредитации или статус (самозанятый, ИП, юридическое лицо).",
+  "Гид отвечает за достоверность размещённой информации о цене, включённых услугах, ограничениях программы и условиях отмены.",
+  "Гид несёт ответственность перед путешественником за фактическое исполнение обязательств по согласованному заказу.",
+];
+
+const travelerResponsibilities = [
+  "Путешественник указывает достоверные данные о составе группы, датах, пожеланиях и иных сведениях, влияющих на исполнение заказа.",
+  "Путешественник самостоятельно оценивает соответствие программы своим возможностям по здоровью, возрасту и физической подготовке до подтверждения заказа.",
+  "Путешественник соблюдает согласованные с гидом условия, правила безопасности и требования законодательства в месте проведения поездки.",
+  "Путешественник своевременно сообщает гиду и платформе о невозможности участия, изменениях состава группы или иных существенных обстоятельствах.",
+];
+
+const paymentTerms = [
+  "Платформа может выступать техническим средством оформления заказа и, при подключении платёжного модуля, — агентом по приёму платежей в пользу гида. Порядок расчётов определяется отдельными условиями и применимым платёжным сервисом.",
+  "Стоимость услуги, состав включённых услуг и условия отмены определяет гид и доводит их до путешественника до подтверждения заказа.",
+  "Возвраты, переносы и удержания при отмене регулируются условиями конкретного заказа и гида, а также обязательными нормами законодательства о защите прав потребителей.",
+  "Платформа не удерживает вознаграждение сверх раскрытых сервисных условий и не является выгодоприобретателем по договору оказания услуг между гидом и путешественником.",
+];
+
+const disputeSteps = [
+  "Сторона, обнаружившая проблему, сначала описывает её через платформу или поддержку с указанием заказа, даты и сути претензии.",
+  "Платформа как нейтральный посредник вправе запросить переписку, фотографии, документы и иные материалы и содействует урегулированию спора.",
+  "Итоговая ответственность по спору о качестве или объёме услуги лежит на гиде как исполнителе; платформа не подменяет собой стороны договора.",
+  "Неурегулированные споры разрешаются в соответствии с законодательством Российской Федерации.",
+];
+
+export default function OfferPage() {
+  return (
+    <div>
+      <PageHeader
+        eyebrow="Правовые документы"
+        title="Публичная оферта Provodnik"
+        subtitle="Документ описывает роль платформы Provodnik как маркетплейса и технического посредника, а также распределение ответственности между гидами и путешественниками при заключении и исполнении заказов."
+      />
+      <p className="mt-1 text-xs text-on-surface-muted">
+        Проект. Обновляется до запуска приёма платежей.
+      </p>
+
+      <Alert className="mt-6 border-border bg-card">
+        <AlertTitle className="text-sm font-semibold">
+          Черновик — требуется финальная юридическая проверка
+        </AlertTitle>
+        <AlertDescription className="text-sm leading-[1.6] text-muted-foreground">
+          Это предварительная редакция оферты. Она не является юридической
+          консультацией и не заменяет проверку юристом. Итоговая редакция и
+          обязывающие условия публикуются после согласования с профильным
+          юристом и до начала приёма платежей на платформе.
+        </AlertDescription>
+      </Alert>
+
+      <nav
+        aria-label="Разделы"
+        className="mt-6 flex flex-wrap gap-x-4 gap-y-1 border-b border-border pb-4 mb-8"
+      >
+        {sections.map((s) => (
+          <a
+            key={s.id}
+            href={`#${s.id}`}
+            className="py-3 min-h-[44px] flex items-center text-sm text-primary hover:underline"
+          >
+            {s.label}
+          </a>
+        ))}
+      </nav>
+
+      <div className="space-y-6">
+        <Card id="role" className="border-border bg-card scroll-mt-24">
+          <CardHeader className="space-y-1">
+            <CardTitle className="text-base">1. Роль платформы</CardTitle>
+          </CardHeader>
+          <CardContent className="space-y-3 text-sm leading-[1.65] text-muted-foreground">
+            <p>
+              Provodnik — это маркетплейс и информационно-технический посредник.
+              Платформа предоставляет цифровую среду, в которой путешественники
+              публикуют запросы и находят гидов, а гиды размещают предложения,
+              отвечают на запросы и оформляют заказы.
+            </p>
+            <p>
+              Платформа не является туроператором, турагентом, перевозчиком или
+              экскурсоводом и не оказывает услуги гида от своего имени. Договор
+              на оказание услуги заключается напрямую между гидом и
+              путешественником; платформа обеспечивает лишь техническую
+              возможность их взаимодействия.
+            </p>
+          </CardContent>
+        </Card>
+
+        <Card id="contract" className="border-border bg-card scroll-mt-24">
+          <CardHeader className="space-y-1">
+            <CardTitle className="text-base">
+              2. Прямой договор между гидом и путешественником
+            </CardTitle>
+          </CardHeader>
+          <CardContent className="space-y-3 text-sm leading-[1.65] text-muted-foreground">
+            <p>
+              При подтверждении заказа договор возмездного оказания услуг
+              заключается непосредственно между гидом (исполнителем) и
+              путешественником (заказчиком). Условия договора формируются из
+              согласованных сторонами параметров заказа: маршрута, даты, состава
+              группы, цены и включённых услуг.
+            </p>
+            <p>
+              Платформа не является стороной этого договора и не принимает на
+              себя обязательств исполнителя или заказчика по нему.
+            </p>
+          </CardContent>
+        </Card>
+
+        <Card id="guide" className="border-border bg-card scroll-mt-24">
+          <CardHeader className="space-y-1">
+            <CardTitle className="text-base">3. Ответственность гида</CardTitle>
+          </CardHeader>
+          <CardContent className="space-y-3 text-sm leading-[1.65] text-muted-foreground">
+            <ul className="space-y-3 list-disc pl-5">
+              {guideResponsibilities.map((item) => (
+                <li key={item}>{item}</li>
+              ))}
+            </ul>
+          </CardContent>
+        </Card>
+
+        <Card id="traveler" className="border-border bg-card scroll-mt-24">
+          <CardHeader className="space-y-1">
+            <CardTitle className="text-base">
+              4. Ответственность путешественника
+            </CardTitle>
+          </CardHeader>
+          <CardContent className="space-y-3 text-sm leading-[1.65] text-muted-foreground">
+            <ul className="space-y-3 list-disc pl-5">
+              {travelerResponsibilities.map((item) => (
+                <li key={item}>{item}</li>
+              ))}
+            </ul>
+          </CardContent>
+        </Card>
+
+        <Card id="payments" className="border-border bg-card scroll-mt-24">
+          <CardHeader className="space-y-1">
+            <CardTitle className="text-base">5. Платежи и возвраты</CardTitle>
+          </CardHeader>
+          <CardContent className="space-y-3 text-sm leading-[1.65] text-muted-foreground">
+            <ul className="space-y-3 list-disc pl-5">
+              {paymentTerms.map((item) => (
+                <li key={item}>{item}</li>
+              ))}
+            </ul>
+          </CardContent>
+        </Card>
+
+        <Card id="disputes" className="border-border bg-card scroll-mt-24">
+          <CardHeader className="space-y-1">
+            <CardTitle className="text-base">6. Споры</CardTitle>
+          </CardHeader>
+          <CardContent className="space-y-3 text-sm leading-[1.65] text-muted-foreground">
+            <ul className="space-y-3 list-disc pl-5">
+              {disputeSteps.map((item) => (
+                <li key={item}>{item}</li>
+              ))}
+            </ul>
+          </CardContent>
+        </Card>
+
+        <Card id="liability" className="border-border bg-card scroll-mt-24">
+          <CardHeader className="space-y-1">
+            <CardTitle className="text-base">
+              7. Ограничение ответственности платформы
+            </CardTitle>
+          </CardHeader>
+          <CardContent className="space-y-3 text-sm leading-[1.65] text-muted-foreground">
+            <p>
+              Платформа как технический посредник не отвечает за качество,
+              объём, безопасность и результат услуг, оказываемых гидом, а также
+              за действия или бездействие пользователей.
+            </p>
+            <p>
+              Платформа не отвечает за убытки, вызванные действиями третьих лиц,
+              погодными условиями, транспортными сбоями, форс-мажором и иными
+              обстоятельствами вне её разумного контроля. Ответственность
+              платформы, если применимыми обязательными нормами не установлено
+              иное, ограничивается размером фактически удержанного платформой
+              сервисного вознаграждения по соответствующему заказу.
+            </p>
+          </CardContent>
+        </Card>
+
+        <Card id="data" className="border-border bg-card scroll-mt-24">
+          <CardHeader className="space-y-1">
+            <CardTitle className="text-base">
+              8. Персональные данные и приватность
+            </CardTitle>
+          </CardHeader>
+          <CardContent className="space-y-3 text-sm leading-[1.65] text-muted-foreground">
+            <p>
+              Обработка персональных данных осуществляется в соответствии с{" "}
+              <a
+                href="/policies/privacy"
+                className="underline underline-offset-4"
+              >
+                Политикой конфиденциальности
+              </a>{" "}
+              и{" "}
+              <a
+                href="/policies/terms"
+                className="underline underline-offset-4"
+              >
+                Пользовательским соглашением
+              </a>
+              . Стороны обмениваются только теми данными, которые необходимы для
+              оформления и исполнения заказа.
+            </p>
+          </CardContent>
+        </Card>
+
+        <Card id="final" className="border-border bg-card scroll-mt-24">
+          <CardHeader className="space-y-1">
+            <CardTitle className="text-base">9. Статус документа</CardTitle>
+          </CardHeader>
+          <CardContent className="space-y-3 text-sm leading-[1.65] text-muted-foreground">
+            <p>
+              Настоящий документ является проектом и носит информационный
+              характер. Обязывающая редакция публичной оферты вступает в силу
+              после финальной юридической проверки и до запуска приёма платежей.
+              По вопросам документа пишите на{" "}
+              <a
+                href="mailto:support@provodnik.app"
+                className="underline underline-offset-4"
+              >
+                support@provodnik.app
+              </a>
+              .
+            </p>
+          </CardContent>
+        </Card>
+      </div>
+    </div>
+  );
+}

--- a/src/app/(site)/trust/page.tsx
+++ b/src/app/(site)/trust/page.tsx
@@ -115,7 +115,7 @@ export default function TrustPage() {
 
         <div className="mt-10">
           <Button asChild size="lg">
-            <Link href="/listings">Смотреть экскурсии</Link>
+            <Link href="/guides">Смотреть гидов</Link>
           </Button>
         </div>
       </div>

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -1,6 +1,7 @@
 import type { MetadataRoute } from "next";
 
 import { hasSupabaseAdminEnv } from "@/lib/env";
+import { flags } from "@/lib/flags";
 import { createSupabaseAdminClient } from "@/lib/supabase/admin";
 
 const BASE_URL = "https://provodnik.app";
@@ -25,11 +26,19 @@ function buildEntry(
 }
 
 export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
+  // The public excursions/destinations catalog is hidden per the Wildberries
+  // review; when it is off we must not advertise those routes in the sitemap.
+  const catalogPublic = flags.FEATURE_PUBLIC_CATALOG;
+
   const entries: MetadataRoute.Sitemap = [
     buildEntry("/", 1.0, "weekly"),
     buildEntry("/ai", 0.9, "weekly"),
-    buildEntry("/destinations", 0.9, "weekly"),
-    buildEntry("/listings", 0.9, "daily"),
+    ...(catalogPublic
+      ? [
+          buildEntry("/destinations", 0.9, "weekly"),
+          buildEntry("/listings", 0.9, "daily"),
+        ]
+      : []),
     buildEntry("/guides", 0.9, "weekly"),
     buildEntry("/requests", 0.8, "daily"),
     buildEntry("/trust", 0.5, "monthly"),
@@ -64,7 +73,7 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
           .eq("status", "open"),
       ]);
 
-    if (!destinationsResult.error) {
+    if (catalogPublic && !destinationsResult.error) {
       entries.push(
         ...(destinationsResult.data ?? []).map((destination) =>
           buildEntry(
@@ -77,7 +86,7 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
       );
     }
 
-    if (!listingsResult.error) {
+    if (catalogPublic && !listingsResult.error) {
       entries.push(
         ...(listingsResult.data ?? []).map((listing) =>
           buildEntry(

--- a/src/features/homepage-classic/components/homepage-hero-form-classic.tsx
+++ b/src/features/homepage-classic/components/homepage-hero-form-classic.tsx
@@ -34,10 +34,6 @@ export function HomepageHeroFormClassic({ destinations }: Props) {
         <div className="w-full max-w-lg rounded-hero bg-surface p-5 text-left shadow-lift">
           <HomepageRequestFormClassic destinations={destinations} />
         </div>
-
-        <p className="mt-4 text-sm font-medium text-white/80">
-          Бесплатно · без регистрации · гиды обычно отвечают в течение дня
-        </p>
       </div>
 
       <div className="absolute bottom-6 left-1/2 z-[2] flex -translate-x-1/2 flex-col items-center gap-1.5 text-xs font-semibold tracking-wider text-white/75">

--- a/src/features/homepage-classic/components/homepage-request-form-classic.date.test.tsx
+++ b/src/features/homepage-classic/components/homepage-request-form-classic.date.test.tsx
@@ -1,0 +1,20 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+import { DateField } from "./homepage-request-form-classic";
+
+// WB-017 / #9: after a date is picked the trigger must show the formatted
+// Russian date, not the «Когда» placeholder.
+describe("DateField display", () => {
+  it("shows the «Когда» placeholder when no date is selected", () => {
+    render(<DateField value="" onChange={vi.fn()} />);
+    expect(screen.getByText("Когда")).toBeInTheDocument();
+  });
+
+  it("shows the formatted Russian date once a date is selected", () => {
+    render(<DateField value="2026-08-15" onChange={vi.fn()} />);
+    expect(screen.getByText("15 августа")).toBeInTheDocument();
+    // The placeholder text node must be gone (the aria-label stays "Когда").
+    expect(screen.queryByText("Когда")).not.toBeInTheDocument();
+  });
+});

--- a/src/features/homepage-classic/components/homepage-request-form-classic.tsx
+++ b/src/features/homepage-classic/components/homepage-request-form-classic.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import * as React from "react";
-import type { UseFormRegisterReturn } from "react-hook-form";
+import { useWatch, type UseFormRegisterReturn } from "react-hook-form";
 import { ru } from "date-fns/locale";
 import {
   Calendar as CalendarIcon,
@@ -127,7 +127,7 @@ function dateToISO(d: Date): string {
 }
 
 /** Custom date field — a calendar popover (Russian, no native widget jitter). */
-function DateField({
+export function DateField({
   value,
   onChange,
   min,
@@ -193,7 +193,7 @@ export function HomepageRequestFormClassic({ destinations }: Props) {
     serverError,
     isLoading,
   } = useRequestForm();
-  const startDate = form.watch("startDate");
+  const startDate = useWatch({ control: form.control, name: "startDate" });
 
   return (
     <TooltipProvider delayDuration={150}>

--- a/src/features/homepage-classic/components/homepage-shell2-classic.tsx
+++ b/src/features/homepage-classic/components/homepage-shell2-classic.tsx
@@ -1,4 +1,3 @@
-import { DestinationTile } from "@/components/shared/destination-tile";
 import { OpenGroupCard } from "@/components/shared/open-group-card";
 import { SectionHeading } from "@/components/shared/section-heading";
 import { SiteFooter } from "@/components/shared/site-footer";
@@ -11,8 +10,6 @@ import { HomepageHeroFormClassic } from "./homepage-hero-form-classic";
 interface Props {
   destinations: DestinationOption[];
   requests: RequestRecord[];
-  /** Destination name (lowercased) → catalog slug, for deep-linking tiles. */
-  destinationSlugs?: Record<string, string>;
 }
 
 const HOW_IT_WORKS = [
@@ -26,9 +23,8 @@ const HOW_IT_WORKS = [
 
 const SECTION = "mx-auto w-full max-w-page px-gutter";
 
-export function HomePageShell2Classic({ destinations, requests, destinationSlugs = {} }: Props) {
+export function HomePageShell2Classic({ destinations, requests }: Props) {
   const openGroups = requests.slice(0, 3);
-  const popularDestinations = destinations.slice(0, 6);
 
   return (
     <>
@@ -66,29 +62,6 @@ export function HomePageShell2Classic({ destinations, requests, destinationSlugs
                   participantCount={req.groupSize}
                   price={req.budgetRub ? `${formatRubNumber(req.budgetRub)} ₽ / чел` : undefined}
                   priority={index === 0}
-                />
-              );
-            })}
-          </div>
-        </section>
-      )}
-
-      {popularDestinations.length > 0 && (
-        <section className={`${SECTION} pb-6 pt-8`} aria-label="Популярные направления">
-          <SectionHeading
-            title="Популярные направления"
-            action={{ label: "Все направления", href: "/destinations" }}
-          />
-          <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
-            {popularDestinations.map((d) => {
-              const slug = destinationSlugs[d.name.trim().toLowerCase()];
-              return (
-                <DestinationTile
-                  key={`${d.name}-${d.region}`}
-                  href={slug ? `/destinations/${slug}` : `/listings?q=${encodeURIComponent(d.name)}`}
-                  name={d.name}
-                  imageUrl={cityImage(d.name)}
-                  guidesCount={d.guideCount}
                 />
               );
             })}

--- a/src/lib/flags.test.ts
+++ b/src/lib/flags.test.ts
@@ -17,6 +17,7 @@ describe("flags registry", () => {
       "FEATURE_TR_QUIZ",
       "FEATURE_TR_DISPUTES",
       "FEATURE_DEPOSITS",
+      "FEATURE_PUBLIC_CATALOG",
     ];
     expect(subs).toEqual(Object.keys(flags));
     for (const k of subs) {

--- a/src/lib/flags.ts
+++ b/src/lib/flags.ts
@@ -16,6 +16,9 @@ const flagsSchema = z.object({
   FEATURE_TR_QUIZ: envFlag,
   FEATURE_TR_DISPUTES: envFlag,
   FEATURE_DEPOSITS: envFlag,
+  // Public excursions/destinations catalog. Hidden per Wildberries review:
+  // /listings & /destinations are inaccessible (404) unless this is set to "1".
+  FEATURE_PUBLIC_CATALOG: envFlag,
 });
 
 const env = (k: string): string | undefined =>
@@ -35,6 +38,7 @@ const rawFlags = {
   FEATURE_TR_QUIZ: env("FEATURE_TR_QUIZ"),
   FEATURE_TR_DISPUTES: env("FEATURE_TR_DISPUTES"),
   FEATURE_DEPOSITS: env("FEATURE_DEPOSITS"),
+  FEATURE_PUBLIC_CATALOG: env("FEATURE_PUBLIC_CATALOG"),
 };
 
 const parsed = flagsSchema.parse(rawFlags);
@@ -53,6 +57,7 @@ export const flags = {
   FEATURE_TR_QUIZ: parsed.FEATURE_TR_QUIZ === "1",
   FEATURE_TR_DISPUTES: parsed.FEATURE_TR_DISPUTES === "1",
   FEATURE_DEPOSITS: parsed.FEATURE_DEPOSITS === "1",
+  FEATURE_PUBLIC_CATALOG: parsed.FEATURE_PUBLIC_CATALOG === "1",
 } as const;
 
 export type FlagName = keyof typeof flags;

--- a/src/lib/navigation.test.ts
+++ b/src/lib/navigation.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 
 import {
   adminAccountMenu,
+  adminHeaderNav,
   adminPrimaryNav,
   filterNavItemsByHiddenHrefs,
   footerNav,
@@ -10,6 +11,7 @@ import {
   hiddenNavHrefsForFlags,
   mobileBottomNavByRole,
   NAV_FLAG_BY_HREF,
+  publicPrimaryNav,
   travelerAccountMenu,
   travelerPrimaryNav,
 } from "@/lib/navigation";
@@ -118,18 +120,43 @@ describe("role-based nav groups", () => {
   });
 
   it("keeps the traveler primary nav focused on marketplace + trips", () => {
+    // The public catalog surfaces (/listings «Экскурсии», /destinations
+    // «Направления») are hidden per the Wildberries review, so discovery flows
+    // through requests + guides instead.
     expect(travelerPrimaryNav.map((item) => item.href)).toEqual([
       "/requests",
-      "/listings",
-      "/destinations",
+      "/guides",
       "/trips",
     ]);
     expect(travelerPrimaryNav.map((item) => item.label)).toEqual([
       "Запросы",
-      "Экскурсии",
-      "Направления",
+      "Гиды",
       "Мои поездки",
     ]);
+  });
+
+  it("hides the public catalog surfaces from every non-workspace nav", () => {
+    // Wildberries review: «Экскурсии» (/listings) and «Направления»
+    // (/destinations) must not surface in public/traveler/admin-header nav —
+    // no href and no label. Guide/admin *workspace* listing management keeps its
+    // own internal «Экскурсии»/«Листинги» labels and is intentionally excluded.
+    const HIDDEN_HREFS = ["/listings", "/destinations"];
+    const HIDDEN_LABELS = ["Экскурсии", "Направления"];
+
+    for (const nav of [publicPrimaryNav, travelerPrimaryNav, adminHeaderNav]) {
+      const hrefs = nav.map((item) => item.href);
+      const labels = nav.map((item) => item.label);
+      for (const href of HIDDEN_HREFS) expect(hrefs).not.toContain(href);
+      for (const label of HIDDEN_LABELS) expect(labels).not.toContain(label);
+    }
+
+    // Footer legal/support/about groups must not link the hidden catalog either.
+    const footerHrefs = [
+      ...footerNav.about,
+      ...footerNav.support,
+      ...footerNav.legal,
+    ].map((item) => item.href);
+    for (const href of HIDDEN_HREFS) expect(footerHrefs).not.toContain(href);
   });
 
   it("uses the simplified guide workspace labels", () => {

--- a/src/lib/navigation.ts
+++ b/src/lib/navigation.ts
@@ -65,14 +65,21 @@ const adminBridge: NavItem = { ...ROUTES.adminDashboard, label: "Админка"
 // matching grouped export below so a role's nav is defined in exactly one place.
 // ---------------------------------------------------------------------------
 
-/** Anonymous / public marketplace discovery (max 5 items). */
+/**
+ * Anonymous / public marketplace discovery (max 5 items).
+ *
+ * The public «Экскурсии» (/listings) and «Направления» (/destinations) catalog
+ * surfaces are hidden per the Wildberries review: they carry no nav entry and
+ * their routes are inaccessible unless `FEATURE_PUBLIC_CATALOG` is re-enabled.
+ * Discovery flows through requests + guides instead.
+ */
 export const publicPrimaryNav = [
-  ROUTES.requests, ROUTES.listings, ROUTES.guides, ROUTES.destinations, ROUTES.howItWorks,
+  ROUTES.requests, ROUTES.guides, ROUTES.howItWorks,
 ] as const;
 
-/** Traveler: marketplace + personal trips. */
+/** Traveler: marketplace discovery + personal trips (catalog surfaces hidden). */
 export const travelerPrimaryNav = [
-  ROUTES.requests, ROUTES.listings, ROUTES.destinations, ROUTES.trips,
+  ROUTES.requests, ROUTES.guides, ROUTES.trips,
 ] as const;
 
 /** Guide workspace (also drives the mobile bottom nav). */
@@ -93,7 +100,7 @@ export const adminPrimaryNav = [
  * sidebar at desktop widths.
  */
 export const adminHeaderNav = [
-  ROUTES.requests, ROUTES.guides, ROUTES.destinations, adminBridge,
+  ROUTES.requests, ROUTES.guides, adminBridge,
 ] as const;
 
 /** Visible top-header nav per authenticated role (anon handled separately). */
@@ -148,6 +155,7 @@ export const footerNav = {
             { href: "mailto:support@provodnik.app", label: "Email: support@provodnik.app", icon: MessageSquare } as NavItem],
   legal:   [
     { href: "/policies/terms",   label: "Условия использования", icon: ScrollText } as NavItem,
+    { href: "/policies/offer",   label: "Публичная оферта",      icon: ScrollText } as NavItem,
     { href: "/policies/privacy", label: "Конфиденциальность",    icon: ScrollText } as NavItem,
     { href: "/policies/cookies", label: "Cookies",               icon: ScrollText } as NavItem,
   ],


### PR DESCRIPTION
Fixes remaining actionable Wildberries Excel review items: hides public catalog/routes, repairs homepage date display, adds guide auth home link, adds legal offer draft route, updates state.json, and adds tests.\n\nVerification:\n- bun run typecheck\n- bun run lint\n- bun run test:run (1112 passed)\n- NEXT_TELEMETRY_DISABLED=1 bun run build\n- Playwright local smoke for date display, hidden catalog, guide auth home link, offer route