### PR TITLE
feat: guide availability controls

### DIFF
--- a/docs/qa/guide-availability-execution-20260708/REPORT.md
+++ b/docs/qa/guide-availability-execution-20260708/REPORT.md
@@ -1,0 +1,114 @@
+# Execution Report — Guide/Admin Availability Controls
+
+**Branch:** `feature/guide-availability-controls-20260708`
+**Date:** 2026-07-08 (UTC+3)
+**Plan:** `docs/superpowers/plans/2026-07-08-guide-availability-admin-guide.md`
+
+## Summary
+
+Implemented the MVP availability control: a guide can pause/resume taking new
+requests from their profile, an admin can view and override that state from the
+guide detail page, every change is written to a new append-only audit table, and
+the two consistency gaps the plan identified are closed (admin re-approval no
+longer clobbers a self-pause; a paused guide can no longer submit new offers —
+enforced at both app and RLS layers). No column was added to `guide_profiles`, so
+the frozen `search_guides` rowtype is untouched. Public catalog, matching, and
+existing bookings/messages are unchanged.
+
+## One-line principal-engineer decisions
+
+- **Reuse `is_available`, add zero columns to `guide_profiles`** — dodges the frozen
+  `guide_search_result_row` (error 42804) landmine; audit lives in a separate table.
+- **Task 5 tested via a pure `buildGuideApprovalUpdate(existing, guideId)` helper**
+  instead of mocking the 6-table `performModerationAction` chain — smaller, robust,
+  and it tests the exact branching logic (first-approval publishes, re-approval
+  leaves `is_available` alone). *(Divergence from the plan's inline-mock test; simpler + safer.)*
+- **Did NOT run `bun run db:reset` / `bun run types`** — the shared local Supabase is
+  bound to a *different parallel job's* project (`pvd-agent-fix-missing-alert-dialog`);
+  resetting it would clobber that job. Clients are untyped (no `Database` generic), so
+  typecheck passes without regenerating types. Type regen is an operator/local step (below).
+
+## Self-critique answers
+
+- **Would a senior staff engineer approve this?** Yes — smallest reversible surface,
+  identity from session, RLS backstop for the app gate, audit trail, no schema risk.
+- **Does this scale?** Binary pause is O(1); audit table is indexed `(guide_id, created_at desc)`.
+  A weekly-schedule engine is deliberately deferred (no time-slot booking model to consume it).
+- **Is there a simpler path?** The pure helper for Task 5 is the simplification; everything
+  else is already at the minimum (one 2-function service, reused UI idioms).
+- **What breaks first under pressure?** The audit insert — intentionally best-effort
+  (wrapped in try/catch + Sentry) so a logging failure never blocks the toggle itself.
+
+## Files changed
+
+Product code:
+- `src/lib/supabase/availability.ts` (new) — `setOwnAvailability` / `setGuideAvailabilityByAdmin` + private `writeAvailability` with best-effort audit insert.
+- `src/features/guide/actions/setAvailability.ts` (new) — guide self-service server action.
+- `src/features/guide/components/profile/guide-availability-toggle.tsx` (new) — guide toggle UI (GlassCard + Button, no custom CSS).
+- `src/app/(protected)/guide/profile/page.tsx` — select `is_available`; render toggle when `verification_status === "approved"`.
+- `src/app/(protected)/admin/guides/[id]/actions.ts` — new `setGuideAvailability` route action.
+- `src/app/(protected)/admin/guides/[id]/guide-availability-control.tsx` (new) — admin override UI (useActionState + formAction + .bind).
+- `src/app/(protected)/admin/guides/[id]/page.tsx` — render "Доступность" card (`detail.profile.is_available` already available via `select("*")`).
+- `src/lib/supabase/moderation.ts` — extract `buildGuideApprovalUpdate`; reject hides, approve only publishes on FIRST approval.
+- `src/features/guide/offer-actions.ts` — select `is_available`; block paused guides from submitting new offers.
+
+Tests:
+- `src/lib/supabase/availability.test.ts` (new, 3)
+- `src/features/guide/actions/setAvailability.test.ts` (new, 2)
+- `src/features/guide/components/profile/guide-availability-toggle.test.tsx` (new, 2)
+- `src/app/(protected)/admin/guides/[id]/actions.test.ts` (+2)
+- `src/app/(protected)/admin/guides/[id]/guide-availability-control.test.tsx` (new, 2)
+- `src/app/(protected)/admin/guides/[id]/page.test.tsx` (+1 mock export — fixes cross-file pollution)
+- `src/lib/supabase/moderation.test.ts` (+2, `buildGuideApprovalUpdate`)
+- `src/features/guide/offer-actions.test.ts` (+1, approved-but-paused)
+
+## Migrations authored (NOT applied to prod)
+
+1. `supabase/migrations/20260708120000_guide_availability_events.sql` — append-only audit
+   table + RLS (`_select`: own-or-admin; `_insert`: self-as-actor-and-guide or admin) + index.
+2. `supabase/migrations/20260708120001_guide_offers_insert_requires_available.sql` — replaces
+   `guide_offers_insert`, adding `AND gp.is_available = true` while preserving the prior
+   `account_status = 'active'` and `is_admin()` conditions from `20260702143000_...`.
+
+## Commands run — results
+
+| Gate | Command | Result |
+|---|---|---|
+| Targeted tests | `bun run test:run <8 spec files>` | ✅ all pass |
+| Typecheck | `bun run typecheck` | ✅ exit 0 |
+| Lint | `bun run lint` | ✅ 0 errors (21 pre-existing warnings, all in `src/data/**`, none in new files) |
+| Full suite | `bun run test:run` | ✅ 223 files, 1136 tests pass |
+| Build | `bun run build` | ✅ Compiled successfully, 60/60 static pages |
+
+(`bun install` was required first — the fresh checkout had no `node_modules`.)
+
+## Unresolved blockers / notes
+
+- **No product-code blocker.** All gates green.
+- `bun run db:reset` / `bun run types` deliberately skipped (shared local Supabase owned by
+  another job). Section 5.2 SQL/RLS checks and 5.3 Playwright were not run for the same
+  reason (no isolated running app/DB in this checkout). Logic is covered by mocked unit tests.
+
+## For Hermes / operator (push + deploy + DB)
+
+1. **Push** branch `feature/guide-availability-controls-20260708` (not pushed per packet).
+2. **Prod DB applies, in order** (per `.claude/checklists/hand-edit-flow.md`):
+   1. Pending backfill `20260702000001_publish_approved_guides.sql` — standing bug: approved
+      guides stay hidden until this lands, so the toggle would have nothing to reveal.
+   2. `20260708120000_guide_availability_events.sql` (audit table).
+   3. `20260708120001_guide_offers_insert_requires_available.sql` (offer RLS gate).
+3. **Local/preview:** run `bun run db:reset && bun run types` on an isolated Supabase and
+   commit the regenerated `database.types.ts` (additive `guide_availability_events` block).
+4. **Verify (SHIP_GATE, 1280px + 375px):** guide pause → absent from `/guides`; admin override;
+   in-progress booking/inbox still loads; paused guide blocked from new offer. Watch Sentry
+   `guide-availability-event` for 30 min.
+
+## Method evidence
+
+- **Context7** — `/vercel/next.js` (Server Actions mutate-then-`revalidatePath` from `next/cache`,
+  `useActionState` + `formAction`) and `/supabase/supabase` (RLS `with check ((select auth.uid()) = col)`,
+  boolean-gated `select` policy, service-role bypass). Both confirm the service/action/RLS shapes used.
+- **Ponytail** — reuse `is_available` (no enum, no new column); one 2-function service; reused
+  `GlassCard`/`Button`/`useActionState`; pure helper for Task 5; audit insert best-effort. No new deps.
+- **Superpowers** — TDD per task (failing test → impl → green); verification-before-completion
+  (every claim above is backed by a command result, not asserted).

--- a/docs/qa/guide-availability-execution-20260708/TASK_PACKET.md
+++ b/docs/qa/guide-availability-execution-20260708/TASK_PACKET.md
@@ -1,0 +1,96 @@
+# Opus execution packet — Guide/Admin availability controls
+
+You are working in `/tmp/provodnik-guide-availability-exec` on branch `feature/guide-availability-controls-20260708`, created from current `origin/main`.
+
+## Prime directive from owner
+You are fully autonomous. You receive a goal. You deliver the result.
+
+Never ask questions. Never wait for approval. Never pause for confirmation.
+The user tells you WHAT. You figure out HOW, WHY, and in what order.
+
+When facing ambiguity: pick the best path for the project's long-term health.
+When facing a choice between approaches: think like a principal engineer — pick fewer moving parts, easier to reverse, better maintainability.
+State your decision in one line, then execute immediately.
+
+You are also your own toughest critic. Before committing to any plan or architectural decision, attack it yourself:
+- Would a senior staff engineer approve this?
+- Does this scale?
+- Is there a simpler path?
+- What breaks first under pressure?
+
+## Required methods
+- Use Superpowers where applicable, especially test-driven-development / executing-plans / verification-before-completion.
+- Use Ponytail: smallest correct reversible implementation, no overbuilt schedule engine, no unnecessary abstractions.
+- Use Context7 for relevant current docs before implementing: Next.js App Router/server actions/revalidatePath and Supabase JS/Postgres/RLS. In final report, cite library IDs/topics used.
+- Follow Provodnik project rules in `AGENTS.md`, `CLAUDE.md`, `.claude/CLAUDE.md`, and `.claude/rules/*`.
+
+## Source of truth
+Read first:
+1. `docs/superpowers/plans/2026-07-08-guide-availability-admin-guide.md`
+2. Current source files referenced by that plan
+3. Existing tests around guide profile, admin moderation, offers, notifications, guide catalog/RPC
+
+## Goal
+Implement the MVP from the plan:
+- Guide can pause/resume taking new requests from the guide profile/dashboard area.
+- Guide can restrict themselves from working by using the availability control. Do not build a full recurring calendar engine unless the existing code already has one that can be reused safely; MVP is the reversible working-days/self-pause control from the plan.
+- Admin can see and control/override guide availability from admin guide detail/list surfaces.
+- Availability changes are audited in a separate DB table/event trail, not as new columns on `guide_profiles`.
+- Re-approving a guide must not accidentally clobber a guide self-pause unless the admin explicitly changes availability.
+- A paused guide must not receive new request matching/notifications and must not submit new offers/bids for new work.
+- Existing bookings/messages must continue working.
+- Public catalog/search behavior remains approved + available.
+
+## Scope and safety
+Allowed:
+- Product source/tests/docs/migrations needed for this feature.
+- New migration(s) for audit events and offer/RLS availability gates.
+- Generated Supabase types if the repo script works.
+- A final execution report.
+- Local commits.
+
+Forbidden unless absolutely required and documented:
+- Production DB mutation (`db push`, manual SQL against prod, data updates).
+- Vercel/prod deploy.
+- Broad redesign, unrelated refactors, changing auth/session model.
+- Adding columns to `guide_profiles` unless you first prove the frozen RPC rowtype risk is fully handled. Prefer the plan's separate audit table.
+- Secrets in output/commits.
+
+## Expected implementation shape
+The plan is authoritative but not sacred. If code reality differs, choose the simpler safer path and record the one-line decision.
+
+Minimum expected files/areas:
+- `src/lib/supabase/availability.ts` or equivalent focused service
+- guide profile action/component/page area
+- admin guide detail/list action/component/page area
+- moderation approval logic so it does not clobber self-pause unintentionally
+- offer submission app gate + RLS/migration gate
+- migration for `guide_availability_events` + policies
+- tests for service/actions/admin/guide/offer/moderation/RLS as feasible
+- `docs/qa/guide-availability-execution-20260708/REPORT.md`
+
+## Verification gates
+Run and fix until green or a concrete blocker is proven:
+- targeted tests you add/modify
+- `bun run typecheck`
+- `bun run lint`
+- `bun run test:run`
+- `bun run build`
+
+If a gate is blocked by a pre-existing unrelated issue, prove it with a narrow rerun and document exact evidence. Do not fabricate pass results.
+
+## Commit policy
+Commit completed work locally on this branch with human commit message(s). Do not push. Include report in commit if it is useful and non-secret.
+
+## Final report contract
+Write `docs/qa/guide-availability-execution-20260708/REPORT.md` with:
+- summary
+- one-line principal-engineer decision(s)
+- self-critique answers
+- files changed
+- migrations authored
+- tests/commands run with results
+- unresolved blockers, if any
+- push/deploy/manual DB instructions for Hermes/operator
+
+Then print a concise final transcript summary with commit hash, verification results, and report path.

--- a/src/app/(protected)/admin/guides/[id]/actions.test.ts
+++ b/src/app/(protected)/admin/guides/[id]/actions.test.ts
@@ -4,10 +4,12 @@ const {
   ensureOpenModerationCaseMock,
   performModerationActionMock,
   requireAdminSessionMock,
+  setGuideAvailabilityByAdminMock,
 } = vi.hoisted(() => ({
   ensureOpenModerationCaseMock: vi.fn(),
   performModerationActionMock: vi.fn(),
   requireAdminSessionMock: vi.fn(),
+  setGuideAvailabilityByAdminMock: vi.fn(),
 }));
 
 vi.mock("@/lib/supabase/moderation", () => ({
@@ -16,11 +18,15 @@ vi.mock("@/lib/supabase/moderation", () => ({
   requireAdminSession: requireAdminSessionMock,
 }));
 
+vi.mock("@/lib/supabase/availability", () => ({
+  setGuideAvailabilityByAdmin: setGuideAvailabilityByAdminMock,
+}));
+
 vi.mock("next/cache", () => ({
   revalidatePath: vi.fn(),
 }));
 
-import { approveGuide, rejectGuide } from "./actions";
+import { approveGuide, rejectGuide, setGuideAvailability } from "./actions";
 
 describe("guide approval actions", () => {
   beforeEach(() => {
@@ -51,5 +57,24 @@ describe("guide approval actions", () => {
 
     expect(result.error).toBe("Доступ только для администраторов.");
     expect(performModerationActionMock).not.toHaveBeenCalled();
+  });
+
+  it("setGuideAvailability calls the admin service with the resolved admin id", async () => {
+    requireAdminSessionMock.mockResolvedValue({ adminId: "admin-1" });
+
+    const result = await setGuideAvailability("g2", false, { error: null }, new FormData());
+
+    expect(setGuideAvailabilityByAdminMock).toHaveBeenCalledWith("g2", false, "admin-1");
+    expect(result.error).toBeNull();
+    expect(result.success).toBe("Приём заявок приостановлен.");
+  });
+
+  it("setGuideAvailability returns an error when the service throws", async () => {
+    requireAdminSessionMock.mockResolvedValue({ adminId: "admin-1" });
+    setGuideAvailabilityByAdminMock.mockRejectedValueOnce(new Error("db down"));
+
+    const result = await setGuideAvailability("g2", true, { error: null }, new FormData());
+
+    expect(result.error).toBe("Не удалось изменить доступность гида.");
   });
 });

--- a/src/app/(protected)/admin/guides/[id]/actions.ts
+++ b/src/app/(protected)/admin/guides/[id]/actions.ts
@@ -2,6 +2,7 @@
 
 import { revalidatePath } from "next/cache";
 
+import { setGuideAvailabilityByAdmin } from "@/lib/supabase/availability";
 import {
   ensureOpenModerationCase,
   performModerationAction,
@@ -63,6 +64,26 @@ export async function rejectGuide(
     return { error: null, success: "Гид отклонён" };
   } catch (err) {
     return { error: err instanceof Error ? err.message : "Неизвестная ошибка при отклонении" };
+  }
+}
+
+export async function setGuideAvailability(
+  guideId: string,
+  available: boolean,
+  _prevState: ActionState,
+  _formData: FormData,
+): Promise<ActionState> {
+  try {
+    const { adminId } = await requireAdminSession();
+    await setGuideAvailabilityByAdmin(guideId, available, adminId);
+    revalidatePath(`/admin/guides/${guideId}`);
+    revalidatePath("/guides");
+    return {
+      error: null,
+      success: available ? "Гид снова принимает заявки." : "Приём заявок приостановлен.",
+    };
+  } catch {
+    return { error: "Не удалось изменить доступность гида." };
   }
 }
 

--- a/src/app/(protected)/admin/guides/[id]/guide-availability-control.test.tsx
+++ b/src/app/(protected)/admin/guides/[id]/guide-availability-control.test.tsx
@@ -1,0 +1,22 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+
+vi.mock("./actions", () => ({ setGuideAvailability: vi.fn() }));
+
+import { GuideAvailabilityControl } from "./guide-availability-control";
+
+describe("GuideAvailabilityControl", () => {
+  it("labels the override for an available guide", () => {
+    render(<GuideAvailabilityControl guideId="g1" available={true} />);
+    expect(
+      screen.getByRole("button", { name: /приостановить/i }),
+    ).toBeInTheDocument();
+  });
+
+  it("labels the override for a paused guide", () => {
+    render(<GuideAvailabilityControl guideId="g1" available={false} />);
+    expect(
+      screen.getByRole("button", { name: /возобновить/i }),
+    ).toBeInTheDocument();
+  });
+});

--- a/src/app/(protected)/admin/guides/[id]/guide-availability-control.tsx
+++ b/src/app/(protected)/admin/guides/[id]/guide-availability-control.tsx
@@ -1,0 +1,35 @@
+"use client";
+
+import * as React from "react";
+
+import { Button } from "@/components/ui/button";
+
+import { setGuideAvailability, type ActionState } from "./actions";
+
+const INITIAL: ActionState = { error: null };
+
+export function GuideAvailabilityControl({
+  guideId,
+  available,
+}: {
+  guideId: string;
+  available: boolean;
+}) {
+  const [state, action] = React.useActionState(
+    setGuideAvailability.bind(null, guideId, !available),
+    INITIAL,
+  );
+
+  return (
+    <form className="space-y-2">
+      <p className="text-sm text-muted-foreground">
+        Текущий статус: {available ? "принимает заявки" : "приём приостановлен"}
+      </p>
+      {state.error ? <p className="text-sm text-destructive">{state.error}</p> : null}
+      {state.success ? <p className="text-sm text-success">{state.success}</p> : null}
+      <Button formAction={action} type="submit" variant={available ? "outline" : "default"}>
+        {available ? "Приостановить приём заявок" : "Возобновить приём заявок"}
+      </Button>
+    </form>
+  );
+}

--- a/src/app/(protected)/admin/guides/[id]/page.test.tsx
+++ b/src/app/(protected)/admin/guides/[id]/page.test.tsx
@@ -19,6 +19,7 @@ vi.mock("./actions", () => ({
   approveGuide: vi.fn(),
   rejectGuide: vi.fn(),
   requestChanges: vi.fn(),
+  setGuideAvailability: vi.fn(),
 }));
 
 import AdminGuideDetailPage from "./page";

--- a/src/app/(protected)/admin/guides/[id]/page.tsx
+++ b/src/app/(protected)/admin/guides/[id]/page.tsx
@@ -23,6 +23,7 @@ import { resolveDisplayName } from "@/lib/profile/resolve-display-name";
 import { getGuideReviewDetail } from "@/lib/supabase/moderation";
 
 import { GuideApprovalForm } from "./guide-approval-form";
+import { GuideAvailabilityControl } from "./guide-availability-control";
 
 export const metadata: Metadata = {
   title: "Верификация гида",
@@ -434,6 +435,22 @@ export default async function AdminGuideDetailPage({
             </CardHeader>
             <CardContent>
               <GuideApprovalForm guideId={id} />
+            </CardContent>
+          </Card>
+
+          <Card>
+            <CardHeader>
+              <CardTitle className="text-lg">Доступность</CardTitle>
+              <CardDescription>
+                Приём новых заявок. Гид управляет этим сам, админ может
+                переопределить. Не влияет на текущие бронирования и переписку.
+              </CardDescription>
+            </CardHeader>
+            <CardContent>
+              <GuideAvailabilityControl
+                guideId={id}
+                available={detail.profile.is_available ?? false}
+              />
             </CardContent>
           </Card>
 

--- a/src/app/(protected)/guide/profile/page.tsx
+++ b/src/app/(protected)/guide/profile/page.tsx
@@ -10,6 +10,7 @@ import {
 } from "@/components/ui/card";
 import { GUIDE_TYPES } from "@/features/auth/guide-type";
 import { GuideAboutForm } from "@/features/guide/components/profile/guide-about-form";
+import { GuideAvailabilityToggle } from "@/features/guide/components/profile/guide-availability-toggle";
 import { GuideProfileChecklist } from "@/features/guide/components/profile/guide-profile-checklist";
 import type { ChecklistStep } from "@/features/guide/components/profile/guide-profile-checklist-types";
 import { LegalInformationForm } from "@/features/profile/components/LegalInformationForm";
@@ -157,7 +158,7 @@ export default async function GuideProfilePage() {
       supabase
         .from("guide_profiles")
         .select(
-          "bio, base_city, languages, specializations, years_experience, regions, legal_status, inn, document_country, is_tour_operator, tour_operator_registry_number, verification_status, verification_notes, guide_type",
+          "bio, base_city, languages, specializations, years_experience, regions, legal_status, inn, document_country, is_tour_operator, tour_operator_registry_number, verification_status, verification_notes, guide_type, is_available",
         )
         .eq("user_id", guideId)
         .maybeSingle(),
@@ -317,6 +318,10 @@ export default async function GuideProfilePage() {
         firstIncompleteStep={firstIncompleteStep}
         verificationStatus={verificationStatus}
       />
+
+      {verificationStatus === "approved" ? (
+        <GuideAvailabilityToggle available={profile?.is_available ?? false} />
+      ) : null}
 
       <GuideProfileSectionBoundary id="avatar" title="Фото">
         {() => <AvatarUploadBlock avatarUrl={avatarUrl} displayName={displayName} />}

--- a/src/features/guide/actions/setAvailability.test.ts
+++ b/src/features/guide/actions/setAvailability.test.ts
@@ -1,0 +1,25 @@
+import { describe, it, expect, vi } from "vitest";
+
+const { setOwnAvailability } = vi.hoisted(() => ({
+  setOwnAvailability: vi.fn(async () => undefined),
+}));
+vi.mock("@/lib/supabase/availability", () => ({ setOwnAvailability }));
+vi.mock("next/cache", () => ({ revalidatePath: vi.fn() }));
+
+import { setGuideAvailabilityAction } from "./setAvailability";
+
+describe("setGuideAvailabilityAction", () => {
+  it("returns ok on success", async () => {
+    expect(await setGuideAvailabilityAction(false)).toEqual({ ok: true });
+    expect(setOwnAvailability).toHaveBeenCalledWith(false);
+  });
+
+  it("returns error text when the service throws ActionError", async () => {
+    const { ActionError } = await import("@/lib/actions/create-action");
+    setOwnAvailability.mockRejectedValueOnce(new ActionError("Требуется вход"));
+    expect(await setGuideAvailabilityAction(true)).toEqual({
+      ok: false,
+      error: "Требуется вход",
+    });
+  });
+});

--- a/src/features/guide/actions/setAvailability.ts
+++ b/src/features/guide/actions/setAvailability.ts
@@ -1,0 +1,22 @@
+"use server";
+
+import { revalidatePath } from "next/cache";
+
+import { ActionError } from "@/lib/actions/create-action";
+import { setOwnAvailability } from "@/lib/supabase/availability";
+
+const GENERIC = "Не удалось изменить статус. Попробуйте ещё раз.";
+
+export async function setGuideAvailabilityAction(
+  available: boolean,
+): Promise<{ ok: true } | { ok: false; error: string }> {
+  try {
+    await setOwnAvailability(available);
+    revalidatePath("/guide/profile");
+    revalidatePath("/guides");
+    return { ok: true };
+  } catch (err) {
+    if (err instanceof ActionError) return { ok: false, error: err.message };
+    return { ok: false, error: GENERIC };
+  }
+}

--- a/src/features/guide/components/profile/guide-availability-toggle.test.tsx
+++ b/src/features/guide/components/profile/guide-availability-toggle.test.tsx
@@ -1,0 +1,24 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+
+vi.mock("@/features/guide/actions/setAvailability", () => ({
+  setGuideAvailabilityAction: vi.fn(async () => ({ ok: true })),
+}));
+
+import { GuideAvailabilityToggle } from "./guide-availability-toggle";
+
+describe("GuideAvailabilityToggle", () => {
+  it("shows 'paused' affordance when currently available", () => {
+    render(<GuideAvailabilityToggle available={true} />);
+    expect(
+      screen.getByRole("button", { name: /приостановить/i }),
+    ).toBeInTheDocument();
+  });
+
+  it("shows 'resume' affordance when currently paused", () => {
+    render(<GuideAvailabilityToggle available={false} />);
+    expect(
+      screen.getByRole("button", { name: /возобновить/i }),
+    ).toBeInTheDocument();
+  });
+});

--- a/src/features/guide/components/profile/guide-availability-toggle.tsx
+++ b/src/features/guide/components/profile/guide-availability-toggle.tsx
@@ -1,0 +1,45 @@
+"use client";
+
+import * as React from "react";
+
+import { GlassCard } from "@/components/shared/glass-card";
+import { Button } from "@/components/ui/button";
+import { setGuideAvailabilityAction } from "@/features/guide/actions/setAvailability";
+
+export function GuideAvailabilityToggle({ available }: { available: boolean }) {
+  const [isAvailable, setIsAvailable] = React.useState(available);
+  const [error, setError] = React.useState<string | null>(null);
+  const [pending, startTransition] = React.useTransition();
+
+  function toggle() {
+    const next = !isAvailable;
+    setError(null);
+    startTransition(async () => {
+      const res = await setGuideAvailabilityAction(next);
+      if (res.ok) setIsAvailable(next);
+      else setError(res.error);
+    });
+  }
+
+  return (
+    <GlassCard className="space-y-3 p-5">
+      <div className="space-y-1">
+        <p className="text-sm font-medium text-primary">Приём заявок</p>
+        <p className="text-sm text-muted-foreground">
+          {isAvailable
+            ? "Вы получаете новые заявки и видны в каталоге."
+            : "Приём заявок приостановлен. Вас не видно в каталоге, новые заявки не приходят. Текущие бронирования и переписка сохраняются."}
+        </p>
+      </div>
+      {error ? <p className="text-sm text-destructive">{error}</p> : null}
+      <Button
+        type="button"
+        variant={isAvailable ? "outline" : "default"}
+        disabled={pending}
+        onClick={toggle}
+      >
+        {isAvailable ? "Приостановить приём заявок" : "Возобновить приём заявок"}
+      </Button>
+    </GlassCard>
+  );
+}

--- a/src/features/guide/offer-actions.test.ts
+++ b/src/features/guide/offer-actions.test.ts
@@ -148,6 +148,39 @@ describe("submitOfferAction", () => {
     expect(result).toEqual({ error: "Аккаунт заблокирован." });
     expect(from).not.toHaveBeenCalledWith("guide_profiles");
   });
+
+  it("rejects an approved but paused guide before submitting an offer", async () => {
+    const guideMaybeSingle = vi.fn().mockResolvedValue({
+      data: { verification_status: "approved", is_available: false },
+    });
+    const guideEq = vi.fn().mockReturnValue({ maybeSingle: guideMaybeSingle });
+    const guideSelect = vi.fn().mockReturnValue({ eq: guideEq });
+    const profileMaybeSingle = vi.fn().mockResolvedValue({ data: { account_status: "active" } });
+    const profileEq = vi.fn().mockReturnValue({ maybeSingle: profileMaybeSingle });
+    const profileSelect = vi.fn().mockReturnValue({ eq: profileEq });
+    const from = vi.fn((table: string) => {
+      if (table === "profiles") return { select: profileSelect };
+      if (table === "guide_profiles") return { select: guideSelect };
+      throw new Error(`unexpected table ${table}`);
+    });
+
+    createSupabaseServerClientMock.mockResolvedValue({
+      auth: {
+        getUser: vi.fn().mockResolvedValue({
+          data: { user: { id: "guide-1" } },
+          error: null,
+        }),
+      },
+      from,
+    });
+
+    const result = await submitOfferAction("request-1", new FormData());
+
+    expect(result).toEqual({
+      error: "Приём заявок приостановлен. Возобновите его в профиле, чтобы откликаться.",
+    });
+    expect(guideSelect).toHaveBeenCalledWith("verification_status, is_available");
+  });
 });
 
 describe("withdrawOfferAction", () => {

--- a/src/features/guide/offer-actions.ts
+++ b/src/features/guide/offer-actions.ts
@@ -99,12 +99,18 @@ export async function submitOfferAction(
     const supabaseAuth = await createSupabaseServerClient();
     const { data: guideProfile } = await supabaseAuth
       .from("guide_profiles")
-      .select("verification_status")
+      .select("verification_status, is_available")
       .eq("user_id", guideId)
       .maybeSingle();
 
     if (guideProfile?.verification_status !== "approved") {
       return { error: "Доступно после верификации" };
+    }
+    // Paused guides stop taking new work. Mirrored by RLS guide_offers_insert.
+    if (guideProfile?.is_available !== true) {
+      return {
+        error: "Приём заявок приостановлен. Возобновите его в профиле, чтобы откликаться.",
+      };
     }
 
     // Duplicate guard

--- a/src/lib/supabase/availability.test.ts
+++ b/src/lib/supabase/availability.test.ts
@@ -1,0 +1,55 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+const updateEq = vi.fn(() => ({ error: null }));
+const insert = vi.fn(() => ({ error: null }));
+const from = vi.fn((table: string) =>
+  table === "guide_profiles"
+    ? { update: () => ({ eq: updateEq }) }
+    : { insert },
+);
+const getUser = vi.fn(async () => ({ data: { user: { id: "g1" } }, error: null }));
+
+vi.mock("./server", () => ({
+  createSupabaseServerClient: async () => ({ from, auth: { getUser } }),
+}));
+vi.mock("./admin", () => ({ createSupabaseAdminClient: () => ({ from }) }));
+
+import { setOwnAvailability, setGuideAvailabilityByAdmin } from "./availability";
+
+beforeEach(() => {
+  updateEq.mockClear();
+  insert.mockClear();
+});
+
+describe("availability service", () => {
+  it("guide self-pause updates own row and logs a guide event", async () => {
+    await setOwnAvailability(false);
+    expect(updateEq).toHaveBeenCalledWith("user_id", "g1");
+    expect(insert).toHaveBeenCalledWith(
+      expect.objectContaining({
+        guide_id: "g1",
+        actor_id: "g1",
+        actor_role: "guide",
+        available: false,
+      }),
+    );
+  });
+
+  it("admin override updates target row and logs an admin event", async () => {
+    await setGuideAvailabilityByAdmin("g2", true, "admin1");
+    expect(updateEq).toHaveBeenCalledWith("user_id", "g2");
+    expect(insert).toHaveBeenCalledWith(
+      expect.objectContaining({
+        guide_id: "g2",
+        actor_id: "admin1",
+        actor_role: "admin",
+        available: true,
+      }),
+    );
+  });
+
+  it("throws when guide is unauthenticated", async () => {
+    getUser.mockResolvedValueOnce({ data: { user: null }, error: null } as never);
+    await expect(setOwnAvailability(true)).rejects.toThrow("Требуется вход");
+  });
+});

--- a/src/lib/supabase/availability.ts
+++ b/src/lib/supabase/availability.ts
@@ -1,0 +1,55 @@
+import * as Sentry from "@sentry/nextjs";
+import type { SupabaseClient } from "@supabase/supabase-js";
+
+import { ActionError } from "@/lib/actions/create-action";
+
+import { createSupabaseAdminClient } from "./admin";
+import { createSupabaseServerClient } from "./server";
+
+type Actor = { userId: string; role: "guide" | "admin" };
+
+async function writeAvailability(
+  client: SupabaseClient,
+  guideId: string,
+  available: boolean,
+  actor: Actor,
+): Promise<void> {
+  const { error } = await client
+    .from("guide_profiles")
+    .update({ is_available: available })
+    .eq("user_id", guideId);
+  if (error) throw error;
+
+  // Audit is secondary — never fail the toggle if the event insert fails.
+  try {
+    const { error: eventError } = await client.from("guide_availability_events").insert({
+      guide_id: guideId,
+      actor_id: actor.userId,
+      actor_role: actor.role,
+      available,
+    });
+    if (eventError) throw eventError;
+  } catch (err) {
+    Sentry.captureException(err, { tags: { context: "guide-availability-event" } });
+  }
+}
+
+/** Guide toggling their own availability. Identity comes from the session, never input. */
+export async function setOwnAvailability(available: boolean): Promise<void> {
+  const supabase = await createSupabaseServerClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+  if (!user) throw new ActionError("Требуется вход");
+  await writeAvailability(supabase, user.id, available, { userId: user.id, role: "guide" });
+}
+
+/** Admin overriding a guide's availability. Caller must already be an authenticated admin. */
+export async function setGuideAvailabilityByAdmin(
+  guideId: string,
+  available: boolean,
+  adminId: string,
+): Promise<void> {
+  const admin = createSupabaseAdminClient();
+  await writeAvailability(admin, guideId, available, { userId: adminId, role: "admin" });
+}

--- a/src/lib/supabase/moderation.test.ts
+++ b/src/lib/supabase/moderation.test.ts
@@ -17,8 +17,34 @@ vi.mock("@/lib/notifications/create-notification", () => ({
   createNotification: vi.fn(),
 }));
 
-import { getGuideReviewQueue, getPendingListingReviews } from "./moderation";
+import {
+  buildGuideApprovalUpdate,
+  getGuideReviewQueue,
+  getPendingListingReviews,
+} from "./moderation";
 import type { GuideProfileRow, ListingRow, Uuid } from "./types";
+
+describe("buildGuideApprovalUpdate", () => {
+  it("first approval (previously submitted) publishes and backfills a slug", () => {
+    const payload = buildGuideApprovalUpdate(
+      { slug: null, display_name: "Иван Гид", verification_status: "submitted" },
+      "guide-1",
+    );
+    expect(payload.verification_status).toBe("approved");
+    expect(payload.is_available).toBe(true);
+    expect(typeof payload.slug).toBe("string");
+  });
+
+  it("re-approving an already-approved self-paused guide does NOT touch is_available or slug", () => {
+    const payload = buildGuideApprovalUpdate(
+      { slug: "ivan-guide", display_name: "Иван Гид", verification_status: "approved" },
+      "guide-1",
+    );
+    expect(payload).toEqual({ verification_status: "approved" });
+    expect("is_available" in payload).toBe(false);
+    expect("slug" in payload).toBe(false);
+  });
+});
 
 function makeGuideProfile(
   userId: string,

--- a/src/lib/supabase/moderation.ts
+++ b/src/lib/supabase/moderation.ts
@@ -616,6 +616,32 @@ function slugifyGuideProfileName(value: string | null | undefined, guideId: stri
   return `${base || "guide"}-${suffix}`;
 }
 
+type GuideApprovalExisting = {
+  slug: string | null;
+  display_name: string | null;
+  verification_status: string | null;
+};
+
+/**
+ * Build the guide_profiles update for an APPROVE decision.
+ * Only the FIRST approval publishes (is_available=true); re-approving an
+ * already-approved guide leaves is_available untouched, so an admin re-approval
+ * never clobbers a guide's self-pause. First approval also backfills a slug.
+ */
+export function buildGuideApprovalUpdate(
+  existing: GuideApprovalExisting | null,
+  guideId: string,
+): Record<string, unknown> {
+  const payload: Record<string, unknown> = { verification_status: "approved" };
+  if (existing?.verification_status !== "approved") {
+    payload.is_available = true;
+  }
+  if (!existing?.slug) {
+    payload.slug = slugifyGuideProfileName(existing?.display_name, guideId);
+  }
+  return payload;
+}
+
 export async function performModerationAction(
   caseId: string,
   adminId: string,
@@ -660,28 +686,27 @@ export async function performModerationAction(
   if (caseError) throw caseError;
 
   if (moderationCase.subject_type === "guide_profile" && moderationCase.guide_id) {
-    if (input.decision === "approve" || input.decision === "reject") {
-      const nextVerificationStatus = input.decision === "approve" ? "approved" : "rejected";
-      const updatePayload: Record<string, unknown> = {
-        verification_status: nextVerificationStatus,
-        is_available: input.decision === "approve",
-      };
+    if (input.decision === "reject") {
+      // Reject always hides the guide from the catalog.
+      const { error } = await adminClient
+        .from("guide_profiles")
+        .update({ verification_status: "rejected", is_available: false })
+        .eq("user_id", moderationCase.guide_id);
 
-      if (input.decision === "approve") {
-        const { data: guideProfile, error: guideProfileError } = await adminClient
-          .from("guide_profiles")
-          .select("slug, display_name")
-          .eq("user_id", moderationCase.guide_id)
-          .maybeSingle();
+      if (error) throw error;
+    } else if (input.decision === "approve") {
+      const { data: existing, error: existingError } = await adminClient
+        .from("guide_profiles")
+        .select("slug, display_name, verification_status")
+        .eq("user_id", moderationCase.guide_id)
+        .maybeSingle();
 
-        if (guideProfileError) throw guideProfileError;
-        if (!guideProfile?.slug) {
-          updatePayload.slug = slugifyGuideProfileName(
-            guideProfile?.display_name as string | null | undefined,
-            moderationCase.guide_id,
-          );
-        }
-      }
+      if (existingError) throw existingError;
+
+      const updatePayload = buildGuideApprovalUpdate(
+        (existing as GuideApprovalExisting | null) ?? null,
+        moderationCase.guide_id,
+      );
 
       const { error } = await adminClient
         .from("guide_profiles")

--- a/supabase/migrations/20260708120000_guide_availability_events.sql
+++ b/supabase/migrations/20260708120000_guide_availability_events.sql
@@ -1,0 +1,24 @@
+-- Append-only audit trail for guide availability changes.
+-- Kept OFF guide_profiles on purpose: adding a column to guide_profiles breaks the
+-- frozen search_guides rowtype (error 42804) until the refreeze migration re-runs.
+create table public.guide_availability_events (
+  id         uuid primary key default extensions.gen_random_uuid(),
+  guide_id   uuid not null references public.guide_profiles(user_id) on delete cascade,
+  actor_id   uuid not null references public.profiles(id),
+  actor_role text not null check (actor_role in ('guide','admin')),
+  available  boolean not null,          -- the new state written
+  created_at timestamptz not null default timezone('utc', now())
+);
+
+alter table public.guide_availability_events enable row level security;
+
+create policy "guide_availability_events_select" on public.guide_availability_events
+  for select using ((select auth.uid()) = guide_id or public.is_admin());
+
+create policy "guide_availability_events_insert" on public.guide_availability_events
+  for insert with check (
+    ((select auth.uid()) = actor_id and (select auth.uid()) = guide_id) or public.is_admin()
+  );
+
+create index guide_availability_events_guide_idx
+  on public.guide_availability_events (guide_id, created_at desc);

--- a/supabase/migrations/20260708120001_guide_offers_insert_requires_available.sql
+++ b/supabase/migrations/20260708120001_guide_offers_insert_requires_available.sql
@@ -1,0 +1,24 @@
+-- Tighten guide_offers_insert: a guide must be approved AND currently available
+-- (accepting new work) to submit a new offer. Mirrors the app gate in
+-- src/features/guide/offer-actions.ts. Preserves the prior account_status and
+-- admin conditions from 20260702143000_enforce_active_account_for_guide_offers.sql;
+-- only adds the is_available conjunct. Existing offers/bookings are untouched.
+
+DROP POLICY IF EXISTS "guide_offers_insert" ON public.guide_offers;
+
+CREATE POLICY "guide_offers_insert" ON public.guide_offers
+  FOR INSERT
+  WITH CHECK (
+    (
+      (SELECT auth.uid()) = guide_id
+      AND public.profile_account_status_for(guide_id) = 'active'::public.account_status
+      AND EXISTS (
+        SELECT 1
+        FROM public.guide_profiles gp
+        WHERE gp.user_id = guide_offers.guide_id
+          AND gp.verification_status = 'approved'::public.guide_verification_status
+          AND gp.is_available = true
+      )
+    )
+    OR public.is_admin()
+  );


### PR DESCRIPTION
Implements guide self-pause/resume, admin availability override, availability audit events, and paused-guide offer gating.\n\nVerification:\n- bun run typecheck\n- bun run lint\n- bun run test:run\n- bun run build\n\nNotes:\n- Production DB migrations authored but not applied. Apply pending backfill first, then new availability migrations.\n- No Vercel/prod deploy yet because DB migrations need controlled apply order.