### PR TITLE
Fix guide detail links from public guide cards

### DIFF
--- a/src/data/supabase/queries.test.ts
+++ b/src/data/supabase/queries.test.ts
@@ -76,8 +76,8 @@ class FakeQuery {
     return this;
   }
 
-  in() {
-    this.calls.push(`${this.table}.in`);
+  in(column?: string, values?: unknown[]) {
+    this.calls.push(`${this.table}.in:${column ?? ""}:${JSON.stringify(values ?? [])}`);
     return this;
   }
 
@@ -445,6 +445,32 @@ describe("guide stats layering (no fabricated zeros)", () => {
     expect(result.data?.reviewCount).toBe(8);
     expect(result.data?.responseRate).toBe(91);
     expect(result.data?.verified).toBe(true);
+  });
+
+  it("resolves public guide detail when Next passes an encoded slug", async () => {
+    const client = createFakeClient({
+      guide_profiles: [
+        {
+          user_id: "guide-1",
+          slug: "жюль-верников-69f18040",
+          display_name: "Жюль Верников",
+          regions: ["Волгоградская область"],
+          verification_status: "approved",
+        },
+      ],
+      v_guide_public_profile: [],
+    });
+
+    const result = await getGuideBySlug(
+      client,
+      "%D0%B6%D1%8E%D0%BB%D1%8C-%D0%B2%D0%B5%D1%80%D0%BD%D0%B8%D0%BA%D0%BE%D0%B2-69f18040",
+    );
+
+    expect(result.error).toBeNull();
+    expect(result.data?.fullName).toBe("Жюль Верников");
+    expect(client.calls).toContain(
+      'guide_profiles.in:slug:["%D0%B6%D1%8E%D0%BB%D1%8C-%D0%B2%D0%B5%D1%80%D0%BD%D0%B8%D0%BA%D0%BE%D0%B2-69f18040","жюль-верников-69f18040"]',
+    );
   });
 
   it("keeps getGuideBySlug unverified with null responseRate when stats are absent", async () => {

--- a/src/data/supabase/queries.ts
+++ b/src/data/supabase/queries.ts
@@ -467,15 +467,37 @@ export async function getGuidesByDestination(
   }
 }
 
+function getSlugLookupCandidates(slug: string): string[] {
+  const candidates = new Set<string>();
+  const add = (value: string) => {
+    if (!value) return;
+    candidates.add(value);
+    candidates.add(value.normalize("NFC"));
+    candidates.add(value.normalize("NFKD"));
+  };
+
+  add(slug);
+
+  try {
+    add(decodeURIComponent(slug));
+  } catch {
+    // The route param can already be decoded; ignore malformed percent escapes.
+  }
+
+  return Array.from(candidates);
+}
+
 export async function getGuideBySlug(
   client: SupabaseClient,
   slug: string,
 ): Promise<QueryResult<GuideRecord>> {
   try {
+    const slugCandidates = getSlugLookupCandidates(slug);
     const { data, error } = await client
       .from("guide_profiles")
       .select("*, profiles!guide_profiles_user_id_fkey(id, full_name, avatar_url)")
-      .eq("slug", slug)
+      .in("slug", slugCandidates)
+      .limit(1)
       .maybeSingle();
 
     if (error) throw error;


### PR DESCRIPTION
## Summary
- resolve guide detail pages when the route slug arrives URL-encoded
- keep canonical/cyrillic slug matching stable via normalized lookup candidates
- add regression coverage for encoded public guide slugs

## Verification
- bun run test:run src/data/supabase/queries.test.ts
- bun run typecheck
- bun run lint
- bun run test:run
- NEXT_TELEMETRY_DISABLED=1 bun run build
- local production click from /guides to Жюль Верников opens guide profile, not 404