### PR TITLE
Task 48: refine guide closed periods

### DIFF
--- a/src/app/(protected)/guide/profile/page.tsx
+++ b/src/app/(protected)/guide/profile/page.tsx
@@ -11,10 +11,6 @@ import {
 import { GUIDE_TYPES } from "@/features/auth/guide-type";
 import { GuideAboutForm } from "@/features/guide/components/profile/guide-about-form";
 import { GuideAvailabilityToggle } from "@/features/guide/components/profile/guide-availability-toggle";
-import {
-  GuideCalendarBlocks,
-  type CalendarBlock,
-} from "@/features/guide/components/profile/guide-calendar-blocks";
 import { GuideProfileChecklist } from "@/features/guide/components/profile/guide-profile-checklist";
 import type { ChecklistStep } from "@/features/guide/components/profile/guide-profile-checklist-types";
 import { LegalInformationForm } from "@/features/profile/components/LegalInformationForm";
@@ -34,7 +30,6 @@ import {
   submitForVerification,
 } from "@/features/guide/verification-actions";
 import { createSupabaseServerClient } from "@/lib/supabase/server";
-import { listOwnActiveBlocks } from "@/lib/supabase/guide-availability-blocks";
 import { roleHasAccess } from "@/lib/auth/role-routing";
 import { readAuthContextFromServer } from "@/lib/auth/server-auth";
 import { isGuideProfileConfirmed } from "@/lib/profile/guide-verification";
@@ -304,15 +299,6 @@ export default async function GuideProfilePage() {
   const guideTypeLabel =
     GUIDE_TYPES.find((t) => t.id === profile?.guide_type)?.label ?? null;
 
-  let calendarBlocks: CalendarBlock[] = [];
-  if (verificationStatus === "approved") {
-    try {
-      calendarBlocks = await listOwnActiveBlocks();
-    } catch (err) {
-      console.error("[GuideProfilePage] calendar blocks fetch failed:", err);
-    }
-  }
-
   return (
     <div className="space-y-10">
       <header className="space-y-2">
@@ -336,7 +322,6 @@ export default async function GuideProfilePage() {
       {verificationStatus === "approved" ? (
         <div className="space-y-4">
           <GuideAvailabilityToggle available={profile?.is_available ?? false} />
-          <GuideCalendarBlocks blocks={calendarBlocks} />
         </div>
       ) : null}
 

--- a/src/features/guide/actions/availabilityBlocks.test.ts
+++ b/src/features/guide/actions/availabilityBlocks.test.ts
@@ -23,7 +23,8 @@ describe("createAvailabilityBlockAction", () => {
     createOwnBlock.mockClear();
     const res = await createAvailabilityBlockAction({
       kind: "window",
-      date: "2026-07-10",
+      startDate: "2026-07-10",
+      endDate: "2026-07-10",
       startTime: "18:00",
       endTime: "14:00",
     });
@@ -36,6 +37,25 @@ describe("createAvailabilityBlockAction", () => {
     const res = await createAvailabilityBlockAction({ kind: "day", date: "2026-07-10" });
     expect(res.ok).toBe(true);
     expect(res.ok && res.warning).toBeTruthy();
+  });
+
+  it("accepts a time-window date range", async () => {
+    createOwnBlock.mockClear();
+    const res = await createAvailabilityBlockAction({
+      kind: "window",
+      startDate: "2026-07-01",
+      endDate: "2026-07-20",
+      startTime: "15:00",
+      endTime: "20:00",
+    });
+    expect(res).toEqual({ ok: true });
+    expect(createOwnBlock).toHaveBeenCalledWith({
+      kind: "window",
+      startDate: "2026-07-01",
+      endDate: "2026-07-20",
+      startTime: "15:00",
+      endTime: "20:00",
+    });
   });
 
   it("returns the ActionError message when the service throws one", async () => {

--- a/src/features/guide/actions/availabilityBlocks.ts
+++ b/src/features/guide/actions/availabilityBlocks.ts
@@ -26,7 +26,7 @@ export async function createAvailabilityBlockAction(
   }
   try {
     const { overlappingCommitments } = await createOwnBlock(parsed.data);
-    revalidatePath("/guide/profile");
+    revalidatePath("/guide/calendar");
     return overlappingCommitments > 0 ? { ok: true, warning: COMMITMENTS_WARNING } : { ok: true };
   } catch (err) {
     if (err instanceof ActionError) return { ok: false, error: err.message };
@@ -39,7 +39,7 @@ export async function deleteAvailabilityBlockAction(
 ): Promise<{ ok: true } | { ok: false; error: string }> {
   try {
     await softDeleteOwnBlock(blockId);
-    revalidatePath("/guide/profile");
+    revalidatePath("/guide/calendar");
     return { ok: true };
   } catch (err) {
     if (err instanceof ActionError) return { ok: false, error: err.message };

--- a/src/features/guide/components/profile/guide-calendar-blocks.test.tsx
+++ b/src/features/guide/components/profile/guide-calendar-blocks.test.tsx
@@ -1,10 +1,15 @@
 import { describe, it, expect, vi } from "vitest";
-import { render, screen } from "@testing-library/react";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+
+const { createAvailabilityBlockAction, deleteAvailabilityBlockAction } = vi.hoisted(() => ({
+  createAvailabilityBlockAction: vi.fn(async () => ({ ok: true })),
+  deleteAvailabilityBlockAction: vi.fn(async () => ({ ok: true })),
+}));
 
 vi.mock("next/navigation", () => ({ useRouter: () => ({ refresh: vi.fn() }) }));
 vi.mock("@/features/guide/actions/availabilityBlocks", () => ({
-  createAvailabilityBlockAction: vi.fn(async () => ({ ok: true })),
-  deleteAvailabilityBlockAction: vi.fn(async () => ({ ok: true })),
+  createAvailabilityBlockAction,
+  deleteAvailabilityBlockAction,
 }));
 
 import { GuideCalendarBlocks } from "./guide-calendar-blocks";
@@ -49,5 +54,29 @@ describe("GuideCalendarBlocks", () => {
       />,
     );
     expect(screen.getByText(/14:00\s*–\s*18:00/)).toBeInTheDocument();
+  });
+
+  it("submits a daily time window with start and end dates", async () => {
+    createAvailabilityBlockAction.mockClear();
+    render(<GuideCalendarBlocks blocks={[]} />);
+
+    fireEvent.click(screen.getByRole("button", { name: /Закрыть часы/i }));
+    fireEvent.change(screen.getByLabelText("С"), { target: { value: "2026-07-01" } });
+    fireEvent.change(screen.getByLabelText("По"), { target: { value: "2026-07-20" } });
+    fireEvent.change(screen.getByLabelText("Время с"), { target: { value: "15:00" } });
+    fireEvent.change(screen.getByLabelText("Время по"), { target: { value: "20:00" } });
+
+    fireEvent.click(screen.getByRole("button", { name: "Закрыть период" }));
+
+    await waitFor(() => {
+      expect(createAvailabilityBlockAction).toHaveBeenCalledWith({
+        kind: "window",
+        startDate: "2026-07-01",
+        endDate: "2026-07-20",
+        startTime: "15:00",
+        endTime: "20:00",
+        reason: undefined,
+      });
+    });
   });
 });

--- a/src/features/guide/components/profile/guide-calendar-blocks.tsx
+++ b/src/features/guide/components/profile/guide-calendar-blocks.tsx
@@ -24,7 +24,7 @@ export type CalendarBlock = {
 const KINDS = [
   { id: "day", label: "Закрыть день" },
   { id: "range", label: "Закрыть даты" },
-  { id: "window", label: "Закрыть время" },
+  { id: "window", label: "Закрыть часы" },
 ] as const;
 type Kind = (typeof KINDS)[number]["id"];
 
@@ -54,6 +54,11 @@ export function GuideCalendarBlocks({ blocks }: { blocks: CalendarBlock[] }) {
   const [message, setMessage] = React.useState<{ tone: "error" | "warning"; text: string } | null>(null);
   const [pending, startTransition] = React.useTransition();
 
+  function handleStartDateChange(value: string) {
+    setDate(value);
+    if (endDate < value) setEndDate(value);
+  }
+
   function submit() {
     setMessage(null);
     const reasonValue = reason.trim() ? reason.trim() : undefined;
@@ -62,7 +67,7 @@ export function GuideCalendarBlocks({ blocks }: { blocks: CalendarBlock[] }) {
         ? { kind, date, reason: reasonValue }
         : kind === "range"
           ? { kind, startDate: date, endDate, reason: reasonValue }
-          : { kind, date, startTime, endTime, reason: reasonValue };
+          : { kind, startDate: date, endDate, startTime, endTime, reason: reasonValue };
 
     startTransition(async () => {
       const res = await createAvailabilityBlockAction(payload);
@@ -111,17 +116,17 @@ export function GuideCalendarBlocks({ blocks }: { blocks: CalendarBlock[] }) {
 
       <div className="grid gap-3 sm:grid-cols-2">
         <div className="space-y-1.5">
-          <Label htmlFor="block-date">{kind === "range" ? "С" : "Дата"}</Label>
+          <Label htmlFor="block-date">{kind === "day" ? "Дата" : "С"}</Label>
           <Input
             id="block-date"
             type="date"
             min={today}
             value={date}
-            onChange={(e) => setDate(e.target.value)}
+            onChange={(e) => handleStartDateChange(e.target.value)}
           />
         </div>
 
-        {kind === "range" ? (
+        {kind === "range" || kind === "window" ? (
           <div className="space-y-1.5">
             <Label htmlFor="block-end-date">По</Label>
             <Input
@@ -137,7 +142,7 @@ export function GuideCalendarBlocks({ blocks }: { blocks: CalendarBlock[] }) {
         {kind === "window" ? (
           <>
             <div className="space-y-1.5">
-              <Label htmlFor="block-start-time">Начало</Label>
+              <Label htmlFor="block-start-time">Время с</Label>
               <Input
                 id="block-start-time"
                 type="time"
@@ -146,7 +151,7 @@ export function GuideCalendarBlocks({ blocks }: { blocks: CalendarBlock[] }) {
               />
             </div>
             <div className="space-y-1.5">
-              <Label htmlFor="block-end-time">Конец</Label>
+              <Label htmlFor="block-end-time">Время по</Label>
               <Input
                 id="block-end-time"
                 type="time"

--- a/src/lib/availability/blocks.test.ts
+++ b/src/lib/availability/blocks.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect } from "vitest";
 
 import {
   buildBlockInterval,
+  buildBlockIntervals,
   intervalsOverlap,
   isIntervalBlocked,
   createBlockInputSchema,
@@ -31,13 +32,29 @@ describe("buildBlockInterval", () => {
   it("time-window block uses the Moscow wall-clock times", () => {
     const interval = buildBlockInterval({
       kind: "window",
-      date: "2026-07-10",
+      startDate: "2026-07-10",
+      endDate: "2026-07-10",
       startTime: "14:00",
       endTime: "18:00",
     });
     expect(interval.startAt).toBe("2026-07-10T11:00:00.000Z");
     expect(interval.endAt).toBe("2026-07-10T15:00:00.000Z");
     expect(interval.allDay).toBe(false);
+  });
+
+  it("time-window date range creates one daily window per Moscow date", () => {
+    const intervals = buildBlockIntervals({
+      kind: "window",
+      startDate: "2026-07-01",
+      endDate: "2026-07-03",
+      startTime: "15:00",
+      endTime: "20:00",
+    });
+    expect(intervals).toEqual([
+      { startAt: "2026-07-01T12:00:00.000Z", endAt: "2026-07-01T17:00:00.000Z", allDay: false },
+      { startAt: "2026-07-02T12:00:00.000Z", endAt: "2026-07-02T17:00:00.000Z", allDay: false },
+      { startAt: "2026-07-03T12:00:00.000Z", endAt: "2026-07-03T17:00:00.000Z", allDay: false },
+    ]);
   });
 });
 
@@ -65,7 +82,8 @@ describe("isIntervalBlocked (union of blocks)", () => {
   const day = buildBlockInterval({ kind: "day", date: "2026-07-10" });
   const window = buildBlockInterval({
     kind: "window",
-    date: "2026-07-12",
+    startDate: "2026-07-12",
+    endDate: "2026-07-12",
     startTime: "09:00",
     endTime: "12:00",
   });
@@ -96,9 +114,21 @@ describe("createBlockInputSchema", () => {
   it("rejects a window whose end is not after its start", () => {
     const res = createBlockInputSchema.safeParse({
       kind: "window",
-      date: "2026-07-10",
+      startDate: "2026-07-10",
+      endDate: "2026-07-10",
       startTime: "18:00",
       endTime: "14:00",
+    });
+    expect(res.success).toBe(false);
+  });
+
+  it("rejects a window range whose end date is before its start date", () => {
+    const res = createBlockInputSchema.safeParse({
+      kind: "window",
+      startDate: "2026-07-20",
+      endDate: "2026-07-01",
+      startTime: "15:00",
+      endTime: "20:00",
     });
     expect(res.success).toBe(false);
   });

--- a/src/lib/availability/blocks.ts
+++ b/src/lib/availability/blocks.ts
@@ -15,6 +15,7 @@ const DAY_MS = 24 * 60 * 60 * 1000;
 
 const DATE_RE = /^\d{4}-\d{2}-\d{2}$/;
 const TIME_RE = /^\d{2}:\d{2}$/;
+const MAX_WINDOW_RANGE_DAYS = 366;
 
 const dateField = z.string().regex(DATE_RE, "Укажите дату.");
 const timeField = z.string().regex(TIME_RE, "Укажите время.");
@@ -30,7 +31,9 @@ export const createBlockInputSchema = z.discriminatedUnion("kind", [
   }),
   z.object({
     kind: z.literal("window"),
-    date: dateField,
+    date: dateField.optional(),
+    startDate: dateField.optional(),
+    endDate: dateField.optional(),
     startTime: timeField,
     endTime: timeField,
     reason: reasonField,
@@ -49,6 +52,42 @@ export const createBlockInputSchema = z.discriminatedUnion("kind", [
       message: "Время окончания должно быть позже начала.",
       path: ["endTime"],
     });
+  }
+  if (input.kind === "window") {
+    const startDate = input.startDate ?? input.date;
+    const endDate = input.endDate ?? startDate;
+    if (!startDate) {
+      ctx.addIssue({
+        code: "custom",
+        message: "Укажите дату начала.",
+        path: ["startDate"],
+      });
+    }
+    if (!endDate) {
+      ctx.addIssue({
+        code: "custom",
+        message: "Укажите дату окончания.",
+        path: ["endDate"],
+      });
+    }
+    if (startDate && endDate) {
+      if (endDate < startDate) {
+        ctx.addIssue({
+          code: "custom",
+          message: "Дата окончания раньше даты начала.",
+          path: ["endDate"],
+        });
+      } else {
+        const spanDays = Math.floor((moscowDayStart(endDate) - moscowDayStart(startDate)) / DAY_MS) + 1;
+        if (spanDays > MAX_WINDOW_RANGE_DAYS) {
+          ctx.addIssue({
+            code: "custom",
+            message: "Период для ежедневного окна не должен быть длиннее года.",
+            path: ["endDate"],
+          });
+        }
+      }
+    }
   }
 });
 
@@ -87,13 +126,51 @@ export function buildBlockInterval(input: CreateBlockInput): BlockInterval {
       };
     }
     case "window": {
+      const date = input.startDate ?? input.date;
+      if (!date) throw new Error("window_start_date_required");
       return {
-        startAt: new Date(`${input.date}T${input.startTime}:00${MSK_UTC_OFFSET}`).toISOString(),
-        endAt: new Date(`${input.date}T${input.endTime}:00${MSK_UTC_OFFSET}`).toISOString(),
+        startAt: new Date(`${date}T${input.startTime}:00${MSK_UTC_OFFSET}`).toISOString(),
+        endAt: new Date(`${date}T${input.endTime}:00${MSK_UTC_OFFSET}`).toISOString(),
         allDay: false,
       };
     }
   }
+}
+
+function formatDateOnlyLocal(d: Date): string {
+  const y = d.getUTCFullYear();
+  const m = String(d.getUTCMonth() + 1).padStart(2, "0");
+  const day = String(d.getUTCDate()).padStart(2, "0");
+  return `${y}-${m}-${day}`;
+}
+
+/** Convert one user input into the stored interval rows it represents. */
+export function buildBlockIntervals(input: CreateBlockInput): BlockInterval[] {
+  if (input.kind !== "window") return [buildBlockInterval(input)];
+
+  const startDate = input.startDate ?? input.date;
+  const endDate = input.endDate ?? startDate;
+  if (!startDate || !endDate) throw new Error("window_date_range_required");
+
+  const start = moscowDayStart(startDate);
+  const end = moscowDayStart(endDate);
+  const spanDays = Math.floor((end - start) / DAY_MS) + 1;
+  const intervals: BlockInterval[] = [];
+  for (let offset = 0; offset < spanDays; offset += 1) {
+    const date = formatDateOnlyLocal(new Date(`${startDate}T00:00:00.000Z`));
+    const dateWithOffset = new Date(`${date}T00:00:00.000Z`);
+    dateWithOffset.setUTCDate(dateWithOffset.getUTCDate() + offset);
+    intervals.push(
+      buildBlockInterval({
+        kind: "window",
+        startDate: formatDateOnlyLocal(dateWithOffset),
+        endDate: formatDateOnlyLocal(dateWithOffset),
+        startTime: input.startTime,
+        endTime: input.endTime,
+      }),
+    );
+  }
+  return intervals;
 }
 
 /** Half-open overlap test: [aStart, aEnd) ∩ [bStart, bEnd) ≠ ∅. */

--- a/src/lib/supabase/guide-availability-blocks.ts
+++ b/src/lib/supabase/guide-availability-blocks.ts
@@ -11,7 +11,7 @@ import "server-only";
 
 import { ActionError } from "@/lib/actions/create-action";
 import {
-  buildBlockInterval,
+  buildBlockIntervals,
   isIntervalBlocked,
   type CreateBlockInput,
 } from "@/lib/availability/blocks";
@@ -65,18 +65,20 @@ export async function createOwnBlock(
   input: CreateBlockInput,
 ): Promise<{ overlappingCommitments: number }> {
   const guideId = await currentGuideId();
-  const interval = buildBlockInterval(input);
+  const intervals = buildBlockIntervals(input);
   const supabase = await createSupabaseServerClient();
 
-  const { error } = await supabase.from(TABLE).insert({
-    guide_id: guideId,
-    start_at: interval.startAt,
-    end_at: interval.endAt,
-    all_day: interval.allDay,
-    reason: input.reason?.trim() ? input.reason.trim() : null,
-    source: "manual",
-    created_by: guideId,
-  });
+  const { error } = await supabase.from(TABLE).insert(
+    intervals.map((interval) => ({
+      guide_id: guideId,
+      start_at: interval.startAt,
+      end_at: interval.endAt,
+      all_day: interval.allDay,
+      reason: input.reason?.trim() ? input.reason.trim() : null,
+      source: "manual",
+      created_by: guideId,
+    })),
+  );
   if (error) throw error;
 
   // Existing commitments are never cancelled by a new block — only counted so the
@@ -90,10 +92,10 @@ export async function createOwnBlock(
     .not("starts_at", "is", null)
     .not("ends_at", "is", null);
 
-  const blockInterval = [{ start_at: interval.startAt, end_at: interval.endAt }];
+  const blockIntervals = intervals.map((interval) => ({ start_at: interval.startAt, end_at: interval.endAt }));
   const overlappingCommitments = (
     (offers as { starts_at: string; ends_at: string }[]) ?? []
-  ).filter((o) => isIntervalBlocked(blockInterval, o.starts_at, o.ends_at)).length;
+  ).filter((o) => isIntervalBlocked(blockIntervals, o.starts_at, o.ends_at)).length;
 
   return { overlappingCommitments };
 }


### PR DESCRIPTION
## Summary
- remove the closed-periods block from Guide Profile while testing stays in Calendar
- add end date for time-window closures so guides can close the same hours across a date range
- store time-window ranges as daily blocked intervals, preserving one-day time windows and whole-day/date-range closures
- revalidate the calendar page after creating/deleting blocks

## Verification
- bun run test:run src/lib/availability/blocks.test.ts src/features/guide/actions/availabilityBlocks.test.ts src/features/guide/components/profile/guide-calendar-blocks.test.tsx
- bun run typecheck
- bun run lint -- src/app/'\(protected\)'/guide/profile/page.tsx src/features/guide/actions/availabilityBlocks.ts src/features/guide/actions/availabilityBlocks.test.ts src/features/guide/components/profile/guide-calendar-blocks.tsx src/features/guide/components/profile/guide-calendar-blocks.test.tsx src/lib/availability/blocks.ts src/lib/availability/blocks.test.ts src/lib/supabase/guide-availability-blocks.ts

Note: initial commit hook failed on a stale missing script `lint:canon`; the same relevant checks above passed manually.