### PR TITLE
Fix approved guide public visibility

### DIFF
--- a/src/app/(protected)/admin/guides/[id]/actions.ts
+++ b/src/app/(protected)/admin/guides/[id]/actions.ts
@@ -31,6 +31,8 @@ export async function approveGuide(
     revalidatePath("/admin/dashboard");
     revalidatePath("/admin/guides");
     revalidatePath(`/admin/guides/${guideId}`);
+    revalidatePath("/guides");
+    revalidatePath("/destinations");
     return { error: null, success: "Гид одобрен" };
   } catch (err) {
     return { error: err instanceof Error ? err.message : "Неизвестная ошибка при одобрении" };

--- a/src/app/(protected)/admin/guides/page.tsx
+++ b/src/app/(protected)/admin/guides/page.tsx
@@ -124,6 +124,8 @@ async function approveGuideAction(guideId: string) {
   revalidatePath("/admin/dashboard");
   revalidatePath("/admin/guides");
   revalidatePath(`/admin/guides/${guideId}`);
+  revalidatePath("/guides");
+  revalidatePath("/destinations");
 }
 
 async function rejectGuideAction(guideId: string) {
@@ -140,6 +142,8 @@ async function rejectGuideAction(guideId: string) {
   revalidatePath("/admin/dashboard");
   revalidatePath("/admin/guides");
   revalidatePath(`/admin/guides/${guideId}`);
+  revalidatePath("/guides");
+  revalidatePath("/destinations");
 }
 
 export default async function AdminGuidesPage({

--- a/src/data/supabase/queries.test.ts
+++ b/src/data/supabase/queries.test.ts
@@ -130,8 +130,8 @@ function createFakeClient(fixtures: FixtureMap = {}, errors: ErrorMap = {}): Fak
       calls.push(`from:${table}`);
       return new FakeQuery(calls, fixtures, errors, table);
     },
-    rpc(name: string) {
-      calls.push(`rpc:${name}`);
+    rpc(name: string, args?: unknown) {
+      calls.push(`rpc:${name}:${JSON.stringify(args ?? {})}`);
       const error = errors[`rpc:${name}`] ?? null;
       return Promise.resolve({ data: error ? null : (fixtures[`rpc:${name}`] ?? []), error });
     },
@@ -469,7 +469,7 @@ describe("guide stats layering (no fabricated zeros)", () => {
     expect(result.data?.responseRate).toBeNull();
   });
 
-  it("layers real view stats and approved verification onto getGuidesByDestination", async () => {
+  it("includes approved guides in destination blocks even before they have listings", async () => {
     const client = createFakeClient({
       "rpc:search_guides": [
         {
@@ -490,6 +490,35 @@ describe("guide stats layering (no fabricated zeros)", () => {
     expect(result.error).toBeNull();
     expect(result.data?.[0]?.rating).toBe(4.9);
     expect(result.data?.[0]?.verified).toBe(true);
+    expect(client.calls).toContain(
+      'rpc:search_guides:{"q":"","p_region":"Москва","p_has_listings":false}',
+    );
+  });
+
+  it("includes approved guides in public guide search even before they have listings", async () => {
+    const client = createFakeClient({
+      "rpc:search_guides": [
+        {
+          user_id: "guide-1",
+          slug: "guide-1",
+          display_name: "Иван Гид",
+          regions: ["Москва"],
+          verification_status: "approved",
+        },
+      ],
+      profiles: [],
+      listings: [],
+      v_guide_public_profile: [],
+    });
+
+    const result = await getGuides(client, { q: "Иван" });
+
+    expect(result.error).toBeNull();
+    expect(result.data?.[0]?.fullName).toBe("Иван Гид");
+    expect(result.data?.[0]?.listingCount).toBe(0);
+    expect(client.calls).toContain(
+      'rpc:search_guides:{"q":"Иван","p_specializations":null,"p_has_listings":false}',
+    );
   });
 });
 

--- a/src/data/supabase/queries.ts
+++ b/src/data/supabase/queries.ts
@@ -318,13 +318,14 @@ export async function getGuides(
   filters?: GuideFilters,
 ): Promise<QueryResult<GuideRecord[]>> {
   try {
-    // OPT-001: Push specializations + has_listings filter server-side
+    // Public guide discovery must include approved/available guides even before
+    // they publish their first route. Listing counts are layered below.
     const { data: searchRows, error } = await client.rpc("search_guides", {
       q: filters?.q ?? "",
       p_specializations: (filters?.specializations && filters.specializations.length > 0)
         ? filters.specializations
         : null,
-      p_has_listings: true,
+      p_has_listings: false,
     });
 
     if (error) throw error;
@@ -411,11 +412,12 @@ export async function getGuidesByDestination(
   region: string,
 ): Promise<QueryResult<GuideRecord[]>> {
   try {
-    // OPT-001: Push region filter + has_listings server-side
+    // Destination guide blocks should also surface approved guides that have not
+    // published listings yet.
     const { data: searchRows, error } = await client.rpc("search_guides", {
       q: "",
       p_region: region,
-      p_has_listings: true,
+      p_has_listings: false,
     });
 
     if (error) throw error;

--- a/src/lib/supabase/moderation.ts
+++ b/src/lib/supabase/moderation.ts
@@ -605,6 +605,17 @@ export async function ensureOpenModerationCase(input: {
   return createModerationCase(input);
 }
 
+function slugifyGuideProfileName(value: string | null | undefined, guideId: string) {
+  const base = (value ?? "")
+    .normalize("NFKD")
+    .toLowerCase()
+    .replace(/[^\p{L}\p{N}]+/gu, "-")
+    .replace(/^-+|-+$/g, "")
+    .slice(0, 56);
+  const suffix = guideId.replace(/-/g, "").slice(0, 8);
+  return `${base || "guide"}-${suffix}`;
+}
+
 export async function performModerationAction(
   caseId: string,
   adminId: string,
@@ -650,11 +661,31 @@ export async function performModerationAction(
 
   if (moderationCase.subject_type === "guide_profile" && moderationCase.guide_id) {
     if (input.decision === "approve" || input.decision === "reject") {
+      const nextVerificationStatus = input.decision === "approve" ? "approved" : "rejected";
+      const updatePayload: Record<string, unknown> = {
+        verification_status: nextVerificationStatus,
+        is_available: input.decision === "approve",
+      };
+
+      if (input.decision === "approve") {
+        const { data: guideProfile, error: guideProfileError } = await adminClient
+          .from("guide_profiles")
+          .select("slug, display_name")
+          .eq("user_id", moderationCase.guide_id)
+          .maybeSingle();
+
+        if (guideProfileError) throw guideProfileError;
+        if (!guideProfile?.slug) {
+          updatePayload.slug = slugifyGuideProfileName(
+            guideProfile?.display_name as string | null | undefined,
+            moderationCase.guide_id,
+          );
+        }
+      }
+
       const { error } = await adminClient
         .from("guide_profiles")
-        .update({
-          verification_status: input.decision === "approve" ? "approved" : "rejected",
-        })
+        .update(updatePayload)
         .eq("user_id", moderationCase.guide_id);
 
       if (error) throw error;

--- a/supabase/migrations/20260702000001_publish_approved_guides.sql
+++ b/supabase/migrations/20260702000001_publish_approved_guides.sql
@@ -1,0 +1,24 @@
+-- Approved guide profiles must be public-searchable immediately after admin verification.
+-- Historical approvals only set verification_status, leaving is_available=false and slug=null;
+-- search_guides filters those rows out and slug-null cards cannot resolve to detail pages.
+
+update public.guide_profiles gp
+set
+  is_available = true,
+  slug = coalesce(
+    nullif(gp.slug, ''),
+    concat(
+      coalesce(
+        nullif(
+          trim(both '-' from lower(regexp_replace(coalesce(gp.display_name, 'guide'), '[^[:alnum:]]+', '-', 'g'))),
+          ''
+        ),
+        'guide'
+      ),
+      '-',
+      left(replace(gp.user_id::text, '-', ''), 8)
+    )
+  ),
+  updated_at = now()
+where gp.verification_status = 'approved'
+  and (gp.is_available is distinct from true or gp.slug is null or gp.slug = '');


### PR DESCRIPTION
## Summary
- make public guide search/destination guide blocks include approved guides before first listing
- publish guide profiles on admin approval by setting availability and stable slug
- backfill existing approved guides so they become searchable and detail links resolve

## Verification
- bun run typecheck
- bun run lint
- bun run test:run (227 files / 1113 tests)
- NEXT_TELEMETRY_DISABLED=1 bun run build