### PR TITLE
fix: redirect stale offer notifications to bookings

### DIFF
--- a/src/app/(site)/requests/[requestId]/page.test.tsx
+++ b/src/app/(site)/requests/[requestId]/page.test.tsx
@@ -219,6 +219,11 @@ describe("RequestDetailPage", () => {
     createSupabaseServerClient.mockResolvedValue({ from: vi.fn() });
     getRequestById.mockResolvedValue({ data: null });
     hasSupabaseEnv.mockReturnValue(false);
+    getRequestViewerContext.mockResolvedValueOnce({
+      role: "public",
+      userId: "",
+      authReadFailed: false,
+    });
     viewerRoleForRequest.mockResolvedValueOnce("owner");
 
     await expect(
@@ -229,6 +234,42 @@ describe("RequestDetailPage", () => {
     ).rejects.toThrow("NEXT_REDIRECT:/trips");
 
     expect(redirect).toHaveBeenCalledWith("/trips");
+  });
+
+  it("redirects stale owner offer notifications to the resulting booking", async () => {
+    const maybeSingle = vi.fn().mockResolvedValue({
+      data: {
+        id: "booking-1",
+        traveler_id: "traveler-1",
+        guide_id: "guide-1",
+      },
+    });
+    const limit = vi.fn(() => ({ maybeSingle }));
+    const order = vi.fn(() => ({ limit }));
+    const or = vi.fn(() => ({ order }));
+    const eq = vi.fn(() => ({ or }));
+    const select = vi.fn(() => ({ eq }));
+    const from = vi.fn(() => ({ select }));
+
+    createSupabaseServerClient.mockResolvedValue({ from });
+    getRequestById.mockResolvedValue({ data: null });
+    getRequestViewerContext.mockResolvedValueOnce({
+      role: "public",
+      userId: "traveler-1",
+      authReadFailed: false,
+    });
+
+    await expect(
+      RequestDetailPage({
+        params: Promise.resolve({ requestId: "gone-request" }),
+        searchParams: Promise.resolve({}),
+      }),
+    ).rejects.toThrow("NEXT_REDIRECT:/bookings/booking-1");
+
+    expect(from).toHaveBeenCalledWith("bookings");
+    expect(eq).toHaveBeenCalledWith("request_id", "gone-request");
+    expect(or).toHaveBeenCalledWith("traveler_id.eq.traveler-1,guide_id.eq.traveler-1");
+    expect(redirect).toHaveBeenCalledWith("/bookings/booking-1");
   });
 });
 

--- a/src/app/(site)/requests/[requestId]/page.tsx
+++ b/src/app/(site)/requests/[requestId]/page.tsx
@@ -251,6 +251,31 @@ async function getOwnerDetailData(requestId: string, currentUserId: string | nul
   };
 }
 
+async function getBookingRedirectForMissingRequest(requestId: string): Promise<string | null> {
+  const viewerContext = await getRequestViewerContext(requestId);
+  if (!viewerContext.userId) return null;
+
+  try {
+    const supabase = await createSupabaseServerClient();
+    const { data } = await supabase
+      .from("bookings")
+      .select("id, traveler_id, guide_id")
+      .eq("request_id", requestId)
+      .or(`traveler_id.eq.${viewerContext.userId},guide_id.eq.${viewerContext.userId}`)
+      .order("created_at", { ascending: false })
+      .limit(1)
+      .maybeSingle();
+
+    const booking = data as { id?: string | null; guide_id?: string | null } | null;
+    if (!booking?.id) return null;
+    return booking.guide_id === viewerContext.userId
+      ? `/guide/bookings/${booking.id}`
+      : `/bookings/${booking.id}`;
+  } catch {
+    return null;
+  }
+}
+
 async function getGuideDetailData(requestId: string, guideId: string | null) {
   const supabase = await createSupabaseServerClient();
 
@@ -329,11 +354,12 @@ export default async function RequestDetailPage({
   const result = await getRequestDetail(requestId);
 
   if (!result.data) {
-    // The request is gone (withdrawn, deleted, or unreadable). A guide following
-    // an inbox "Подробнее" link lands back in their inbox; an owner/traveler who
-    // followed a stale "Новое предложение" notification lands in their trips
-    // cabinet — never the public "Запрос не найден" 404. Anonymous/unrelated
-    // visitors still get the correct notFound().
+    // The request is gone (withdrawn, deleted, or unreadable). If it already
+    // turned into a booking, send the signed-in traveler/guide to that booking
+    // instead of dead-ending stale offer notifications on a public 404.
+    const bookingRedirect = await getBookingRedirectForMissingRequest(requestId);
+    if (bookingRedirect) redirect(bookingRedirect);
+
     const missingViewerRole = await viewerRoleForRequest(requestId);
     if (missingViewerRole === "guide") redirect("/guide/inbox");
     if (missingViewerRole === "owner") redirect("/trips");


### PR DESCRIPTION
Hotfix for post-deploy QA: stale traveler offer notifications for requests already converted to bookings were still landing on /requests/:id 404. This adds a signed-in booking fallback and regression test.\n\nVerification:\n- bun run test:run src/app/(site)/requests/[requestId]/page.test.tsx\n- bun run typecheck\n- bun run lint\n- bun run build