### PR TITLE
fix: booking offer QA fixes

### DIFF
--- a/docs/qa/qa-fix-exec-opus-20260708/OPUS-EXECUTE-TASK.md
+++ b/docs/qa/qa-fix-exec-opus-20260708/OPUS-EXECUTE-TASK.md
@@ -1,0 +1,84 @@
+# Opus Execution Task — implement all booking/offer QA fix plan tasks
+
+You are working in `/tmp/provodnik-qa-fix-exec-opus` on branch `fix/booking-offer-qa-fixes-20260708`, based on production main commit `45ccbb50`.
+
+## Required first sentence in final response
+
+Start your final response with exactly:
+
+> I'm using the executing-plans skill to implement this plan.
+
+## Goal
+
+Implement every task in the plan file:
+
+`docs/superpowers/plans/2026-07-08-provodnik-booking-offer-qa-fixes.md`
+
+Fix all seven production QA issues covered by that plan:
+
+1. Traveler confirmed booking card renders full summary, not only `—`.
+2. New-offer notification/deep link no longer opens missing request / 404 content for the traveler path.
+3. Confirmed booking contact card distinguishes missing contacts from load failure and restores QA fixture safety as needed.
+4. Public homepage hero/city images stop returning 400.
+5. Admin booking rows become clickable and expose booking detail/admin action path per plan.
+6. Guide availability pause/resume events appear in admin audit/moderation history per plan.
+7. Guide `/messages` empty-state copy becomes role-aware.
+
+## Required skills / tools inside Claude
+
+Use:
+- `superpowers:executing-plans`
+- `superpowers:test-driven-development` where tests are added/changed
+- `superpowers:verification-before-completion`
+- Context7 for Next.js/React/Supabase API details when touching those integration points
+- Ponytail review/audit if available before finalizing
+
+Final report must say how these were used or, if one is unavailable, what fallback was used.
+
+## Source of truth
+
+Read first:
+
+1. `CLAUDE.md`
+2. `.claude/CLAUDE.md` if present
+3. `AGENTS.md`
+4. The implementation plan above
+5. QA reports copied here:
+   - `docs/qa/qa-fix-exec-opus-20260708/admin-report.md`
+   - `docs/qa/qa-fix-exec-opus-20260708/guide-report.md`
+   - `docs/qa/qa-fix-exec-opus-20260708/traveler-report.md`
+
+## Execution rules
+
+- Implement product code, tests, scripts, migrations/assets only as needed by the plan.
+- Follow the plan task-by-task, but adapt if source reality requires it; document deviations.
+- Do not push.
+- Do not deploy.
+- Do not run production DB writes. If a production data repair is needed, create targeted SQL/migration/runbook artifacts and mark production application as a follow-up unless explicitly safe in local/test.
+- Do not print secrets, env values, raw passwords, API keys, tokens, or cookies.
+- Preserve existing unrelated dirty files if any appear.
+- Commit meaningful completed batches locally. Use project commit style. No automation/co-author trailers.
+- If a gate is too large or blocked, still run the narrower task-level verification and state the blocker clearly; do not claim full completion without evidence.
+
+## Required verification
+
+At minimum run and report exact results for:
+
+- Relevant task-level tests introduced/changed by the plan.
+- `bun run typecheck`
+- `bun run lint`
+- `bun run test:run`
+- `bun run build`
+
+Run Playwright/browser smoke if feasible in this worktree. If Playwright is blocked by env or time, write the exact command and blocker, and produce enough lower-level evidence not to fake browser proof.
+
+## Required final report
+
+Print:
+
+1. Files changed grouped by task.
+2. Commits created, with hashes.
+3. Exact verification commands and results.
+4. Which of the seven QA issues are fixed vs blocked/partial.
+5. Any DB/production follow-up steps required.
+6. Current branch, final `git status --short`, and whether anything remains uncommitted.

--- a/docs/qa/qa-fix-exec-opus-20260708/admin-report.md
+++ b/docs/qa/qa-fix-exec-opus-20260708/admin-report.md
@@ -1,0 +1,79 @@
+# Admin role QA report — provodnik.app (live production)
+
+Date: 2026-07-08
+Tester: Claude Code (autonomous QA agent), Playwright MCP against https://provodnik.app
+Account: qa-admin@example.com (demo admin account, password from repo audit harness `AUDIT_PW`/`QA_SEED_PASSWORD`, not printed)
+Viewports: 1280×900 (desktop), 375×812 (mobile)
+Screenshots: `/tmp/provodnik-role-qa-20260708/admin-screens/admin-01..13-*.png`
+
+## Scope covered
+
+1. Login/logout and admin route protection — ✅ tested
+2. Admin dashboard overview — ✅ tested
+3. Admin guides list and guide detail — ✅ tested
+4. Guide approval/moderation controls incl. availability controls/status display — ✅ tested
+5. Admin bookings list/detail and approval/status visibility — ✅ tested (detail view is missing, see Issues)
+6. Admin users list/detail — ✅ tested
+7. Admin listings/moderation/audit/disputes pages — ✅ tested
+8. QA guide visibility + availability override — ✅ tested end-to-end (paused → confirmed hidden from public `/guides` → resumed)
+9. Empty/error states and console/network errors — ✅ tested (all pages clean)
+10. Mobile layout for highest-risk admin page — ✅ tested (guide verification detail w/ availability override, 375px)
+
+## Routes tested
+
+| Route | Result |
+|---|---|
+| `/admin` (unauthenticated) | Redirects to `/auth?next=%2Fadmin` — route protection works |
+| `/admin/dashboard` | Loads, stats correct, no console errors |
+| `/admin/guides` (verification queue) | Empty state correct ("Нет заявок на проверке") |
+| `/admin/guides?view=drafts` | Empty state correct ("Нет черновиков анкет гидов") |
+| `/admin/guides/[id]` (guide verification detail) | Loads full profile, docs, decision panel, **availability override** |
+| `/admin/users` | List loads, 9 users, filters (role/status/verification/guide type/demo) present, pagination correct |
+| `/admin/users/[id]` | QA Guide detail loads: account info, guide profile summary, audit journal panel, account status (block/archive), role change, danger zone (delete demo account) |
+| `/admin/bookings` | List loads, 2 confirmed bookings shown (amounts, parties, status) — **no detail drill-down**, see Issues |
+| `/admin/listings` | Empty state correct ("В очереди нет объявлений") |
+| `/admin/moderation` | Empty, two tabs (listings/review-replies), both 0 |
+| `/admin/disputes` | Empty, stat tiles (Открыт/В работе/Решён/Закрыт) all 0, clear empty state |
+| `/admin/audit` | Log loads, 2 entries (both guide-approval events for another demo guide), filters for object/action/note-search present |
+| `/guides` (public) | Used to verify availability-override cascade |
+
+## Booking/approval coverage
+
+- **Guide approval controls**: verification queue empty (QA Guide already approved); decision panel present with Одобрить/Запросить изменения/Отклонить buttons and mandatory-comment textbox for reject/changes — not exercised further since no guide was pending (would have required destroying real approved-guide state, out of scope).
+- **Availability override** (the feature under test for this branch): confirmed full round-trip.
+  1. QA Guide default state: "Текущий статус: принимает заявки".
+  2. Clicked "Приостановить приём заявок" → POST 200, status flipped to "приём приостановлен", confirmation text "Приём заявок приостановлен." shown, persisted across reload.
+  3. Verified on public `/guides` (unauthenticated fetch check): QA Guide no longer appears in the catalog while paused — override correctly cascades to visibility.
+  4. Clicked "Возобновить приём заявок" → status flipped back to "принимает заявки", confirmation "Гид снова принимает заявки." — restored to original state before finishing.
+- **Bookings**: 2 confirmed bookings visible in the admin list, including one QA Traveler ↔ QA Guide booking (#465201b5, 10 000 ₽, "Подтверждено") and one real-demo-guide booking (#854b1723, 31 500 ₽). No admin action (approve/cancel/refund) is exposed on this list — see Issues #1.
+- **Disputes**: none open; could not exercise dispute resolution flow (no dispute data in QA fixtures — documented as skipped, not a defect).
+
+## Issues found
+
+| # | Severity | Category | Steps | Expected | Actual | Evidence |
+|---|---|---|---|---|---|---|
+| 1 | Medium | Missing feature / gap | Open `/admin/bookings`, try to click a booking row | Row opens a detail view with full booking info and admin actions (cancel/refund/status change) | Rows are plain non-interactive `<div>`s (confirmed via DOM inspection: no `href`, no click handler) — there is no way to drill into a booking from the admin UI at all | `admin-08-bookings-list.png` |
+| 2 | Medium | Audit/observability gap | On `/admin/guides/[id]`, click "Приостановить приём заявок" or "Возобновить приём заявок", then check "История модерации" on the same page, the "Журнал аудита" panel on `/admin/users/[id]`, and `/admin/audit` | The availability override is a state-changing admin action ("админ может переопределить" per the UI's own copy) and should be recorded somewhere an admin can review who paused a guide and when | None of the three audit surfaces record the action. `/admin/audit`'s action filter only offers Одобрено/Отклонено/Запрошены правки — availability overrides aren't a tracked event type at all | `admin-06/07-*.png`, `admin-12-audit-log.png` |
+| 3 | Low | Data visibility | View `/admin/users` list | — | Full list includes the site owner's real production admin account (`alexeytlt@gmail.com`) alongside demo/QA accounts, with no visual distinction beyond the missing "демо-аккаунт" tag (which QA accounts do have) — informational only, not a bug, but worth confirming this is intended before any bulk-action feature is added to this table | `admin-04-users-list.png` |
+
+No blocking bugs found. No console errors or warnings on any tested page. No failed/4xx/5xx network requests observed on any tested route (all requests in the `browser_network_requests` log returned 200).
+
+## Console/network errors
+
+Zero across all 13 pages/states tested (checked via `browser_console_messages(level: "warning")` after every navigation — 0 errors, 0 warnings every time). Network requests filtered for the guide-availability POST and general navigation all returned `200`.
+
+## Skipped / unreachable areas
+
+- **Guide reject/request-changes flow**: not exercised — would require a guide in "На проверке" status; none existed in the QA fixture set at test time, and creating one would have meant knocking a real or QA guide back to pending (out of scope for a read-mostly admin sweep).
+- **Booking detail/cancel/refund actions**: could not test — no such view exists (see Issue #1).
+- **Dispute resolution workflow**: no open disputes in QA fixtures; empty-state only.
+- **Bulk user actions** (checkbox column in `/admin/users`): visible but not exercised — no bulk-action toolbar appeared to activate; treated as low-risk, not explicitly in scope.
+- **Role-change and block/archive/delete-demo-account controls** on `/admin/users/[id]`: visible and read-verified but **not clicked**, since they are destructive/hard-to-reverse against the QA Guide account`s working state.
+- Traveler-side and guide-side effects of the availability override beyond the public `/guides` catalog (e.g., existing offer/inbox behavior for the paused guide) are covered by the parallel guide/traveler QA agents, not duplicated here.
+
+## Recommendations
+
+1. **Add a booking detail view** in `/admin/bookings` (or at minimum make rows link to `/admin/bookings/[id]`) so admins can inspect/cancel/refund a specific booking without dropping to Supabase directly.
+2. **Log availability overrides to the audit trail** — same mechanism already used for guide approve/reject, so the "who paused this guide and when" question is answerable from the UI instead of only from `guide_profiles.updated_at`.
+3. Consider tagging the audit-log action filter with an "Доступность" (availability) option once #2 lands, for consistency with the existing Одобрено/Отклонено/Запрошены правки filter.
+4. No urgent visual/console fixes needed — the admin surface is clean at both 1280px and 375px.

--- a/docs/qa/qa-fix-exec-opus-20260708/guide-report.md
+++ b/docs/qa/qa-fix-exec-opus-20260708/guide-report.md
@@ -1,0 +1,100 @@
+# Guide role QA report — provodnik.app (production)
+
+**Date:** 2026-07-08 (UTC)
+**Account:** qa-guide@example.com (role: guide, verification_status: approved)
+**Target:** https://provodnik.app
+**Tooling:** Playwright (chromium, headless) driven via `bun run scripts/qa-guide-role-flow.mjs` plus three targeted follow-up scripts, all under `/private/tmp/provodnik-guide-availability-exec/scripts/` (source-reference workspace) / `/Users/idev/.claude/jobs/7b651ca6/tmp/`. Ground truth for `is_available` cross-checked directly against `guide_profiles` via the Supabase service role (read-only selects only; no writes outside the product's own toggle action).
+
+## Scope
+
+Full guide-role checklist per `/tmp/provodnik-role-qa-20260708/guide-task.md`: login/route-protection, dashboard, profile + availability toggle, pause/resume public effect, calendar, listings, inbox/open requests, offer submission, bookings, messages, console/network errors, mobile (375px).
+
+## Routes tested
+
+| Route | Result |
+|---|---|
+| `/guide` (unauthenticated) | ✅ Redirects to `/auth?next=%2Fguide` |
+| `/auth?next=/guide` (login) | ✅ Logs in, redirects to `/guide/inbox` |
+| `/guide` (authenticated) | ✅ Redirects to `/guide/inbox` (this route *is* the dashboard) |
+| `/guide/profile` | ✅ Loads; availability toggle present |
+| `/guide/calendar` | ✅ Loads; weekly schedule view, empty (no active listings) |
+| `/guide/listings` | ✅ Loads; "Мои экскурсии", empty state + "Добавить экскурсию" CTA |
+| `/guide/inbox` | ✅ Loads; "Новые: 0", "Мои отклики: 0", "Подтверждённые: 1" |
+| `/guide/bookings` | ✅ Loads; 1 confirmed booking, 10 000 ₽ |
+| `/guide/bookings/[bookingId]` | ✅ Loads; status "Подтверждена", contact-reveal card |
+| `/guide/reviews` | ✅ Loads; empty state |
+| `/guide/stats` | ✅ Loads; all-zero metrics (expected, no completed tours) |
+| `/messages` | ✅ Loads; empty state (copy issue — see Issues) |
+| `/guides` (public listing) | ✅ Used to verify availability pause/resume effect |
+
+## Flows tested
+
+1. **Route protection** — unauthenticated access to `/guide` correctly bounces to `/auth?next=...`. Confirmed with screenshot.
+2. **Login/logout** — login succeeded and landed on `/guide/inbox`. Logout control was not found by accessible role/name search (`Выйти`/`Log out`/`Sign out`) within the header/nav in the automated pass — see Skipped areas; not confirmed as broken, just not located by the generic selector.
+3. **Guide dashboard** — `/guide` is a pure redirect to `/guide/inbox`; there is no separate dashboard route. Working as designed.
+4. **Profile editing surface** — profile page renders (About form, availability toggle, checklist, legal info, license manager, verification upload). Did not submit edits to About/legal fields to avoid mutating the QA fixture beyond the availability toggle (out of the stated test's primary target); the checklist and forms rendered without console/network errors.
+5. **Availability toggle (self-service pause/resume) — core feature under test:**
+   - Initial state: button read **"Приостановить приём заявок"** (available; click to pause).
+   - Clicked → guide became unavailable. Confirmed via a *separate* navigation to the public `/guides` listing: **"QA Guide" no longer appeared** (`appearsInListing: false`).
+   - Navigated back to `/guide/profile` fresh: button correctly read **"Возобновить приём заявок"** (paused; click to resume).
+   - Clicked → guide became available again. Confirmed via `/guides`: **"QA Guide" reappeared** (`appearsInListing: true`).
+   - **Ground truth cross-check** against `guide_profiles.is_available` via Supabase service role after the full run: `is_available: true` — matches the intended end state, and the public listing / toggle both agreed with it in a fresh, isolated session (see Issues #1 for a caveat observed mid-run).
+6. **Calendar / working-days** — `/guide/calendar` shows a weekly slot schedule tied to *active excursion listings*; since the QA guide has zero listings, every day correctly shows "Нет событий." No separate "working days" control exists outside the main availability toggle and per-listing scheduling — this matches the codebase (`src/lib/supabase/availability.ts` only exposes guide-level `is_available`, no day-of-week granularity).
+7. **Listings** — `/guide/listings` shows the expected empty state ("Экскурсий пока нет") with a "Добавить экскурсию" CTA. Did not create a listing (see Skipped areas / offer submission below for why this wasn't necessary to unblock).
+8. **Inbox / open requests** — `/guide/inbox` correctly shows 0 new requests, 0 responses, 1 confirmed. No traveler requests were open in the QA environment at test time.
+9. **Offer submission** — **blocked, not a defect.** No open traveler request existed to respond to (inbox confirmed 0 new). Creating a synthetic open request would require a *traveler*-role account and action, which is outside this guide-scoped account and task; per the task's own safety constraints (QA-only data, minimal footprint) the safer choice was to document the blocker rather than fabricate cross-role state. Creating a guide listing alone would not have unblocked this, since the gating resource is the traveler request, not the guide's listing. Recommend a coordinated run where the traveler-role QA pass creates a `ROLEQA-20260708-traveler-*` request first, then this guide flow re-runs step 9 against it.
+10. **Bookings** — 1 pre-existing confirmed booking (10 000 ₽) was visible and its detail page opened without errors. Detail page showed "Завершить / Отменить / Неявка" action buttons (not exercised, to avoid mutating a booking outside this account's own test-created data) and a contact-reveal card.
+11. **Messages** — `/messages` loads cleanly with an empty-state card. See Issues #2 for a copy defect.
+12. **Console/network errors** — see below.
+13. **Mobile (375px)** — `/guide/profile` and `/guide/inbox` both rendered without layout breakage at 375×812. Screenshots captured.
+
+## Booking/approval coverage
+
+- Guide-side view of an already-confirmed booking was exercised (detail page, action buttons present per state machine: complete/cancel/no-show).
+- Did **not** exercise the confirm/complete/cancel/no-show transitions themselves, since the only booking present was pre-existing (not QA-created by this run) and mutating its state would leave production data in an altered state outside this task's authority. Flagged in Skipped areas.
+- Did **not** exercise a full request → offer → accept → booking cycle end-to-end, because no open traveler request existed (see flow #9).
+
+## Issues found
+
+| # | Severity | Category | Where | Steps | Expected | Actual | Evidence |
+|---|---|---|---|---|---|---|---|
+| 1 | Low | UI consistency (unconfirmed/flaky) | `/guide/profile` availability toggle | Toggle availability twice in one long-lived browser session interleaved with ~10 other page navigations, then reload `/guide/profile` | Toggle label matches current `is_available` state | Label briefly showed "Возобновить приём заявок" (implying paused) once even though DB `is_available` was `true` and the public `/guides` listing correctly showed the guide as available | `guide-screens/20-final-profile-state.png`; `guide-flow-log.json` step `final-availability-check` |
+| 2 | Low | Copy/content (confirmed) | `/messages` empty state | Log in as a **guide** with no conversations, visit `/messages` | Role-appropriate empty-state copy | Copy reads "Здесь появятся переписки **с гидами**" ("chats with guides will appear here") and CTA "Найти тур" (traveler action) — both are traveler-oriented text shown to a guide | `guide-screens/24-messages-page.png`; source: `src/features/messaging/components/conversation-list.tsx:69-73` (hardcoded, no role branch) |
+
+**Follow-up on Issue #1:** re-tested twice in isolation — (a) a brand-new browser context + fresh login immediately after the main run showed the *correct* label matching DB state, and (b) a second isolated single-toggle test also showed the correct label after a full page reload. Response headers on `/guide/profile` are correctly `cache-control: private, no-cache, no-store, max-age=0, must-revalidate` with `x-vercel-cache: MISS` on every request — this is **not** an HTTP/CDN caching bug. Most likely a client-side render race after many rapid consecutive navigations in one session rather than a persistent data-correctness bug. Backend state (`guide_profiles.is_available`) and the public `/guides` listing were correct at every checkpoint. Recommend engineering add a Playwright regression test that toggles + rapidly navigates across guide routes and asserts the toggle label on return, since this is exactly the kind of race a guide could hit in real usage (multiple tabs, quick nav clicks).
+
+One non-issue investigated and ruled out: the booking detail page showed "Контакт появится после подтверждения" (phone will appear after confirmation) for the QA Traveler contact card even though the booking status was "Подтверждена" (confirmed). Traced to `booking-detail-screen.tsx:837-861` — the reveal condition (`contactRevealed`) had already correctly triggered (the card rendered); the fallback text only appears because `record.travelerPhone` is empty on this specific QA Traveler fixture account, not because of a logic defect.
+
+## Console/network errors
+
+- **Console errors/warnings:** none observed across all 21 scripted steps.
+- **Uncaught page errors:** none observed.
+- **HTTP 4xx/5xx responses:** none observed.
+- **Network events captured:** 68, all `net::ERR_ABORTED` on `requestfailed`, all attributable to benign Next.js prefetch cancellations (`?_rsc=...` segment prefetches aborted by the next navigation) and analytics/RUM beacons (`/cdn-cgi/rum`, `/monitoring`) aborted on page unload. These are expected artifacts of rapid scripted navigation, not product defects — full list in `guide-flow-log.json`.
+
+## Skipped / unreachable areas
+
+- **Logout control** — not located via generic accessible-name search (`Выйти` / `Log out` / `Sign out`); likely lives inside a menu/dropdown not expanded by the script. Not confirmed broken — recommend a follow-up with an explicit nav-menu-open step.
+- **Profile field edits** (About form, legal info, license manager, verification upload) — rendered without errors but form submissions were not exercised, to keep the QA footprint minimal on a shared fixture account.
+- **Full request → offer → accept → booking cycle** — blocked by no open traveler request in the environment at test time (see flow #9). Requires a coordinated traveler-role QA pass.
+- **Booking status transitions** (Завершить / Отменить / Неявка) — visible but not exercised, since the only booking present was pre-existing, not created by this run.
+- **Listing creation** ("Добавить экскурсию") — not exercised; not needed to unblock any other checklist item, and creating a public listing has real footprint on production (visible on `/guides` search) for no additional coverage gained this run.
+- **Contact-visibility settings** (`/guide/settings/contact-visibility`, present in the route map) — not in the guide-task checklist scope, not visited.
+
+## Recommendations
+
+1. **Fix `/messages` empty-state copy** to branch on role (guide vs. traveler) — currently hardcoded traveler-oriented text (`src/features/messaging/components/conversation-list.tsx:69-73`). Small, low-risk fix.
+2. **Add a regression test** for the availability toggle label staying correct after rapid multi-route navigation in one session (see Issue #1) — cheap insurance even though this run couldn't reproduce it in isolation.
+3. **Coordinate a cross-role QA pass**: have the traveler-role QA script create a `ROLEQA-20260708-traveler-*` request, then re-run this guide flow's offer-submission step against it to get real coverage of request → offer → accept → booking.
+4. **Add an explicit "open nav menu" step** to any future automated guide QA script so logout and any menu-only controls get exercised and screenshotted.
+5. No changes needed to the core availability pause/resume feature itself — it correctly gates public visibility in both directions and persisted correctly end-to-end.
+
+## Final state confirmation
+
+`qa-guide@example.com` (`guide_profiles.user_id = 904cdd5c-aa53-4d61-9986-65b9340b66b1`) is restored to `is_available: true`, `verification_status: approved` — verified via direct read-only Supabase query after all test steps completed, matching the task's safety requirement to leave the fixture account available.
+
+## Artifacts
+
+- Flow log / structured events: `/tmp/provodnik-role-qa-20260708/guide-flow-log.json`
+- Screenshots (24 files, desktop 1440px + mobile 375px): `/tmp/provodnik-role-qa-20260708/guide-screens/`
+- Driver scripts (source-reference workspace, not committed): `scripts/qa-guide-role-flow.mjs` under `/private/tmp/provodnik-guide-availability-exec/`

--- a/docs/qa/qa-fix-exec-opus-20260708/traveler-report.md
+++ b/docs/qa/qa-fix-exec-opus-20260708/traveler-report.md
@@ -1,0 +1,104 @@
+# Traveler role QA report — provodnik.app (production)
+
+**Date:** 2026-07-08
+**Target:** https://provodnik.app
+**Account:** qa-traveler@example.com (role: traveler)
+**Tooling:** standalone Playwright (Chromium) driver scripts under `/tmp/provodnik-role-qa-20260708/`, run against production with credentials loaded from the repo's `.env.local` (`QA_SEED_PASSWORD`). No secrets are printed below.
+
+## Scope
+
+Per `traveler-task.md`: login/logout + route protection, public catalog routes, traveler account/dashboard surfaces, traveler request creation with a QA-labeled request, guide search, booking/offer acceptance coverage, listing booking route, validation errors, and console/network + mobile check on the highest-risk flow.
+
+## Routes tested
+
+**Public / catalog**
+- `/` (home) — OK
+- `/guides` — OK, QA Guide visible in listing
+- `/guides/[slug]` (guide detail, e.g. `qa-guide-test-904cdd5c`) — OK
+- `/listings` and `/listings/[id]` — **404** (see Issues; feature-flagged off, not a bug)
+- `/requests` (public open-groups marketplace) — OK
+- `/requests/[id]` (existing open group / offer detail) — OK when the id is valid; **404** for one notification-linked id (see Issues)
+- `/how-it-works`, `/destinations` — OK
+
+**Traveler account**
+- `/trips` ("Мои поездки" — Активные / Подтверждённые / Мои группы tabs) — OK, with a rendering bug in the Подтверждённые tab (see Issues)
+- `/favorites` — intentional "coming soon" placeholder, not a bug
+- `/notifications` — OK, shows 1 unread "Новое предложение от QA Guide" — its deep link is broken (see Issues)
+- `/messages` — OK, empty state
+- `/account` (traveler profile edit — this is the actual profile page; `/profile` does not exist as a route, see below) — OK
+- `/account/notifications` — OK
+- `/bookings` (no index page exists in the codebase, only `/bookings/[bookingId]`) — 404, **expected**, not a bug
+- `/bookings/[bookingId]` (direct link to the one confirmed booking) — OK, fully populated except a broken contacts widget (see Issues)
+- `/profile` — 404, **expected** (no page.tsx in that route folder — it only holds server actions used by `/account`)
+- `/form` (traveler request creation — note: this resolves to `/`, the request form is the homepage hero, not a separate route) — OK
+
+## Flows tested
+
+1. **Route protection while logged out**: `/trips` → redirected to `/auth?next=%2Ftrips`. Correct.
+2. **Login**: qa-traveler@example.com logged in successfully, landed on `/trips`.
+3. **Logout**: found via the account-menu dropdown in the header (avatar trigger `aria-label="Меню аккаунта: …"` → "Выйти"). Confirmed working — header reverts to "Войти / Стать гидом" afterward.
+4. **Guide search**: "QA Guide Test" is visible and reachable at `/guides/qa-guide-test-904cdd5c`.
+5. **Traveler request creation**: filled destination (Казань), picked a date via the calendar popover, picked a theme ("История и культура"), expanded "Детали" and filled notes with `ROLEQA-20260708-traveler-20260708-1400`, submitted. Request was created successfully — confirmed present on `/requests` as "Казань" with "Это ваша группа" and initials "QT" (QA Traveler), and under `/trips → Активные (1)`.
+6. **Empty-form validation**: both the login form and the request form allow submit-click with empty required fields but show clear inline Russian validation messages afterward ("Укажите город или направление.", "Укажите дату начала.", "Выберите хотя бы одну категорию.") without creating bad data. Working as intended.
+7. **Join an open group** ("Присоединиться" on a `Сборные группы` card on the homepage): navigates correctly to `/requests/[id]` (confirmed after fixing a race condition in the test script — the link itself works fine).
+8. **Booking/approval coverage**: the QA traveler account already has **one confirmed booking** (`/bookings/30212d35-…`) with QA Guide, showing full trip/cost/payment-agreement details and a "Подтвердить договорённость" (confirm payment agreement) action still pending on both sides. I deliberately **did not click "Подтвердить договорённость" or "Отменить бронирование"**, since this booking is a shared fixture likely also used by the concurrent guide/admin role QA passes, and confirming or cancelling it would mutate shared state those tests may depend on. This is flagged as a blocker/judgment call, not a defect.
+9. **New-offer notification → accept flow**: the one unread notification ("Новое предложение от QA Guide") links to `/requests/d2b57384-…`, which **404s** — this is the actual blocker preventing an "accept a brand-new offer" walkthrough (distinct from the already-confirmed booking in #8). See Issues.
+10. **Listing booking route** `/listings/[id]/book`: could not be exercised — `/listings` itself 404s because `FEATURE_PUBLIC_CATALOG` is off in production (confirmed in source: `src/app/(site)/listings/page.tsx`). Not a bug, an active feature flag.
+11. **Mobile (375×812)**: repeated login, `/guides`, and `/form` (homepage) — layouts render correctly, no overflow or broken controls observed.
+
+## Evidence artifacts
+
+All screenshots under `/tmp/provodnik-role-qa-20260708/traveler-screens/` (42 files), notably:
+- `00-trips-logged-out-redirect.png`, `02-post-login.png` — auth/route-protection
+- `route-_guides.png`, `guide-detail.png` — guide search/detail
+- `form-filled.png`, `followup-03-form-complete.png`, `followup-04-after-submit.png`, `followup-05-requests-list.png` — request creation
+- `trips-confirmed-tab.png` — blank confirmed-booking card (Issue 1)
+- `booking-detail-direct.png` — confirmed booking detail + broken contacts widget (Issue 2)
+- `notification-offer-target.png` — 404 from the offer notification (Issue 3)
+- `route-_listings.png`, `group-join-landing.png` — flag-gated catalog / group-join
+- `mobile-01-post-login.png`, `mobile-02-guides.png`, `mobile-04-form.png` — mobile pass
+- `logout-menu-open.png`, `logout-attempt.png` — logout
+
+Raw structured data: `traveler-events.json`, `traveler-followup-events.json`, `traveler-trips-events.json`, `traveler-confirmed-probe.json`, `traveler-booking-detail.json`, `traveler-notif-offer.json` (all in the QA output folder).
+
+## Issues
+
+| # | Severity | Category | Steps | Expected | Actual | Evidence |
+|---|----------|----------|-------|----------|--------|----------|
+| 1 | **High** | Booking/UI defect | Log in as traveler → `/trips` → open "Подтверждённые" tab (badge shows count 1) | Confirmed-booking card shows guide name, date, price like the detail page does | Card renders only a lone em-dash `—` as its title; DOM shows `<article><h3>—</h3></article>` with no other fields at all, though the underlying booking record is fully populated (verified via the detail page) | `trips-confirmed-tab.png`; DOM dump in `traveler-confirmed-probe.json` |
+| 2 | **High** | Booking flow / broken deep link | Log in as traveler → `/notifications` → click "Открыть событие" on "Новое предложение от QA Guide" | Navigates to the offer/request so the traveler can review and accept it | Navigates to `/requests/d2b57384-c491-466d-b222-75ef0ebdff84` → **404 Страница не найдена** | `notification-offer-target.png`, `traveler-notif-offer.json` |
+| 3 | Medium | Data/contact defect | Log in as traveler → open confirmed booking `/bookings/30212d35-…` → "Свяжитесь с гидом напрямую" | Guide contact info (phone/Telegram) loads | Section shows "Не удалось загрузить контакты" (failed to load contacts); no console/network error was captured for it, so the failure is likely server-side/RSC-level | `booking-detail-direct.png` |
+| 4 | Low | Production content bug | Load `/` as any user | Homepage hero image renders | `/_next/image?...hero-provodnik.png` and `.../cities/kazan.png` both return **HTTP 400** — the underlying Supabase Storage objects themselves return 400 (verified via direct `curl`), so the hero/city images are broken for every visitor, not just this account | `traveler-events.json` network log; reproduced with `curl` |
+| 5 | Info (not a bug) | Feature flag | Visit `/listings` or `/listings/[id]` | — | 404, because `FEATURE_PUBLIC_CATALOG` is intentionally off in production (confirmed in source). Blocks testing item 7 (`/listings/[id]/book`) entirely — no listing page is reachable to reach the book route from. | `route-_listings.png` |
+| 6 | Info (not a bug) | Route design | Visit `/bookings` (no id) or `/profile` | — | Both 404 by design — `/bookings` has no index page (only `/bookings/[bookingId]`), and `/profile` has no `page.tsx` (the real traveler profile page is `/account`). My initial route list assumed these existed; corrected during testing. | `route-_bookings.png`, `route-_profile.png` |
+
+## Booking/approval coverage summary
+
+- **Existing confirmed booking**: found, but its presence in the traveler's own "Подтверждённые" list is effectively invisible due to Issue 1 (blank card) — a traveler using the UI as designed would very likely miss that they have a confirmed trip.
+- **New-offer acceptance**: blocked end-to-end by Issue 2 — the one unread "new offer" notification's link 404s, so there is no reachable in-app path from "I got an offer" to "I accepted it" for this account.
+- **Payment-agreement confirmation** (`Подтвердить договорённость`) on the existing confirmed booking is reachable and both sides show "ожидает" (pending) — intentionally not exercised (see flow #8 above) to avoid corrupting a fixture shared with concurrent guide/admin QA.
+- **Listing-based booking** (`/listings/[id]/book`) is entirely unreachable in production right now because the public listings catalog is feature-flagged off.
+
+## Console/network errors
+
+- 6× `400` on `/_next/image` for the homepage hero and a city thumbnail (Issue 4) — real, reproducible, affects all visitors.
+- 1× `404` on `/requests/d2b57384-…` (Issue 2).
+- 2× `404` on `/bookings` and 1× `404` on `/profile` — expected, non-issues (see Issue 6).
+- Many `net::ERR_ABORTED` entries for `/api/messages/unread-count` — these are the header's unread-badge poll being aborted by the test script navigating away mid-request; normal SPA behavior, not a defect.
+- 1× `401` on `/api/messages/unread-count` captured once, right after logout on the homepage — a background poll firing after the session ended; cosmetic, not visible to the user, low priority to fix.
+- No uncaught client-side JS exceptions (`pageerror`) were observed in any flow.
+
+## Skipped / unreachable areas
+
+- **Listing detail and listing-based booking** (`/listings/[id]`, `/listings/[id]/book`) — unreachable, `FEATURE_PUBLIC_CATALOG` is off in production.
+- **Payment-agreement confirm/cancel actions** on the existing confirmed booking — reachable but intentionally not clicked (shared fixture, see above).
+- **Accepting a brand-new guide offer end-to-end** — blocked by the 404 in Issue 2; no alternate reachable entry point to a "new, not-yet-accepted" offer was found during this pass.
+- Did not attempt any real payment or contact real users, per constraints.
+
+## Recommendations
+
+1. Fix the confirmed-booking list card in `/trips` (Подтверждённые tab) to render the same summary fields (guide name, date, price) the detail page already has — this looks like a simple missing-field/undefined-title bug in the card component, not a data problem.
+2. Fix or remove the dead link behind the "Новое предложение от QA Guide" notification — right now it 404s and fully blocks the accept-an-offer flow from that entry point.
+3. Investigate the "Не удалось загрузить контакты" failure on the booking detail page — likely a server-side fetch that's silently failing; traveler currently has no direct-contact fallback for a confirmed guide.
+4. Fix the broken hero/city images (`hero-provodnik.png`, `kazan.png` in Supabase Storage) — this is a visible, reproducible defect on the homepage for every visitor, unrelated to auth or role.
+5. Consider re-enabling or removing `/listings` entirely rather than leaving a dead, indexable 404 route in production if the public catalog will stay off for a while.

--- a/scripts/seed-test-users.mjs
+++ b/scripts/seed-test-users.mjs
@@ -25,7 +25,9 @@ const supa = createClient(url, key, { auth: { autoRefreshToken: false, persistSe
 
 const accounts = [
   { role: 'admin',    email: 'qa-admin@example.com',    fullName: 'QA Admin' },
-  { role: 'guide',    email: 'qa-guide@example.com',    fullName: 'QA Guide' },
+  // Placeholder phone (never a real number) so /bookings/[id] can demonstrate the
+  // off-platform contact reveal for the confirmed-booking QA path.
+  { role: 'guide',    email: 'qa-guide@example.com',    fullName: 'QA Guide', phone: '+7 900 000-00-00' },
   { role: 'traveler', email: 'qa-traveler@example.com', fullName: 'QA Traveler' }
 ];
 
@@ -56,7 +58,8 @@ for (const acct of accounts) {
     id: userId,
     email: acct.email,
     full_name: acct.fullName,
-    role: acct.role
+    role: acct.role,
+    ...(acct.phone ? { phone: acct.phone } : {})
   }, { onConflict: 'id' });
   if (profErr) throw new Error(`profile upsert ${acct.role}: ${profErr.message}`);
 

--- a/src/app/(protected)/admin/audit/page.test.tsx
+++ b/src/app/(protected)/admin/audit/page.test.tsx
@@ -78,9 +78,11 @@ describe("AdminAuditPage", () => {
       },
     ]);
     const adminClient = {
-      from: vi.fn((table: string) =>
-        table === "moderation_actions" ? actionsQuery : listingEventsQuery,
-      ),
+      from: vi.fn((table: string) => {
+        if (table === "moderation_actions") return actionsQuery;
+        if (table === "listing_moderation_events") return listingEventsQuery;
+        return createQueryResult([]); // guide_availability_events
+      }),
     };
     const serverClient = {
       from: vi.fn(() => createQueryResult([])),
@@ -99,5 +101,36 @@ describe("AdminAuditPage", () => {
     expect(screen.getAllByText("Анна Админ")).toHaveLength(2);
     expect(screen.getByText(/Документы проверены/)).toBeInTheDocument();
     expect(screen.getByText("Листинг «Ладога на каяке»")).toBeInTheDocument();
+  });
+
+  it("surfaces guide availability pause events with a link to the guide", async () => {
+    const availabilityQuery = createQueryResult([
+      {
+        id: "gae-1",
+        created_at: "2026-06-03T10:00:00.000Z",
+        available: false,
+        guide_id: "guide-9",
+        actor_id: "guide-9",
+        actor: { full_name: "Гид Тест", email: "guide@example.com" },
+      },
+    ]);
+    const adminClient = {
+      from: vi.fn((table: string) => {
+        if (table === "guide_availability_events") return availabilityQuery;
+        return createQueryResult([]);
+      }),
+    };
+    requireAdminSession.mockResolvedValue({ adminClient });
+
+    const ui = await AdminAuditPage();
+    render(ui);
+
+    expect(adminClient.from).toHaveBeenCalledWith("guide_availability_events");
+    expect(screen.getByText("Приём приостановлен")).toBeInTheDocument();
+    expect(screen.getByText("Доступность гида")).toBeInTheDocument();
+    const links = screen.getAllByRole("link");
+    expect(
+      links.some((l) => l.getAttribute("href") === "/admin/guides/guide-9"),
+    ).toBe(true);
   });
 });

--- a/src/app/(protected)/admin/audit/page.tsx
+++ b/src/app/(protected)/admin/audit/page.tsx
@@ -40,6 +40,7 @@ const SUBJECT_FILTERS = {
   guide_profile: "Гиды",
   listing: "Объявления",
   review: "Отзывы",
+  availability: "Доступность",
 } as const;
 
 const ACTION_FILTERS = {
@@ -125,6 +126,10 @@ export default async function AdminAuditPage({
   const includeListingEvents =
     (activeSubject === ALL || activeSubject === "listing") &&
     activeAction === ALL;
+  // guide_availability_events have no decision either; they are their own subject.
+  const includeAvailabilityEvents =
+    (activeSubject === ALL || activeSubject === "availability") &&
+    activeAction === ALL;
 
   const actionsPromise = runActions
     ? (() => {
@@ -174,13 +179,27 @@ export default async function AdminAuditPage({
       })()
     : Promise.resolve({ data: [] as const });
 
-  const [actionsResult, listingEventsResult] = await Promise.all([
-    actionsPromise,
-    listingEventsPromise,
-  ]);
+  const availabilityEventsPromise = includeAvailabilityEvents
+    ? adminClient
+        .from("guide_availability_events")
+        .select(
+          `id, created_at, available, guide_id, actor_id,
+           actor:profiles!guide_availability_events_actor_id_fkey(full_name, email)`,
+        )
+        .order("created_at", { ascending: false })
+        .range(offset, offset + PAGE_SIZE - 1)
+    : Promise.resolve({ data: [] as const });
+
+  const [actionsResult, listingEventsResult, availabilityEventsResult] =
+    await Promise.all([
+      actionsPromise,
+      listingEventsPromise,
+      availabilityEventsPromise,
+    ]);
 
   const actionsRows = actionsResult.data ?? [];
   const listingRows = listingEventsResult.data ?? [];
+  const availabilityRows = availabilityEventsResult.data ?? [];
 
   const entries: AuditEntry[] = [];
 
@@ -236,11 +255,27 @@ export default async function AdminAuditPage({
     });
   }
 
+  for (const row of availabilityRows) {
+    if (!row.created_at) continue;
+    const actorRow = first(row.actor);
+    entries.push({
+      id: `gae-${row.id}`,
+      createdAt: row.created_at,
+      adminLabel: profileDisplay(actorRow, row.actor_id),
+      actionLabel: row.available ? "Приём возобновлён" : "Приём приостановлен",
+      subjectLabel: "Доступность гида",
+      subjectHref: `/admin/guides/${row.guide_id}`,
+      note: null,
+    });
+  }
+
   entries.sort((a, b) => (a.createdAt < b.createdAt ? 1 : -1));
 
   const hasPrev = page > 1;
   const hasNext =
-    actionsRows.length === PAGE_SIZE || listingRows.length === PAGE_SIZE;
+    actionsRows.length === PAGE_SIZE ||
+    listingRows.length === PAGE_SIZE ||
+    availabilityRows.length === PAGE_SIZE;
 
   function pageHref(targetPage: number) {
     const params = new URLSearchParams();

--- a/src/app/(protected)/admin/bookings/[id]/actions.ts
+++ b/src/app/(protected)/admin/bookings/[id]/actions.ts
@@ -1,0 +1,24 @@
+"use server";
+
+import { revalidatePath } from "next/cache";
+
+import { requireAdminSession } from "@/lib/supabase/moderation";
+
+/**
+ * Confirm an awaiting-guide-confirmation booking from the detail route, then
+ * revalidate both the detail page and the list so the status flips on both.
+ */
+export async function confirmBookingAction(bookingId: string): Promise<void> {
+  const { adminClient } = await requireAdminSession();
+  const { data, error } = await adminClient
+    .from("bookings")
+    .update({ status: "confirmed" })
+    .eq("id", bookingId)
+    .eq("status", "awaiting_guide_confirmation")
+    .select("id, status")
+    .maybeSingle();
+  if (error) throw new Error("Не удалось подтвердить бронирование");
+  if (!data) throw new Error("Бронирование уже обработано или недоступно");
+  revalidatePath(`/admin/bookings/${bookingId}`);
+  revalidatePath("/admin/bookings");
+}

--- a/src/app/(protected)/admin/bookings/[id]/page.test.tsx
+++ b/src/app/(protected)/admin/bookings/[id]/page.test.tsx
@@ -1,0 +1,95 @@
+import { renderToStaticMarkup } from "react-dom/server";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const bunTestSpecifier = "bun:" + "test";
+const bunMock = process.env.VITEST
+  ? null
+  : ((await import(bunTestSpecifier)) as typeof import("bun:test")).mock;
+
+const requireAdminSession = vi.fn();
+const notFound = vi.fn(() => {
+  throw new Error("NEXT_NOT_FOUND");
+});
+
+if (typeof vi.doMock === "function") {
+  vi.doMock("server-only", () => ({}));
+  vi.doMock("@/lib/supabase/moderation", () => ({ requireAdminSession }));
+  vi.doMock("next/navigation", () => ({ notFound }));
+}
+
+bunMock?.module("server-only", () => ({}));
+bunMock?.module("@/lib/supabase/moderation", () => ({ requireAdminSession }));
+bunMock?.module("next/navigation", () => ({ notFound }));
+
+function createBookingQuery(row: unknown) {
+  const maybeSingle = vi.fn().mockResolvedValue({ data: row, error: null });
+  const eq = vi.fn(() => ({ maybeSingle }));
+  const select = vi.fn(() => ({ eq }));
+  return { select, eq, maybeSingle };
+}
+
+function createProfilesQuery(data: unknown[]) {
+  const inFilter = vi.fn().mockResolvedValue({ data, error: null });
+  const select = vi.fn(() => ({ in: inFilter }));
+  return { select, in: inFilter };
+}
+
+describe("AdminBookingDetailPage", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("renders the booking detail with status, price and party names", async () => {
+    const bookingQuery = createBookingQuery({
+      id: "booking-abcdef12",
+      status: "awaiting_guide_confirmation",
+      subtotal_minor: 125000,
+      currency: "RUB",
+      starts_at: "2026-06-10T10:00:00.000Z",
+      ends_at: null,
+      created_at: "2026-06-01T10:00:00.000Z",
+      updated_at: "2026-06-02T10:00:00.000Z",
+      party_size: 3,
+      meeting_point: "У фонтана",
+      traveler_id: "traveler-123456789",
+      guide_id: "guide-123456789",
+    });
+    const profilesQuery = createProfilesQuery([
+      { id: "traveler-123456789", full_name: "Иван Турист" },
+      { id: "guide-123456789", full_name: "Пётр Гид" },
+    ]);
+    const adminClient = {
+      from: vi.fn((table: string) =>
+        table === "profiles" ? profilesQuery : bookingQuery,
+      ),
+    };
+    requireAdminSession.mockResolvedValue({ adminClient });
+    const { default: AdminBookingDetailPage } = await import("./page");
+
+    const ui = await AdminBookingDetailPage({
+      params: Promise.resolve({ id: "booking-abcdef12" }),
+    });
+    const html = renderToStaticMarkup(ui);
+
+    expect(requireAdminSession).toHaveBeenCalledOnce();
+    expect(adminClient.from).toHaveBeenCalledWith("bookings");
+    expect(html).toContain("#abcdef12");
+    expect(html).toContain("Ожидает подтверждения");
+    expect(html).toContain("1 250 ₽");
+    expect(html).toContain("Иван Турист");
+    expect(html).toContain("Пётр Гид");
+    expect(html).toContain("Подтвердить");
+  });
+
+  it("returns notFound for an unknown booking id", async () => {
+    const bookingQuery = createBookingQuery(null);
+    const adminClient = { from: vi.fn(() => bookingQuery) };
+    requireAdminSession.mockResolvedValue({ adminClient });
+    const { default: AdminBookingDetailPage } = await import("./page");
+
+    await expect(
+      AdminBookingDetailPage({ params: Promise.resolve({ id: "missing" }) }),
+    ).rejects.toThrow("NEXT_NOT_FOUND");
+    expect(notFound).toHaveBeenCalled();
+  });
+});

--- a/src/app/(protected)/admin/bookings/[id]/page.tsx
+++ b/src/app/(protected)/admin/bookings/[id]/page.tsx
@@ -1,0 +1,145 @@
+import type { Metadata } from "next";
+import { notFound } from "next/navigation";
+
+import { PageHeader } from "@/components/shared/page-header";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { kopecksToRub } from "@/data/money";
+import { formatRussianDateTime } from "@/lib/dates";
+import { requireAdminSession } from "@/lib/supabase/moderation";
+
+import { confirmBookingAction } from "./actions";
+import { STATUS_LABELS } from "../status-labels";
+
+export const metadata: Metadata = { title: "Бронирование" };
+
+function DetailRow({ label, value }: { label: string; value: React.ReactNode }) {
+  return (
+    <div>
+      <dt className="text-xs uppercase tracking-[0.18em] text-muted-foreground">
+        {label}
+      </dt>
+      <dd className="mt-1 text-sm text-foreground">{value}</dd>
+    </div>
+  );
+}
+
+export default async function AdminBookingDetailPage({
+  params,
+}: {
+  params: Promise<{ id: string }>;
+}) {
+  const { id } = await params;
+  const { adminClient } = await requireAdminSession();
+
+  const { data: booking } = await adminClient
+    .from("bookings")
+    .select(
+      "id, status, subtotal_minor, currency, starts_at, ends_at, created_at, updated_at, party_size, meeting_point, traveler_id, guide_id",
+    )
+    .eq("id", id)
+    .maybeSingle();
+
+  if (!booking) {
+    notFound();
+  }
+
+  const profileIds = [booking.traveler_id, booking.guide_id].filter(
+    (value): value is string => Boolean(value),
+  );
+  const nameById = new Map<string, string | null>();
+  if (profileIds.length > 0) {
+    const { data: profiles } = await adminClient
+      .from("profiles")
+      .select("id, full_name")
+      .in("id", profileIds);
+    for (const profile of profiles ?? []) {
+      nameById.set(profile.id, profile.full_name);
+    }
+  }
+
+  function resolveName(value: string | null) {
+    if (!value) return "—";
+    const name = nameById.get(value)?.trim();
+    return name && name.length > 0 ? name : value.slice(-8);
+  }
+
+  const statusLabel = STATUS_LABELS[booking.status] ?? booking.status;
+  const priceText = booking.subtotal_minor
+    ? new Intl.NumberFormat("ru-RU", {
+        style: "currency",
+        currency: booking.currency,
+        maximumFractionDigits: 0,
+      }).format(kopecksToRub(booking.subtotal_minor))
+    : "—";
+
+  return (
+    <div className="space-y-8">
+      <PageHeader
+        eyebrow="Бронирование"
+        title={`#${booking.id.slice(-8)}`}
+        actions={<Badge>{statusLabel}</Badge>}
+      />
+
+      <div className="grid gap-6 xl:grid-cols-[minmax(0,1.4fr)_minmax(320px,0.9fr)]">
+        <Card>
+          <CardHeader>
+            <CardTitle className="text-lg">Детали</CardTitle>
+          </CardHeader>
+          <CardContent>
+            <dl className="grid gap-4 md:grid-cols-2">
+              <DetailRow label="Идентификатор" value={booking.id} />
+              <DetailRow label="Статус" value={statusLabel} />
+              <DetailRow label="Стоимость" value={priceText} />
+              <DetailRow
+                label="Путешественник"
+                value={resolveName(booking.traveler_id)}
+              />
+              <DetailRow label="Гид" value={resolveName(booking.guide_id)} />
+              <DetailRow
+                label="Участников"
+                value={booking.party_size ?? "—"}
+              />
+              <DetailRow
+                label="Место встречи"
+                value={booking.meeting_point ?? "—"}
+              />
+              <DetailRow
+                label="Начало"
+                value={
+                  booking.starts_at
+                    ? formatRussianDateTime(booking.starts_at)
+                    : "—"
+                }
+              />
+              <DetailRow
+                label="Создано"
+                value={formatRussianDateTime(booking.created_at)}
+              />
+              <DetailRow
+                label="Обновлено"
+                value={formatRussianDateTime(booking.updated_at)}
+              />
+            </dl>
+          </CardContent>
+        </Card>
+
+        {booking.status === "awaiting_guide_confirmation" ? (
+          <Card className="border-primary/40 shadow-md">
+            <CardHeader>
+              <CardTitle className="text-lg">Действие</CardTitle>
+            </CardHeader>
+            <CardContent>
+              <form action={confirmBookingAction.bind(null, booking.id)}>
+                <Button type="submit" size="default" className="min-h-[44px]">
+                  Подтвердить
+                </Button>
+              </form>
+            </CardContent>
+          </Card>
+        ) : null}
+      </div>
+    </div>
+  );
+}

--- a/src/app/(protected)/admin/bookings/page.tsx
+++ b/src/app/(protected)/admin/bookings/page.tsx
@@ -15,18 +15,9 @@ import { formatRussianDateTime } from "@/lib/dates";
 import { requireAdminSession } from "@/lib/supabase/moderation";
 
 import { confirmPaymentAction } from "./actions";
+import { STATUS_LABELS } from "./status-labels";
 
 export const metadata = { title: "Бронирования" };
-
-const STATUS_LABELS: Record<string, string> = {
-  pending: "В ожидании",
-  awaiting_guide_confirmation: "Ожидает подтверждения",
-  confirmed: "Подтверждено",
-  cancelled: "Отменено",
-  completed: "Завершено",
-  disputed: "Спор",
-  no_show: "Не явился",
-};
 
 const ALL_STATUSES = "all";
 
@@ -138,6 +129,7 @@ export default async function BookingsPage({
             return (
               <ListRow
                 key={booking.id}
+                href={`/admin/bookings/${booking.id}`}
                 title={`#${booking.id.slice(-8)}`}
                 subtitle={
                   <>

--- a/src/app/(protected)/admin/bookings/status-labels.ts
+++ b/src/app/(protected)/admin/bookings/status-labels.ts
@@ -1,0 +1,9 @@
+export const STATUS_LABELS: Record<string, string> = {
+  pending: "В ожидании",
+  awaiting_guide_confirmation: "Ожидает подтверждения",
+  confirmed: "Подтверждено",
+  cancelled: "Отменено",
+  completed: "Завершено",
+  disputed: "Спор",
+  no_show: "Не явился",
+};

--- a/src/app/(protected)/messages/page.tsx
+++ b/src/app/(protected)/messages/page.tsx
@@ -37,7 +37,11 @@ export default async function MessagesPage() {
   return (
     <section className="grid gap-6">
       <PageHeader eyebrow="Кабинет" title="Сообщения" />
-      <ConversationList initialThreads={threads} error={loadError} />
+      <ConversationList
+        initialThreads={threads}
+        error={loadError}
+        viewerRole={auth.role}
+      />
     </section>
   );
 }

--- a/src/app/(site)/requests/[requestId]/page.test.tsx
+++ b/src/app/(site)/requests/[requestId]/page.test.tsx
@@ -214,6 +214,22 @@ describe("RequestDetailPage", () => {
 
     expect(redirect).toHaveBeenCalledWith("/guide/inbox");
   });
+
+  it("redirects an owner/traveler to /trips instead of a public 404 for a missing request", async () => {
+    createSupabaseServerClient.mockResolvedValue({ from: vi.fn() });
+    getRequestById.mockResolvedValue({ data: null });
+    hasSupabaseEnv.mockReturnValue(false);
+    viewerRoleForRequest.mockResolvedValueOnce("owner");
+
+    await expect(
+      RequestDetailPage({
+        params: Promise.resolve({ requestId: "gone-request" }),
+        searchParams: Promise.resolve({}),
+      }),
+    ).rejects.toThrow("NEXT_REDIRECT:/trips");
+
+    expect(redirect).toHaveBeenCalledWith("/trips");
+  });
 });
 
 const ownerConfirmViewModel: PublicRequestDetailViewModel = {

--- a/src/app/(site)/requests/[requestId]/page.tsx
+++ b/src/app/(site)/requests/[requestId]/page.tsx
@@ -329,11 +329,14 @@ export default async function RequestDetailPage({
   const result = await getRequestDetail(requestId);
 
   if (!result.data) {
-    // A guide following an inbox "Подробнее" link to a request that is gone
-    // (withdrawn, deleted, or otherwise unreadable) should land back in their
-    // own inbox, not on the public "Запрос не найден" 404.
+    // The request is gone (withdrawn, deleted, or unreadable). A guide following
+    // an inbox "Подробнее" link lands back in their inbox; an owner/traveler who
+    // followed a stale "Новое предложение" notification lands in their trips
+    // cabinet — never the public "Запрос не найден" 404. Anonymous/unrelated
+    // visitors still get the correct notFound().
     const missingViewerRole = await viewerRoleForRequest(requestId);
     if (missingViewerRole === "guide") redirect("/guide/inbox");
+    if (missingViewerRole === "owner") redirect("/trips");
     notFound();
   }
 

--- a/src/components/trust/__tests__/contact-reveal.test.tsx
+++ b/src/components/trust/__tests__/contact-reveal.test.tsx
@@ -27,12 +27,21 @@ describe("ContactReveal", () => {
     expect(tel).not.toBeNull();
   });
 
-  it("shows a destructive Alert when confirmed but no contact", () => {
-    const { container, getByText } = render(
+  it("shows an info Alert (not a false error) when confirmed but no contact and no load error", () => {
+    const { container, getByText, queryByText } = render(
       <ContactReveal guide={guide} bookingStatus="confirmed" />,
     );
 
     expect(container.querySelector('[data-slot="alert"]')).not.toBeNull();
+    expect(getByText("Гид ещё не указал контакты")).not.toBeNull();
+    expect(queryByText("Не удалось загрузить контакты")).toBeNull();
+  });
+
+  it("shows the destructive load-error Alert only when the fetch actually failed", () => {
+    const { getByText } = render(
+      <ContactReveal guide={guide} bookingStatus="confirmed" contactError />,
+    );
+
     expect(getByText("Не удалось загрузить контакты")).not.toBeNull();
   });
 

--- a/src/components/trust/contact-reveal.test.tsx
+++ b/src/components/trust/contact-reveal.test.tsx
@@ -1,0 +1,42 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import { ContactReveal } from "./contact-reveal";
+
+const guide = { name: "QA Guide" };
+
+describe("ContactReveal", () => {
+  it("shows the phone when contact is present on a confirmed booking", () => {
+    render(
+      <ContactReveal
+        guide={guide}
+        contact={{ phone: "+7 900 000-00-00" }}
+        bookingStatus="confirmed"
+      />,
+    );
+    expect(screen.getByText("+7 900 000-00-00")).toBeInTheDocument();
+  });
+
+  it("says the contact is not on file when confirmed but no phone and no error", () => {
+    render(<ContactReveal guide={guide} contact={{}} bookingStatus="confirmed" />);
+    expect(screen.getByText("Гид ещё не указал контакты")).toBeInTheDocument();
+    expect(
+      screen.queryByText("Не удалось загрузить контакты"),
+    ).not.toBeInTheDocument();
+  });
+
+  it("shows the load-error copy only when the fetch actually failed", () => {
+    render(
+      <ContactReveal
+        guide={guide}
+        contact={{}}
+        bookingStatus="confirmed"
+        contactError
+      />,
+    );
+    expect(screen.getByText("Не удалось загрузить контакты")).toBeInTheDocument();
+    expect(
+      screen.queryByText("Гид ещё не указал контакты"),
+    ).not.toBeInTheDocument();
+  });
+});

--- a/src/components/trust/contact-reveal.tsx
+++ b/src/components/trust/contact-reveal.tsx
@@ -12,11 +12,13 @@ type ContactRevealProps = {
   guide: { name: string; avatarUrl?: string; verified?: boolean };
   contact?: { phone?: string; telegram?: string };
   bookingStatus: "pending" | "confirmed" | "completed";
+  /** true only when the contact fetch actually errored (not merely empty). */
+  contactError?: boolean;
   className?: string;
 };
 
 /** Guide identity always shown; contact details gated by booking status. */
-export function ContactReveal({ guide, contact, bookingStatus, className }: ContactRevealProps) {
+export function ContactReveal({ guide, contact, bookingStatus, contactError, className }: ContactRevealProps) {
   const revealed = bookingStatus === "confirmed" || bookingStatus === "completed";
   const hasContact = Boolean(contact?.phone || contact?.telegram);
 
@@ -71,10 +73,17 @@ export function ContactReveal({ guide, contact, bookingStatus, className }: Cont
       ) : null}
 
       {revealed && !hasContact ? (
-        <Alert variant="destructive">
-          <TriangleAlert />
-          <AlertDescription>Не удалось загрузить контакты</AlertDescription>
-        </Alert>
+        contactError ? (
+          <Alert variant="destructive">
+            <TriangleAlert />
+            <AlertDescription>Не удалось загрузить контакты</AlertDescription>
+          </Alert>
+        ) : (
+          <Alert variant="info">
+            <Phone />
+            <AlertDescription>Гид ещё не указал контакты</AlertDescription>
+          </Alert>
+        )
       ) : null}
     </div>
   );

--- a/src/features/bookings/components/booking-detail-screen.test.tsx
+++ b/src/features/bookings/components/booking-detail-screen.test.tsx
@@ -77,6 +77,7 @@ const booking = {
   created_at: "2026-06-01T00:00:00.000Z",
   updated_at: "2026-06-01T00:00:00.000Z",
   guide_phone: "+79990000000",
+  guide_contact_error: false,
   guide_profile: {
     user_id: "guide-1",
     bio: "",

--- a/src/features/bookings/components/booking-detail-screen.tsx
+++ b/src/features/bookings/components/booking-detail-screen.tsx
@@ -451,6 +451,7 @@ function TravelerBookingDetailView({
                       }}
                       contact={{ phone: guidePhone ?? undefined }}
                       bookingStatus={bookingStatusForReveal}
+                      contactError={booking.guide_contact_error}
                     />
                   </CardContent>
                 </Card>

--- a/src/features/homepage-classic/components/homepage-hero-form-classic.tsx
+++ b/src/features/homepage-classic/components/homepage-hero-form-classic.tsx
@@ -6,8 +6,10 @@ import type { DestinationOption } from "@/data/supabase/queries";
 
 import { HomepageRequestFormClassic } from "./homepage-request-form-classic";
 
-const HERO_IMAGE =
-  "https://yjzpshutgmhxizosbeef.supabase.co/storage/v1/object/public/listing-media/site/hero-provodnik.png";
+// Served from /public (version-controlled) instead of a Supabase Storage object
+// that returned HTTP 400 because it was never uploaded. Swap for a branded
+// /hero-provodnik.png once that asset is committed.
+const HERO_IMAGE = "/hero-valley.jpg";
 
 interface Props {
   destinations: DestinationOption[];

--- a/src/features/messaging/components/conversation-list.test.tsx
+++ b/src/features/messaging/components/conversation-list.test.tsx
@@ -1,0 +1,36 @@
+import { render, screen } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { describe, expect, it } from "vitest";
+
+import { ConversationList } from "./conversation-list";
+
+function renderWith(role: string | null) {
+  const client = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  return render(
+    <QueryClientProvider client={client}>
+      <ConversationList initialThreads={[]} viewerRole={role} />
+    </QueryClientProvider>,
+  );
+}
+
+describe("ConversationList empty state", () => {
+  it("shows traveler-oriented copy for a traveler", () => {
+    renderWith("traveler");
+    expect(
+      screen.getByText("Здесь появятся переписки с гидами."),
+    ).toBeInTheDocument();
+    expect(screen.getByRole("link", { name: "Найти тур" })).toBeInTheDocument();
+  });
+
+  it("shows guide-oriented copy for a guide", () => {
+    renderWith("guide");
+    expect(
+      screen.getByText("Здесь появятся переписки с путешественниками."),
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByRole("link", { name: "Найти тур" }),
+    ).not.toBeInTheDocument();
+  });
+});

--- a/src/features/messaging/components/conversation-list.tsx
+++ b/src/features/messaging/components/conversation-list.tsx
@@ -41,11 +41,13 @@ async function fetchThreads() {
 interface ConversationListProps {
   initialThreads: UserThreadSummary[];
   error?: boolean;
+  viewerRole?: string | null;
 }
 
 export function ConversationList({
   initialThreads,
   error: serverError = false,
+  viewerRole = null,
 }: ConversationListProps) {
   const { data: threads = initialThreads, isError } = useQuery({
     queryKey: ["message-threads"],
@@ -63,15 +65,22 @@ export function ConversationList({
       );
     }
 
+    const isGuide = viewerRole === "guide";
     return (
       <EmptyState
         icon={<MessageSquare />}
         title="Пока нет сообщений"
-        description="Здесь появятся переписки с гидами."
+        description={
+          isGuide
+            ? "Здесь появятся переписки с путешественниками."
+            : "Здесь появятся переписки с гидами."
+        }
         action={
-          <Button asChild>
-            <Link href="/listings">Найти тур</Link>
-          </Button>
+          isGuide ? undefined : (
+            <Button asChild>
+              <Link href="/listings">Найти тур</Link>
+            </Button>
+          )
         }
       />
     );

--- a/src/features/traveler/components/trip-card/trip-card.test.tsx
+++ b/src/features/traveler/components/trip-card/trip-card.test.tsx
@@ -325,4 +325,35 @@ describe("TripCard", () => {
     );
     expect(screen.getByText("Ваш отзыв · 5")).toBeInTheDocument();
   });
+
+  it("renders destination, guide name, and price for an upcoming booking WITHOUT routeStops", () => {
+    render(
+      <TripCard
+        phase="upcoming"
+        trip={{
+          ...baseTrip,
+          destination: "Казань",
+          guideName: "QA Guide",
+          price: { amount: 1_000_000, currency: "RUB" }, // 10 000 ₽ in minor units
+          // NOTE: no routeStops — the exact shape getConfirmedBookings returns.
+        }}
+      />,
+    );
+    expect(screen.getByRole("heading", { name: "Казань" })).toBeInTheDocument();
+    expect(screen.getByText("QA Guide")).toBeInTheDocument();
+    expect(screen.getByText(/10\s?000\s?₽/)).toBeInTheDocument();
+    expect(screen.getByText(/Написать гиду/)).toBeInTheDocument();
+  });
+
+  it("never renders a lone em-dash title for a booking with a destination", () => {
+    render(
+      <TripCard
+        phase="upcoming"
+        trip={{ ...baseTrip, destination: "Казань", guideName: "QA Guide" }}
+      />,
+    );
+    expect(
+      screen.queryByRole("heading", { name: "—" }),
+    ).not.toBeInTheDocument();
+  });
 });

--- a/src/features/traveler/components/trip-card/trip-card.tsx
+++ b/src/features/traveler/components/trip-card/trip-card.tsx
@@ -4,6 +4,7 @@ import { CalendarDays, Clock, Star, Users, Wallet } from "lucide-react";
 
 import { Badge } from "@/components/ui/badge";
 import { formatRubNumber } from "@/data/money";
+import { formatRussianDate } from "@/lib/dates";
 import { BADGE_CLASS } from "@/lib/styles";
 import { cn } from "@/lib/utils";
 
@@ -280,10 +281,14 @@ function TripCardContent({
       {shouldShowMeetingPoint(phase, trip.startsOn) && meetingPoint && (
         <p className="text-sm">{meetingPoint}</p>
       )}
-      {phase === "upcoming" &&
-        trip.routeStops &&
-        trip.routeStops.length >= 3 && (
-          <>
+      {(phase === "upcoming" || phase === "today") && (
+        <>
+          {trip.startsOn && (
+            <p className="text-sm text-muted-foreground">
+              {formatRussianDate(trip.startsOn)}
+            </p>
+          )}
+          {trip.routeStops && trip.routeStops.length >= 3 && (
             <div className="flex gap-1">
               {trip.routeStops.slice(0, 3).map((stop, i) => (
                 <Image
@@ -297,32 +302,29 @@ function TripCardContent({
                 />
               ))}
             </div>
-            {trip.inclusions && (
-              <p className="text-sm">
-                Что входит: {trip.inclusions.join(", ")}
-              </p>
-            )}
-            {trip.guideName && (
-              <div className="flex items-center gap-2">
-                {trip.guideAvatarUrl && (
-                  <Image
-                    unoptimized
-                    src={trip.guideAvatarUrl}
-                    alt=""
-                    width={32}
-                    height={32}
-                    className="size-8 rounded-full object-cover"
-                  />
-                )}
-                <span>{trip.guideName}</span>
-              </div>
-            )}
-            <span className="text-sm font-medium text-primary">Написать гиду</span>
-            {trip.price && (
-              <p>{formatRubNumber(trip.price.amount / 100)} ₽</p>
-            )}
-          </>
-        )}
+          )}
+          {trip.inclusions && (
+            <p className="text-sm">Что входит: {trip.inclusions.join(", ")}</p>
+          )}
+          {trip.guideName && (
+            <div className="flex items-center gap-2">
+              {trip.guideAvatarUrl && (
+                <Image
+                  unoptimized
+                  src={trip.guideAvatarUrl}
+                  alt=""
+                  width={32}
+                  height={32}
+                  className="size-8 rounded-full object-cover"
+                />
+              )}
+              <span>{trip.guideName}</span>
+            </div>
+          )}
+          <span className="text-sm font-medium text-primary">Написать гиду</span>
+          {trip.price && <p>{formatRubNumber(trip.price.amount / 100)} ₽</p>}
+        </>
+      )}
       {phase === "completed" &&
         (trip.hasReview ? (
           <p className="inline-flex items-center gap-1">Ваш отзыв · <Star className="size-3.5 fill-amber-400 text-amber-400" /> {trip.reviewRating}</p>

--- a/src/lib/city-image.test.ts
+++ b/src/lib/city-image.test.ts
@@ -32,14 +32,18 @@ describe("brandGradient", () => {
 });
 
 describe("cityImage", () => {
-  it("returns curated real on-place city imagery for known cities", () => {
-    const result = cityImage("Элиста");
+  it("does not point curated cities at the broken Supabase listing-media host", () => {
+    const url = cityImage("Казань");
+    expect(url).not.toContain(
+      "supabase.co/storage/v1/object/public/listing-media/site/cities",
+    );
+  });
 
-    // Curated branded city plate hosted in Supabase Storage — a real, correct
-    // local image, not a gradient and not foreign stock.
-    expect(result).not.toMatch(/^data:image\/svg/);
-    expect(result).toContain("/site/cities/elista.png");
-    expect(result).not.toContain("unsplash.com");
+  it("returns a local static path or an inline gradient for a curated city", () => {
+    const url = cityImage("Казань");
+    expect(
+      url.startsWith("/cities/") || url.startsWith("data:image/svg"),
+    ).toBe(true);
   });
 
   it("falls back to an on-canon SVG gradient for cities without curated imagery", () => {

--- a/src/lib/city-image.ts
+++ b/src/lib/city-image.ts
@@ -46,37 +46,15 @@ export function brandGradient(seed = "provodnik"): string {
 }
 
 /**
- * Curated, real, ON-PLACE photography per destination — the "replace the
- * gradient with a real city photo" the product always wanted. Foreign stock is
- * banned (a Moscow/alpine shot for a Kalmykia city was a truth + brand bug); only
- * verified-correct local imagery goes here. Keys are normalized (lowercase, ru-RU)
- * and matched by substring, so "Элиста" and "Элиста, Калмыкия" both resolve.
- */
-const SUPABASE_CITY_BASE =
-  "https://yjzpshutgmhxizosbeef.supabase.co/storage/v1/object/public/listing-media/site/cities";
-
-const CURATED_CITY_IMAGES: Record<string, string> = {
-  // Branded architectural-typography city plates (the city name built from its
-  // own landmarks), hosted in Supabase Storage (listing-media/site/cities).
-  "москва": `${SUPABASE_CITY_BASE}/moscow.png`,
-  "элиста": `${SUPABASE_CITY_BASE}/elista.png`,
-  "казань": `${SUPABASE_CITY_BASE}/kazan.png`,
-  "сочи": `${SUPABASE_CITY_BASE}/sochi.png`,
-};
-
-function normalizeCity(s: string): string {
-  return s.trim().toLocaleLowerCase("ru-RU");
-}
-
-/**
- * Backdrop for request heroes/cards, keyed by a destination name. Returns
- * curated real photography for known cities; otherwise an on-canon branded
- * gradient (never foreign stock).
+ * Backdrop for request heroes/cards, keyed by a destination name. Returns an
+ * on-canon branded gradient (never foreign stock).
+ *
+ * The former curated map pointed at Supabase Storage objects
+ * (listing-media/site/cities/*.png) that do not exist — every hit returned
+ * HTTP 400. Until branded city plates are committed to /public, the gradient
+ * is the correct, dependency-free backdrop; add a `/cities/<slug>.png` lookup
+ * here once those assets land.
  */
 export function cityImage(destination: string): string {
-  const key = normalizeCity(destination);
-  for (const [city, url] of Object.entries(CURATED_CITY_IMAGES)) {
-    if (key.includes(city)) return url;
-  }
   return brandGradient(destination);
 }

--- a/src/lib/supabase/bookings.ts
+++ b/src/lib/supabase/bookings.ts
@@ -10,6 +10,8 @@ import "server-only";
  * from client input.
  */
 
+import * as Sentry from "@sentry/nextjs";
+
 import { hasSupabaseAdminEnv } from "@/lib/env";
 import { createSupabaseAdminClient } from "@/lib/supabase/admin";
 import { createSupabaseServerClient } from "@/lib/supabase/server";
@@ -44,6 +46,11 @@ export type BookingWithDetails = BookingRow & {
    * Null for any other viewer or when not yet resolvable.
    */
   guide_phone: string | null;
+  /**
+   * true ONLY when the admin guide-contact query returned an error, so the UI
+   * can tell "guide has no phone on file" apart from "we failed to load it".
+   */
+  guide_contact_error: boolean;
   traveler_request: Pick<
     TravelerRequestRow,
     | "destination"
@@ -184,17 +191,24 @@ export async function getBooking(id: Uuid): Promise<BookingWithDetails | null> {
   // 20260528154254 — profiles.full_name is now the canonical name.)
   let guidePhone: string | null = null;
   let guideFullName: string | null = null;
+  let contactError = false;
   if (hasSupabaseAdminEnv()) {
     const {
       data: { user },
     } = await supabase.auth.getUser();
     if (user && user.id === booking.traveler_id) {
       const admin = createSupabaseAdminClient();
-      const { data: guideContact } = await admin
+      const { data: guideContact, error: guideContactError } = await admin
         .from("profiles")
         .select("full_name, phone")
         .eq("id", booking.guide_id)
         .maybeSingle();
+      if (guideContactError) {
+        Sentry.captureException(guideContactError, {
+          tags: { context: "booking-guide-contact" },
+        });
+        contactError = true;
+      }
       guideFullName = guideContact?.full_name ?? null;
       guidePhone = guideContact?.phone ?? null;
     }
@@ -216,6 +230,7 @@ export async function getBooking(id: Uuid): Promise<BookingWithDetails | null> {
     ...booking,
     guide_profile: resolvedGuideProfile,
     guide_phone: guidePhone,
+    guide_contact_error: contactError,
     traveler_request: (travelerRequestRes.data as BookingWithDetails["traveler_request"]) ?? null,
     guide_offer: (guideOfferRes.data as BookingWithDetails["guide_offer"]) ?? null,
   };

--- a/src/lib/supabase/traveler-requests.test.ts
+++ b/src/lib/supabase/traveler-requests.test.ts
@@ -232,4 +232,46 @@ describe('getConfirmedBookings', () => {
       booking_thread_id: 'thread-1',
     })
   })
+
+  it('falls back to a readable title (never a lone em-dash) when the request row is missing', async () => {
+    const bookingsQuery = {
+      select: vi.fn().mockReturnThis(),
+      eq: vi.fn().mockReturnThis(),
+      in: vi.fn().mockReturnThis(),
+      order: vi.fn().mockResolvedValue({
+        data: [{
+          id: 'booking-2',
+          offer_id: 'offer-2',
+          request_id: 'request-gone',
+          subtotal_minor: 150000,
+          currency: 'RUB',
+          guide_id: 'guide-1',
+          created_at: '2026-06-08T10:00:00Z',
+        }],
+        error: null,
+      }),
+    }
+    const requestsQuery = {
+      select: vi.fn().mockReturnThis(),
+      in: vi.fn().mockResolvedValue({ data: [], error: null }), // request row unreadable/gone
+    }
+    const threadsQuery = {
+      select: vi.fn().mockReturnThis(),
+      in: vi.fn().mockResolvedValue({ data: [], error: null }),
+    }
+    const from = vi.fn((table: string) => {
+      if (table === 'bookings') return bookingsQuery
+      if (table === 'traveler_requests') return requestsQuery
+      if (table === 'conversation_threads') return threadsQuery
+      throw new Error(`Unexpected table: ${table}`)
+    })
+    const rpc = vi.fn().mockResolvedValue({ data: [], error: null })
+
+    createSupabaseServerClient.mockResolvedValue({ from, rpc })
+
+    const [booking] = await getConfirmedBookings('traveler-confirmed-2')
+
+    expect(booking.destination).toBe('Поездка')
+    expect(booking.destination).not.toBe('—')
+  })
 })

--- a/src/lib/supabase/traveler-requests.ts
+++ b/src/lib/supabase/traveler-requests.ts
@@ -236,7 +236,10 @@ export const getConfirmedBookings = cache(async (travelerId: string): Promise<Co
     return {
       booking_id: b.id,
       request_id: b.request_id ?? b.id,
-      destination: req?.destination ?? '—',
+      // Never a lone em-dash: the card now shows guide/date/price, so a
+      // title-only fallback stays a readable card even when the request row
+      // is gone/unreadable (request_id is always set on offer-created bookings).
+      destination: req?.destination ?? 'Поездка',
       starts_on: req?.starts_on ?? '',
       price_minor: b.subtotal_minor ?? 0,
       currency: b.currency ?? 'RUB',

--- a/supabase/migrations/20260708130000_restore_guide_contact_phone.sql
+++ b/supabase/migrations/20260708130000_restore_guide_contact_phone.sql
@@ -1,10 +1,15 @@
--- Restore profiles.phone from the 2026-07-01 backup. The off-platform handoff on
--- confirmed bookings reads profiles.phone directly; it was left null after an
--- out-of-band backup into _bak_profiles_phone_20260701. Idempotent: only fills
--- rows whose phone is currently null so we never clobber a newer value.
-update public.profiles p
-set phone = b.phone
-from public._bak_profiles_phone_20260701 b
-where b.id = p.id
-  and p.phone is null
-  and b.phone is not null;
+-- Restore profiles.phone from the 2026-07-01 production backup when it exists.
+-- Local/CI databases do not have the out-of-band backup table, so this migration
+-- must be a no-op there. Idempotent: only fills rows whose phone is currently
+-- null so we never clobber a newer value.
+do $$
+begin
+  if to_regclass('public._bak_profiles_phone_20260701') is not null then
+    update public.profiles p
+    set phone = b.phone
+    from public._bak_profiles_phone_20260701 b
+    where b.id = p.id
+      and p.phone is null
+      and b.phone is not null;
+  end if;
+end $$;

--- a/supabase/migrations/20260708130000_restore_guide_contact_phone.sql
+++ b/supabase/migrations/20260708130000_restore_guide_contact_phone.sql
@@ -1,0 +1,10 @@
+-- Restore profiles.phone from the 2026-07-01 backup. The off-platform handoff on
+-- confirmed bookings reads profiles.phone directly; it was left null after an
+-- out-of-band backup into _bak_profiles_phone_20260701. Idempotent: only fills
+-- rows whose phone is currently null so we never clobber a newer value.
+update public.profiles p
+set phone = b.phone
+from public._bak_profiles_phone_20260701 b
+where b.id = p.id
+  and p.phone is null
+  and b.phone is not null;


### PR DESCRIPTION
## Summary
- fixes traveler confirmed-booking card rendering and missing-request offer fallback
- adds honest booking contact states plus guide phone restore migration
- fixes homepage image 400s, admin booking detail, availability audit visibility, and role-aware message empty copy
- records QA execution evidence under docs/qa/qa-fix-exec-opus-20260708

## Verification
- bun run typecheck
- bun run lint (0 errors; 21 pre-existing warnings)
- bun run test:run (1150/1150)
- bun run build

## Deployment notes
- includes Supabase migration: 20260708130000_restore_guide_contact_phone.sql
- do not deploy without applying/confirming the migration on production