### PR TITLE
Fix guide nav requests/bookings order

### DIFF
--- a/src/components/shared/guide-bottom-nav.test.tsx
+++ b/src/components/shared/guide-bottom-nav.test.tsx
@@ -8,11 +8,14 @@ vi.mock("next/navigation", () => ({
 import { GuideBottomNav } from "./guide-bottom-nav";
 
 describe("GuideBottomNav", () => {
-  it("renders Запросы, Экскурсии, Заказы and Отзывы nav items", () => {
+  it("renders Запросы and Мои бронирования next to each other", () => {
     render(<GuideBottomNav />);
     expect(screen.getByRole("link", { name: "Запросы" })).toBeDefined();
+    expect(screen.getByRole("link", { name: "Мои бронирования" })).toHaveAttribute("href", "/guide/bookings");
     expect(screen.getByRole("link", { name: "Экскурсии" })).toBeDefined();
-    expect(screen.getByRole("link", { name: "Заказы" })).toBeDefined();
     expect(screen.getByRole("link", { name: "Отзывы" })).toHaveAttribute("href", "/guide/reviews");
+
+    const labels = screen.getAllByRole("link").map((link) => link.textContent?.trim());
+    expect(labels).toEqual(["Запросы", "Мои бронирования", "Экскурсии", "Отзывы"]);
   });
 });

--- a/src/lib/navigation.test.ts
+++ b/src/lib/navigation.test.ts
@@ -162,9 +162,18 @@ describe("role-based nav groups", () => {
   it("uses the simplified guide workspace labels", () => {
     expect(guidePrimaryNav.map((item) => item.label)).toEqual([
       "Запросы",
+      "Мои бронирования",
       "Экскурсии",
-      "Заказы",
       "Отзывы",
+    ]);
+  });
+
+  it("keeps guide requests and bookings next to each other", () => {
+    expect(guidePrimaryNav.map((item) => item.href)).toEqual([
+      "/guide/inbox",
+      "/guide/bookings",
+      "/guide/listings",
+      "/guide/reviews",
     ]);
   });
 });

--- a/src/lib/navigation.ts
+++ b/src/lib/navigation.ts
@@ -37,7 +37,7 @@ export const ROUTES = {
   account:      { href: "/account",      label: "Профиль",           icon: User },
   guideInbox:   { href: "/guide/inbox",    label: "Запросы",         icon: Inbox },
   guideListings:{ href: "/guide/listings", label: "Экскурсии", shortLabel: "Экскурсии", icon: Compass },
-  guideBookings:{ href: "/guide/bookings", label: "Заказы",          icon: BookCheck },
+  guideBookings:{ href: "/guide/bookings", label: "Мои бронирования", icon: BookCheck },
   guideReviews: { href: "/guide/reviews",  label: "Отзывы",          icon: Star },
   guideCalendar:{ href: "/guide/calendar", label: "Календарь",       icon: Calendar },
   guideProfile: { href: "/guide/profile",  label: "Профиль гида",    icon: User },
@@ -83,7 +83,7 @@ export const travelerPrimaryNav = [
 
 /** Guide workspace (also drives the mobile bottom nav). */
 export const guidePrimaryNav = [
-  ROUTES.guideInbox, ROUTES.guideListings, ROUTES.guideBookings, ROUTES.guideReviews,
+  ROUTES.guideInbox, ROUTES.guideBookings, ROUTES.guideListings, ROUTES.guideReviews,
 ] as const;
 
 /** Admin workspace (drives the admin sidebar + mobile tabs). */


### PR DESCRIPTION
## Summary
- keep guide navigation on `Запросы` for request/inbox work
- rename guide bookings nav to `Мои бронирования`
- place `Мои бронирования` directly after `Запросы` in desktop/mobile guide nav

## Tests
- bun run test:run src/lib/navigation.test.ts src/components/shared/guide-bottom-nav.test.tsx
- bun run lint -- src/lib/navigation.ts src/lib/navigation.test.ts src/components/shared/guide-bottom-nav.test.tsx
- bun run typecheck
- bun run build