### PR TITLE
Fix suspended guide lockout enforcement

### DIFF
--- a/src/app/(protected)/guide/layout.tsx
+++ b/src/app/(protected)/guide/layout.tsx
@@ -17,6 +17,10 @@ export default async function GuideLayout({
     redirect("/auth?next=/guide/inbox");
   }
 
+  if (auth.accountStatus && auth.accountStatus !== "active") {
+    redirect("/auth?error=account-suspended");
+  }
+
   if (!auth.role) {
     redirect(auth.missingRoleRecoveryTo ?? "/auth?error=missing-role");
   }

--- a/src/app/(protected)/layout.tsx
+++ b/src/app/(protected)/layout.tsx
@@ -1,12 +1,20 @@
 import { Suspense, type ReactNode } from "react";
+import { redirect } from "next/navigation";
 
 import { SiteHeaderServer } from "@/components/shared/site-header-server";
+import { readAuthContextFromServer } from "@/lib/auth/server-auth";
 
 export default async function ProtectedLayout({
   children,
 }: {
   children: ReactNode;
 }) {
+  const auth = await readAuthContextFromServer();
+
+  if (auth.isAuthenticated && auth.accountStatus && auth.accountStatus !== "active") {
+    redirect("/auth?error=account-suspended");
+  }
+
   return (
     <div className="min-h-screen pt-[88px]">
       <SiteHeaderServer />

--- a/src/app/(protected)/role-layouts.test.tsx
+++ b/src/app/(protected)/role-layouts.test.tsx
@@ -31,6 +31,7 @@ function makeAuthContext(overrides: Partial<AuthContext>): AuthContext {
     isAuthenticated: true,
     source: "supabase",
     role: "guide",
+    accountStatus: "active",
     email: "guide@example.com",
     fullName: null,
     avatarUrl: null,
@@ -82,6 +83,40 @@ describe("protected role layouts", () => {
     ).rejects.toThrow("NEXT_REDIRECT:/auth?error=missing-role");
 
     expect(redirectMock).toHaveBeenCalledWith("/auth?error=missing-role");
+    expect(screen.queryByText("Trips workspace")).not.toBeInTheDocument();
+  });
+
+  it("redirects suspended guide sessions without rendering children", async () => {
+    readAuthContextFromServerMock.mockResolvedValueOnce(
+      makeAuthContext({ accountStatus: "suspended" }),
+    );
+
+    await expect(
+      GuideLayout({
+        children: <div>Guide workspace</div>,
+      }),
+    ).rejects.toThrow("NEXT_REDIRECT:/auth?error=account-suspended");
+
+    expect(redirectMock).toHaveBeenCalledWith("/auth?error=account-suspended");
+    expect(screen.queryByText("Guide workspace")).not.toBeInTheDocument();
+  });
+
+  it("redirects archived traveler sessions without rendering children", async () => {
+    readAuthContextFromServerMock.mockResolvedValueOnce(
+      makeAuthContext({
+        role: "traveler",
+        accountStatus: "archived",
+        canonicalRedirectTo: "/trips",
+      }),
+    );
+
+    await expect(
+      TripsLayout({
+        children: <div>Trips workspace</div>,
+      }),
+    ).rejects.toThrow("NEXT_REDIRECT:/auth?error=account-suspended");
+
+    expect(redirectMock).toHaveBeenCalledWith("/auth?error=account-suspended");
     expect(screen.queryByText("Trips workspace")).not.toBeInTheDocument();
   });
 

--- a/src/app/(protected)/trips/layout.tsx
+++ b/src/app/(protected)/trips/layout.tsx
@@ -15,6 +15,10 @@ export default async function TripsLayout({
     redirect("/auth?next=/trips");
   }
 
+  if (auth.accountStatus && auth.accountStatus !== "active") {
+    redirect("/auth?error=account-suspended");
+  }
+
   if (!auth.role) {
     redirect(auth.missingRoleRecoveryTo ?? "/auth?error=missing-role");
   }

--- a/src/app/(site)/requests/[requestId]/page.tsx
+++ b/src/app/(site)/requests/[requestId]/page.tsx
@@ -251,12 +251,20 @@ async function getGuideDetailData(requestId: string, guideId: string | null) {
   let existingOffer: GuideOfferRow | null = null;
 
   if (guideId) {
-    const { data: profile } = await supabase
-      .from("guide_profiles")
-      .select("verification_status")
-      .eq("user_id", guideId)
-      .maybeSingle();
-    isApproved = profile?.verification_status === "approved";
+    const [{ data: profile }, { data: account }] = await Promise.all([
+      supabase
+        .from("guide_profiles")
+        .select("verification_status")
+        .eq("user_id", guideId)
+        .maybeSingle(),
+      supabase
+        .from("profiles")
+        .select("account_status")
+        .eq("id", guideId)
+        .maybeSingle(),
+    ]);
+    const isActiveAccount = !account?.account_status || account.account_status === "active";
+    isApproved = isActiveAccount && profile?.verification_status === "approved";
 
     const { data: offer } = await supabase
       .from("guide_offers")

--- a/src/features/guide/offer-actions.test.ts
+++ b/src/features/guide/offer-actions.test.ts
@@ -92,12 +92,19 @@ describe("checkOfferAgainstLocks", () => {
 
 describe("submitOfferAction", () => {
   it("rejects unverified guide profiles before submitting an offer", async () => {
-    const maybeSingle = vi.fn().mockResolvedValue({
+    const guideMaybeSingle = vi.fn().mockResolvedValue({
       data: { verification_status: "draft" },
     });
-    const eq = vi.fn().mockReturnValue({ maybeSingle });
-    const select = vi.fn().mockReturnValue({ eq });
-    const from = vi.fn().mockReturnValue({ select });
+    const guideEq = vi.fn().mockReturnValue({ maybeSingle: guideMaybeSingle });
+    const guideSelect = vi.fn().mockReturnValue({ eq: guideEq });
+    const profileMaybeSingle = vi.fn().mockResolvedValue({ data: { account_status: "active" } });
+    const profileEq = vi.fn().mockReturnValue({ maybeSingle: profileMaybeSingle });
+    const profileSelect = vi.fn().mockReturnValue({ eq: profileEq });
+    const from = vi.fn((table: string) => {
+      if (table === "profiles") return { select: profileSelect };
+      if (table === "guide_profiles") return { select: guideSelect };
+      throw new Error(`unexpected table ${table}`);
+    });
 
     createSupabaseServerClientMock.mockResolvedValue({
       auth: {
@@ -112,31 +119,59 @@ describe("submitOfferAction", () => {
     const result = await submitOfferAction("request-1", new FormData());
 
     expect(result).toEqual({ error: "Доступно после верификации" });
+    expect(from).toHaveBeenCalledWith("profiles");
     expect(from).toHaveBeenCalledWith("guide_profiles");
-    expect(eq).toHaveBeenCalledWith("user_id", "guide-1");
+    expect(guideEq).toHaveBeenCalledWith("user_id", "guide-1");
+  });
+
+  it("rejects suspended guide accounts before submitting an offer", async () => {
+    const profileMaybeSingle = vi.fn().mockResolvedValue({ data: { account_status: "suspended" } });
+    const profileEq = vi.fn().mockReturnValue({ maybeSingle: profileMaybeSingle });
+    const profileSelect = vi.fn().mockReturnValue({ eq: profileEq });
+    const from = vi.fn((table: string) => {
+      if (table === "profiles") return { select: profileSelect };
+      throw new Error(`unexpected table ${table}`);
+    });
+
+    createSupabaseServerClientMock.mockResolvedValue({
+      auth: {
+        getUser: vi.fn().mockResolvedValue({
+          data: { user: { id: "guide-1" } },
+          error: null,
+        }),
+      },
+      from,
+    });
+
+    const result = await submitOfferAction("request-1", new FormData());
+
+    expect(result).toEqual({ error: "Аккаунт заблокирован." });
+    expect(from).not.toHaveBeenCalledWith("guide_profiles");
   });
 });
 
 describe("withdrawOfferAction", () => {
   it("sets a pending owned offer to withdrawn", async () => {
-    const maybeSingle = vi.fn().mockResolvedValue({
+    const offerMaybeSingle = vi.fn().mockResolvedValue({
       data: { id: "offer-1", guide_id: "guide-1", status: "pending", request_id: "req-1" },
     });
-    const selectEq = vi.fn().mockReturnValue({ maybeSingle });
-    const select = vi.fn().mockReturnValue({ eq: selectEq });
-    const selectChain = { select };
+    const offerSelectEq = vi.fn().mockReturnValue({ maybeSingle: offerMaybeSingle });
+    const offerSelect = vi.fn().mockReturnValue({ eq: offerSelectEq });
 
     const update = vi.fn().mockReturnValue({
       eq: vi.fn().mockReturnValue({
         eq: vi.fn().mockResolvedValue({ error: null }),
       }),
     });
-    const updateChain = { update };
 
-    const from = vi
-      .fn()
-      .mockReturnValueOnce(selectChain)
-      .mockReturnValueOnce(updateChain);
+    const profileMaybeSingle = vi.fn().mockResolvedValue({ data: { account_status: "active" } });
+    const profileEq = vi.fn().mockReturnValue({ maybeSingle: profileMaybeSingle });
+    const profileSelect = vi.fn().mockReturnValue({ eq: profileEq });
+    const from = vi.fn((table: string) => {
+      if (table === "profiles") return { select: profileSelect };
+      if (table === "guide_offers") return { select: offerSelect, update };
+      throw new Error(`unexpected table ${table}`);
+    });
 
     createSupabaseServerClientMock.mockResolvedValue({
       auth: {
@@ -159,12 +194,19 @@ describe("withdrawOfferAction", () => {
 
 describe("editOfferAction", () => {
   it("rejects when the offer is not pending", async () => {
-    const maybeSingle = vi.fn().mockResolvedValue({
+    const offerMaybeSingle = vi.fn().mockResolvedValue({
       data: { id: "offer-1", guide_id: "guide-1", status: "accepted", request_id: "req-1" },
     });
-    const selectEq = vi.fn().mockReturnValue({ maybeSingle });
-    const select = vi.fn().mockReturnValue({ eq: selectEq });
-    const from = vi.fn().mockReturnValue({ select });
+    const offerSelectEq = vi.fn().mockReturnValue({ maybeSingle: offerMaybeSingle });
+    const offerSelect = vi.fn().mockReturnValue({ eq: offerSelectEq });
+    const profileMaybeSingle = vi.fn().mockResolvedValue({ data: { account_status: "active" } });
+    const profileEq = vi.fn().mockReturnValue({ maybeSingle: profileMaybeSingle });
+    const profileSelect = vi.fn().mockReturnValue({ eq: profileEq });
+    const from = vi.fn((table: string) => {
+      if (table === "profiles") return { select: profileSelect };
+      if (table === "guide_offers") return { select: offerSelect };
+      throw new Error(`unexpected table ${table}`);
+    });
 
     createSupabaseServerClientMock.mockResolvedValue({
       auth: {

--- a/src/features/guide/offer-actions.ts
+++ b/src/features/guide/offer-actions.ts
@@ -63,7 +63,7 @@ export async function checkOfferAgainstLocks(args: {
   return { ok: true };
 }
 
-async function getCurrentUserId(): Promise<string> {
+async function getCurrentActiveUserId(): Promise<string> {
   const supabase = await createSupabaseServerClient();
   const {
     data: { user },
@@ -71,6 +71,16 @@ async function getCurrentUserId(): Promise<string> {
 
   if (!user?.id) {
     throw new Error("Не авторизован.");
+  }
+
+  const { data: profile } = await supabase
+    .from("profiles")
+    .select("account_status")
+    .eq("id", user.id)
+    .maybeSingle();
+
+  if (profile?.account_status && profile.account_status !== "active") {
+    throw new Error("Аккаунт заблокирован.");
   }
 
   return user.id;
@@ -81,7 +91,7 @@ export async function submitOfferAction(
   formData: FormData,
 ): Promise<SubmitOfferResult> {
   try {
-    const guideId = await getCurrentUserId();
+    const guideId = await getCurrentActiveUserId();
 
     // Verification gate. The enum is draft|submitted|approved|rejected; only
     // 'approved' may submit offers. Mirrored by RLS policy guide_offers_insert.
@@ -227,7 +237,7 @@ export async function withdrawOfferAction(
   requestId: string,
 ): Promise<{ ok: true } | { error: string }> {
   try {
-    const guideId = await getCurrentUserId();
+    const guideId = await getCurrentActiveUserId();
     const supabase = await createSupabaseServerClient();
 
     const { data: offer } = await supabase
@@ -265,7 +275,7 @@ export async function editOfferAction(
   formData: FormData,
 ): Promise<SubmitOfferResult> {
   try {
-    const guideId = await getCurrentUserId();
+    const guideId = await getCurrentActiveUserId();
     const supabase = await createSupabaseServerClient();
 
     const { data: offer } = await supabase

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -82,12 +82,16 @@ export async function proxy(request: NextRequest) {
   // was updated without refreshing the claim (see AP-038).
   const { data: profile, error: profileReadError } = await supabase
     .from("profiles")
-    .select("role")
+    .select("role, account_status")
     .eq("id", user.id)
     .maybeSingle();
 
   if (profileReadError) {
     return applyCookies(redirectTo(request, "/auth?error=missing-role"));
+  }
+
+  if (profile?.account_status && profile.account_status !== "active") {
+    return applyCookies(redirectTo(request, "/auth?error=account-suspended"));
   }
 
   const role: AppRole | null = resolveCanonicalRole({

--- a/supabase/migrations/20260702143000_enforce_active_account_for_guide_offers.sql
+++ b/supabase/migrations/20260702143000_enforce_active_account_for_guide_offers.sql
@@ -1,0 +1,40 @@
+-- Suspended/archived guides must not be able to create or mutate their offers.
+-- Admin status controls already update public.profiles.account_status; enforce it
+-- at the DB boundary too so cached UI/session state cannot bypass the block.
+
+DROP POLICY IF EXISTS "guide_offers_insert" ON public.guide_offers;
+
+CREATE POLICY "guide_offers_insert" ON public.guide_offers
+  FOR INSERT
+  WITH CHECK (
+    (
+      (SELECT auth.uid()) = guide_id
+      AND public.profile_account_status_for(guide_id) = 'active'::public.account_status
+      AND EXISTS (
+        SELECT 1
+        FROM public.guide_profiles gp
+        WHERE gp.user_id = guide_offers.guide_id
+          AND gp.verification_status = 'approved'::public.guide_verification_status
+      )
+    )
+    OR public.is_admin()
+  );
+
+DROP POLICY IF EXISTS "guide_offers_update" ON public.guide_offers;
+
+CREATE POLICY "guide_offers_update" ON public.guide_offers
+  FOR UPDATE
+  USING (
+    (
+      (SELECT auth.uid()) = guide_id
+      AND public.profile_account_status_for(guide_id) = 'active'::public.account_status
+    )
+    OR public.is_admin()
+  )
+  WITH CHECK (
+    (
+      (SELECT auth.uid()) = guide_id
+      AND public.profile_account_status_for(guide_id) = 'active'::public.account_status
+    )
+    OR public.is_admin()
+  );


### PR DESCRIPTION
## Summary
- block suspended/archived accounts from protected workspaces via proxy/layout guards
- block guide offer submit/edit/withdraw for suspended accounts
- hide guide offer eligibility on public request detail when account is blocked
- add DB RLS migration so suspended guides cannot insert/update offers even with stale UI/session state

## Verification
- bun run test:run src/app/\(protected\)/role-layouts.test.tsx src/features/guide/offer-actions.test.ts src/app/\(site\)/requests/\[requestId\]/page.test.tsx
- bun run typecheck && bun run lint
- NEXT_TELEMETRY_DISABLED=1 bun run build
- bun run test:run