### PR TITLE
Fix admin user actions root enforcement

### DIFF
--- a/src/app/(protected)/admin/users/actions.test.ts
+++ b/src/app/(protected)/admin/users/actions.test.ts
@@ -31,6 +31,8 @@ vi.mock("@/lib/supabase/server", () => ({
 vi.mock("next/cache", () => ({ revalidatePath: vi.fn() }));
 
 import {
+  approveGuideAction,
+  bulkAction,
   hardDeleteDemoUserAction,
   setAccountStatusAction,
   setUserRoleAction,
@@ -43,11 +45,33 @@ function makeAdminClient() {
   const deleteUser = vi.fn().mockResolvedValue({ error: null });
   const updateUserById = vi.fn().mockResolvedValue({ error: null });
   const updateEq = vi.fn().mockResolvedValue({ error: null });
-  const from = vi.fn(() => ({ update: vi.fn(() => ({ eq: updateEq })) }));
+  const profileUpdate = vi.fn(() => ({ eq: updateEq }));
+  const guideUpdateEq = vi.fn().mockResolvedValue({ error: null });
+  const guideUpdate = vi.fn(() => ({ eq: guideUpdateEq }));
+  const guideUpsert = vi.fn().mockResolvedValue({ error: null });
+  const guideMaybeSingle = vi.fn().mockResolvedValue({
+    data: { user_id: TARGET_ID, verification_status: "submitted" },
+    error: null,
+  });
+  const guideSelectEq = vi.fn(() => ({ maybeSingle: guideMaybeSingle }));
+  const guideSelect = vi.fn(() => ({ eq: guideSelectEq }));
+  const from = vi.fn((table: string) => {
+    if (table === "guide_profiles") {
+      return { update: guideUpdate, upsert: guideUpsert, select: guideSelect };
+    }
+    return { update: profileUpdate };
+  });
   return {
     client: { auth: { admin: { deleteUser, updateUserById } }, from },
     deleteUser,
     updateUserById,
+    updateEq,
+    profileUpdate,
+    guideUpdate,
+    guideUpdateEq,
+    guideUpsert,
+    guideMaybeSingle,
+    from,
   };
 }
 
@@ -158,5 +182,116 @@ describe("setUserRoleAction", () => {
 
     expect(result.ok).toBe(false);
     expect(updateUserById).not.toHaveBeenCalled();
+  });
+
+  it("creates an inactive draft guide profile when promoting a traveler to guide", async () => {
+    const { client, guideUpsert } = makeAdminClient();
+    mocks.requireAdminSession.mockResolvedValue({ adminId: ADMIN_ID, adminClient: client });
+    mocks.getTargetForGuards.mockResolvedValue({
+      id: TARGET_ID,
+      email: "demo@example.com",
+      role: "traveler",
+      accountStatus: "active",
+    });
+    mocks.countOtherActiveAdmins.mockResolvedValue(2);
+
+    const result = await setUserRoleAction(
+      null,
+      form({ targetUserId: TARGET_ID, role: "guide", reason: "role test" }),
+    );
+
+    expect(result.ok).toBe(true);
+    expect(guideUpsert).toHaveBeenCalledWith(
+      expect.objectContaining({
+        user_id: TARGET_ID,
+        verification_status: "draft",
+        is_available: false,
+      }),
+      { onConflict: "user_id" },
+    );
+  });
+
+  it("removes public availability when demoting a guide", async () => {
+    const { client, guideUpdate, guideUpdateEq } = makeAdminClient();
+    mocks.requireAdminSession.mockResolvedValue({ adminId: ADMIN_ID, adminClient: client });
+    mocks.getTargetForGuards.mockResolvedValue({
+      id: TARGET_ID,
+      email: "guide@example.com",
+      role: "guide",
+      accountStatus: "active",
+    });
+    mocks.countOtherActiveAdmins.mockResolvedValue(2);
+
+    const result = await setUserRoleAction(
+      null,
+      form({ targetUserId: TARGET_ID, role: "traveler", reason: "role test" }),
+    );
+
+    expect(result.ok).toBe(true);
+    expect(guideUpdate).toHaveBeenCalledWith({ is_available: false });
+    expect(guideUpdateEq).toHaveBeenCalledWith("user_id", TARGET_ID);
+  });
+
+  it("rolls back auth and profile role if guide side-effect sync fails", async () => {
+    const { client, guideUpsert, updateUserById, profileUpdate } = makeAdminClient();
+    guideUpsert.mockResolvedValueOnce({ error: { message: "boom" } });
+    mocks.requireAdminSession.mockResolvedValue({ adminId: ADMIN_ID, adminClient: client });
+    mocks.getTargetForGuards.mockResolvedValue({
+      id: TARGET_ID,
+      email: "demo@example.com",
+      role: "traveler",
+      accountStatus: "active",
+    });
+    mocks.countOtherActiveAdmins.mockResolvedValue(2);
+
+    const result = await setUserRoleAction(
+      null,
+      form({ targetUserId: TARGET_ID, role: "guide", reason: "role test" }),
+    );
+
+    expect(result.ok).toBe(false);
+    expect(updateUserById).toHaveBeenLastCalledWith(TARGET_ID, {
+      app_metadata: { role: "traveler" },
+    });
+    expect(profileUpdate).toHaveBeenLastCalledWith({ role: "traveler" });
+  });
+});
+
+describe("guide verification actions from admin users", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("does not approve a suspended guide even if the button/action is invoked", async () => {
+    const { client } = makeAdminClient();
+    mocks.requireAdminSession.mockResolvedValue({ adminId: ADMIN_ID, adminClient: client });
+    mocks.getTargetForGuards.mockResolvedValue({
+      id: TARGET_ID,
+      email: "guide@example.com",
+      role: "guide",
+      accountStatus: "suspended",
+    });
+
+    const result = await approveGuideAction(TARGET_ID, null);
+
+    expect(result.ok).toBe(false);
+    expect(mocks.ensureOpenModerationCase).not.toHaveBeenCalled();
+    expect(mocks.performModerationAction).not.toHaveBeenCalled();
+  });
+
+  it("does not report bulk approve as applied when the guide profile is missing", async () => {
+    const { client, guideMaybeSingle } = makeAdminClient();
+    guideMaybeSingle.mockResolvedValueOnce({ data: null, error: null });
+    mocks.requireAdminSession.mockResolvedValue({ adminId: ADMIN_ID, adminClient: client });
+    mocks.getTargetForGuards.mockResolvedValue({
+      id: TARGET_ID,
+      email: "guide@example.com",
+      role: "guide",
+      accountStatus: "active",
+    });
+
+    const result = await bulkAction(null, form({ action: "approve", userIds: TARGET_ID }));
+
+    expect(result.applied).toBe(0);
+    expect(result.skipped).toBe(1);
+    expect(mocks.ensureOpenModerationCase).not.toHaveBeenCalled();
   });
 });

--- a/src/app/(protected)/admin/users/actions.ts
+++ b/src/app/(protected)/admin/users/actions.ts
@@ -36,6 +36,62 @@ function ok(message: string): AdminActionResult {
   return { ok: true, message };
 }
 
+type AdminClient = Awaited<ReturnType<typeof requireAdminSession>>["adminClient"];
+
+async function syncRoleSideEffects(input: {
+  adminClient: AdminClient;
+  targetId: string;
+  targetEmail: string | null;
+  currentRole: string;
+  nextRole: string;
+}) {
+  if (input.nextRole === "guide") {
+    const fallbackName = input.targetEmail?.split("@")[0]?.trim() || "Гид";
+    const { error } = await input.adminClient.from("guide_profiles").upsert(
+      {
+        user_id: input.targetId,
+        display_name: fallbackName,
+        verification_status: "draft",
+        is_available: false,
+      },
+      { onConflict: "user_id" },
+    );
+    if (error) throw error;
+    return;
+  }
+
+  if (input.currentRole === "guide") {
+    const { error } = await input.adminClient
+      .from("guide_profiles")
+      .update({ is_available: false })
+      .eq("user_id", input.targetId);
+    if (error) throw error;
+  }
+}
+
+async function getGuideActionTarget(adminClient: AdminClient, guideId: string) {
+  const target = await getTargetForGuards(adminClient, guideId);
+  if (!target) return { ok: false as const, reason: "Пользователь не найден." };
+  if (target.role !== "guide") {
+    return { ok: false as const, reason: "Действие доступно только для аккаунта гида." };
+  }
+  if (target.accountStatus !== "active") {
+    return { ok: false as const, reason: "Нельзя проверять анкету заблокированного или архивного аккаунта." };
+  }
+
+  const { data: guideProfile, error } = await adminClient
+    .from("guide_profiles")
+    .select("user_id, verification_status")
+    .eq("user_id", guideId)
+    .maybeSingle();
+  if (error) throw error;
+  if (!guideProfile) {
+    return { ok: false as const, reason: "У пользователя нет анкеты гида." };
+  }
+
+  return { ok: true as const, target, guideProfile };
+}
+
 function revalidateUsers(userId?: string) {
   revalidatePath("/admin/users");
   if (userId) revalidatePath(`/admin/users/${userId}`);
@@ -156,6 +212,24 @@ export async function setUserRoleAction(
       return fail("Не удалось обновить роль в профиле. Изменение отменено.");
     }
 
+    try {
+      await syncRoleSideEffects({
+        adminClient,
+        targetId: target.id,
+        targetEmail: target.email,
+        currentRole: target.role,
+        nextRole: parsed.data.role,
+      });
+    } catch {
+      await Promise.allSettled([
+        adminClient.auth.admin.updateUserById(target.id, {
+          app_metadata: { role: target.role },
+        }),
+        adminClient.from("profiles").update({ role: target.role }).eq("id", target.id),
+      ]);
+      return fail("Не удалось синхронизировать данные роли. Изменение отменено.");
+    }
+
     await logAdminAudit({
       actorId: adminId,
       action: "role.change",
@@ -225,7 +299,10 @@ export async function approveGuideAction(
   _prev: AdminActionResult | null,
 ): Promise<AdminActionResult> {
   try {
-    const { adminId } = await requireAdminSession();
+    const { adminId, adminClient } = await requireAdminSession();
+    const target = await getGuideActionTarget(adminClient, guideId);
+    if (!target.ok) return fail(target.reason);
+
     const moderationCase = await ensureOpenModerationCase({
       subjectType: "guide_profile",
       guideId,
@@ -247,7 +324,10 @@ export async function rejectGuideAction(
 ): Promise<AdminActionResult> {
   const note = typeof formData.get("reason") === "string" ? scrubAdminReason((formData.get("reason") as string).trim()) : "";
   try {
-    const { adminId } = await requireAdminSession();
+    const { adminId, adminClient } = await requireAdminSession();
+    const target = await getGuideActionTarget(adminClient, guideId);
+    if (!target.ok) return fail(target.reason);
+
     const moderationCase = await ensureOpenModerationCase({
       subjectType: "guide_profile",
       guideId,
@@ -310,7 +390,12 @@ export async function bulkAction(
       }
 
       if (action === "approve") {
-        if (target.role !== "guide") {
+        const guideTarget = await getGuideActionTarget(adminClient, userId);
+        if (!guideTarget.ok) {
+          skipped += 1;
+          continue;
+        }
+        if (guideTarget.guideProfile.verification_status === "approved") {
           skipped += 1;
           continue;
         }

--- a/src/data/supabase/queries.ts
+++ b/src/data/supabase/queries.ts
@@ -495,8 +495,12 @@ export async function getGuideBySlug(
     const slugCandidates = getSlugLookupCandidates(slug);
     const { data, error } = await client
       .from("guide_profiles")
-      .select("*, profiles!guide_profiles_user_id_fkey(id, full_name, avatar_url)")
+      .select("*, profiles!guide_profiles_user_id_fkey!inner(id, full_name, avatar_url, role, account_status)")
       .in("slug", slugCandidates)
+      .eq("verification_status", "approved")
+      .eq("is_available", true)
+      .eq("profiles.role", "guide")
+      .eq("profiles.account_status", "active")
       .limit(1)
       .maybeSingle();
 

--- a/supabase/migrations/20260702170000_filter_public_guides_by_account_state.sql
+++ b/supabase/migrations/20260702170000_filter_public_guides_by_account_state.sql
@@ -1,0 +1,120 @@
+-- Public guide discovery must respect admin user-page role/status changes.
+-- A guide profile can remain approved/available historically, but it is public
+-- only while the linked account is still an active guide.
+
+CREATE OR REPLACE FUNCTION "public"."search_guides"("q" "text" DEFAULT ''::"text", "p_specializations" "text"[] DEFAULT NULL::"text"[], "p_region" "text" DEFAULT NULL::"text", "p_has_listings" boolean DEFAULT NULL::boolean) RETURNS SETOF "public"."guide_search_result_row"
+    LANGUAGE "plpgsql" STABLE SECURITY DEFINER
+    SET "search_path" TO 'public'
+    AS $_$
+declare
+  tokens text[] := array[]::text[];
+  raw_part text;
+  cleaned text;
+begin
+  if trim(coalesce(q, '')) = '' then
+    return query
+    select g.*, false::boolean as is_partial_match
+    from public.guide_profiles g
+    join public.profiles p on p.id = g.user_id
+    where g.verification_status = 'approved'
+      and p.role = 'guide'
+      and p.account_status = 'active'
+      and g.is_available = true
+      and (p_specializations is null or g.specializations && p_specializations)
+      and (p_region is null or g.regions @> array[p_region])
+      and (p_has_listings is null or p_has_listings = false or exists (
+        select 1 from public.listings l
+        where l.guide_id = g.user_id and l.status = 'published'
+      ))
+    order by g.created_at desc;
+    return;
+  end if;
+
+  foreach raw_part in array string_to_array(q, ',')
+  loop
+    cleaned := lower(trim(raw_part));
+    if cleaned = '' then continue; end if;
+    if cleaned !~ '^[a-zA-Zа-яА-ЯёЁ0-9 -]+$' then continue; end if;
+    tokens := array_append(tokens, cleaned);
+  end loop;
+
+  if coalesce(array_length(tokens, 1), 0) = 0 then
+    return query
+    select g.*, false::boolean as is_partial_match
+    from public.guide_profiles g
+    join public.profiles p on p.id = g.user_id
+    where g.verification_status = 'approved'
+      and p.role = 'guide'
+      and p.account_status = 'active'
+      and g.is_available = true
+      and (p_specializations is null or g.specializations && p_specializations)
+      and (p_region is null or g.regions @> array[p_region])
+      and (p_has_listings is null or p_has_listings = false or exists (
+        select 1 from public.listings l
+        where l.guide_id = g.user_id and l.status = 'published'
+      ))
+    order by g.created_at desc;
+    return;
+  end if;
+
+  return query
+  with visible as (
+    select g, p.full_name
+    from public.guide_profiles g
+    join public.profiles p on p.id = g.user_id
+    where g.verification_status = 'approved'
+      and p.role = 'guide'
+      and p.account_status = 'active'
+      and g.is_available = true
+      and (p_specializations is null or g.specializations && p_specializations)
+      and (p_region is null or g.regions @> array[p_region])
+      and (p_has_listings is null or p_has_listings = false or exists (
+        select 1 from public.listings l
+        where l.guide_id = g.user_id and l.status = 'published'
+      ))
+  ),
+  strict as (
+    select v.g
+    from visible v
+    where not exists (
+      select 1
+      from unnest(tokens) as tok(token)
+      where not (
+        v.full_name ilike '%' || tok.token || '%'
+        or (v.g).bio ilike '%' || tok.token || '%'
+        or (v.g).base_city ilike '%' || tok.token || '%'
+        or exists (select 1 from unnest((v.g).languages) as lang(value) where lower(lang.value) ilike '%' || tok.token || '%')
+        or exists (select 1 from unnest((v.g).specializations) as spec(value) where lower(spec.value) ilike '%' || tok.token || '%')
+      )
+    )
+  ),
+  strict_count as (select count(*)::bigint as c from strict),
+  or_fallback as (
+    select v.g
+    from visible v
+    where exists (
+      select 1
+      from unnest(tokens) as tok(token)
+      where (
+        v.full_name ilike '%' || tok.token || '%'
+        or (v.g).bio ilike '%' || tok.token || '%'
+        or (v.g).base_city ilike '%' || tok.token || '%'
+        or exists (select 1 from unnest((v.g).languages) as lang(value) where lower(lang.value) ilike '%' || tok.token || '%')
+        or exists (select 1 from unnest((v.g).specializations) as spec(value) where lower(spec.value) ilike '%' || tok.token || '%')
+      )
+    )
+  ),
+  result as (
+    select (s.g).*, false::boolean as is_partial_match
+    from strict s
+    where (select c from strict_count) > 0
+    union all
+    select (o.g).*, true::boolean as is_partial_match
+    from or_fallback o
+    where (select c from strict_count) = 0
+  )
+  select r.* from result r order by r.created_at desc;
+end;
+$_$;
+
+


### PR DESCRIPTION
## Summary
- sync role changes with guide profile side effects so guide/traveler changes affect public visibility
- validate guide approve/reject/bulk approve against active guide accounts with guide profiles
- filter public guide detail/search by active guide account state

## Verification
- live admin user QA with disposable admin/guide/traveler accounts: search/list, detail suspend/activate/archive, role promote/demote, guide approve/reject, hard-delete demo, bulk suspend/activate/archive/approve, public visibility
- bun run test:run
- bun run typecheck && bun run lint
- NEXT_TELEMETRY_DISABLED=1 bun run build