### PR TITLE
Fix request and offer UI states

### DIFF
--- a/src/app/(home)/page.tsx
+++ b/src/app/(home)/page.tsx
@@ -20,6 +20,7 @@ export default async function HomePage({
   let requests: RequestRecord[] = [];
   let viewerId: string | null = null;
   let preferredGuide: { slug: string; name: string } | null = null;
+  const joinedRequestIds = new Set<string>();
   const { guide: guideParam } = await searchParams;
   try {
     const supabase = await createSupabaseServerClient();
@@ -35,6 +36,18 @@ export default async function HomePage({
     if (guideResult?.data) {
       preferredGuide = { slug: guideResult.data.slug, name: guideResult.data.fullName };
     }
+    if (viewerId && requests.length > 0) {
+      const { data: memberships } = await supabase
+        .from("open_request_members")
+        .select("request_id")
+        .eq("traveler_id", viewerId)
+        .eq("status", "joined")
+        .is("left_at", null)
+        .in("request_id", requests.map((request) => request.id));
+      for (const membership of memberships ?? []) {
+        if (membership.request_id) joinedRequestIds.add(membership.request_id as string);
+      }
+    }
   } catch {
     // all stay empty
   }
@@ -48,6 +61,7 @@ export default async function HomePage({
           requests={requests}
           viewerId={viewerId}
           preferredGuide={preferredGuide}
+          joinedRequestIds={joinedRequestIds}
         />
       </main>
     </>

--- a/src/app/(protected)/admin/audit/page.test.tsx
+++ b/src/app/(protected)/admin/audit/page.test.tsx
@@ -39,7 +39,7 @@ describe("AdminAuditPage", () => {
     };
     requireAdminSession.mockRejectedValue(new Error("Доступ только для администраторов."));
 
-    await expect(AdminAuditPage()).rejects.toThrow("Доступ только для администраторов.");
+    await expect(AdminAuditPage({})).rejects.toThrow("Доступ только для администраторов.");
 
     expect(requireAdminSession).toHaveBeenCalledOnce();
     expect(adminClient.from).not.toHaveBeenCalled();
@@ -90,7 +90,7 @@ describe("AdminAuditPage", () => {
     requireAdminSession.mockResolvedValue({ adminClient });
     createSupabaseServerClient.mockResolvedValue(serverClient);
 
-    const ui = await AdminAuditPage();
+    const ui = await AdminAuditPage({});
     render(ui);
 
     expect(requireAdminSession).toHaveBeenCalledOnce();
@@ -122,7 +122,7 @@ describe("AdminAuditPage", () => {
     };
     requireAdminSession.mockResolvedValue({ adminClient });
 
-    const ui = await AdminAuditPage();
+    const ui = await AdminAuditPage({});
     render(ui);
 
     expect(adminClient.from).toHaveBeenCalledWith("guide_availability_events");

--- a/src/app/(protected)/admin/audit/page.tsx
+++ b/src/app/(protected)/admin/audit/page.tsx
@@ -100,7 +100,7 @@ export default async function AdminAuditPage({
     q?: string | string[];
     page?: string | string[];
   }>;
-} = {}) {
+}) {
   const { adminClient } = await requireAdminSession();
 
   const resolved = searchParams ? await searchParams : {};

--- a/src/app/(protected)/admin/bookings/page.test.tsx
+++ b/src/app/(protected)/admin/bookings/page.test.tsx
@@ -76,7 +76,7 @@ describe("BookingsPage", () => {
     requireAdminSession.mockRejectedValue(new Error("Доступ только для администраторов."));
     const { default: BookingsPage } = await import("./page");
 
-    await expect(BookingsPage()).rejects.toThrow("Доступ только для администраторов.");
+    await expect(BookingsPage({})).rejects.toThrow("Доступ только для администраторов.");
 
     expect(requireAdminSession).toHaveBeenCalledOnce();
     expect(adminClient.from).not.toHaveBeenCalled();
@@ -112,7 +112,7 @@ describe("BookingsPage", () => {
     createSupabaseServerClient.mockResolvedValue(serverClient);
     const { default: BookingsPage } = await import("./page");
 
-    const ui = await BookingsPage();
+    const ui = await BookingsPage({});
     const html = renderToStaticMarkup(ui);
 
     expect(requireAdminSession).toHaveBeenCalledOnce();

--- a/src/app/(protected)/admin/bookings/page.tsx
+++ b/src/app/(protected)/admin/bookings/page.tsx
@@ -25,7 +25,7 @@ export default async function BookingsPage({
   searchParams,
 }: {
   searchParams?: Promise<{ [key: string]: string | string[] | undefined }>;
-} = {}) {
+}) {
   const { adminClient } = await requireAdminSession();
 
   const resolvedParams = searchParams ? await searchParams : {};

--- a/src/app/(site)/requests/page.test.tsx
+++ b/src/app/(site)/requests/page.test.tsx
@@ -57,6 +57,16 @@ function requestRecord(overrides: Partial<RequestRecord>): RequestRecord {
   };
 }
 
+function mockMembershipQuery(rows: Array<{ request_id: string }> = []) {
+  const query = {
+    select: vi.fn().mockReturnThis(),
+    eq: vi.fn().mockReturnThis(),
+    is: vi.fn().mockReturnThis(),
+    in: vi.fn().mockResolvedValue({ data: rows, error: null }),
+  };
+  return query;
+}
+
 describe("RequestsPage", () => {
   it("loads open requests and passes only сборная records to the catalog", async () => {
     const supabaseClient = { from: vi.fn() };
@@ -77,8 +87,9 @@ describe("RequestsPage", () => {
   });
 
   it("marks records owned by the signed-in viewer with isOwner (№32)", async () => {
+    const membershipQuery = mockMembershipQuery();
     const supabaseClient = {
-      from: vi.fn(),
+      from: vi.fn().mockReturnValue(membershipQuery),
       auth: { getUser: vi.fn().mockResolvedValue({ data: { user: { id: "traveler-9" } } }) },
     };
     createSupabaseServerClient.mockResolvedValue(supabaseClient);
@@ -98,6 +109,33 @@ describe("RequestsPage", () => {
     expect(byId["own-request"]).toBe(true);
     expect(byId["other-request"]).toBe(false);
     expect(byId["anon-view-request"]).toBe(false);
+  });
+
+  it("marks records already joined by the signed-in viewer with isMember", async () => {
+    const membershipQuery = mockMembershipQuery([{ request_id: "joined-request" }]);
+    const supabaseClient = {
+      from: vi.fn().mockReturnValue(membershipQuery),
+      auth: { getUser: vi.fn().mockResolvedValue({ data: { user: { id: "traveler-9" } } }) },
+    };
+    createSupabaseServerClient.mockResolvedValue(supabaseClient);
+    getOpenRequests.mockResolvedValue({
+      data: [
+        requestRecord({ id: "joined-request", travelerId: "traveler-1" }),
+        requestRecord({ id: "other-request", travelerId: "traveler-2" }),
+      ],
+    });
+
+    const rendered = await RequestsPage();
+
+    expect(supabaseClient.from).toHaveBeenCalledWith("open_request_members");
+    expect(membershipQuery.eq).toHaveBeenCalledWith("traveler_id", "traveler-9");
+    expect(membershipQuery.eq).toHaveBeenCalledWith("status", "joined");
+    expect(membershipQuery.is).toHaveBeenCalledWith("left_at", null);
+    const byId = Object.fromEntries(
+      (rendered.props.initialData as Array<{ id: string; isMember?: boolean }>).map((r) => [r.id, r.isMember]),
+    );
+    expect(byId["joined-request"]).toBe(true);
+    expect(byId["other-request"]).toBe(false);
   });
 
   it("passes null initialData to the catalog when the board is empty", async () => {

--- a/src/app/(site)/requests/page.tsx
+++ b/src/app/(site)/requests/page.tsx
@@ -15,13 +15,18 @@ export function generateMetadata(): Metadata {
   };
 }
 
-function mapToOpenRequestRecord(request: RequestRecord, viewerId: string | null): OpenRequestRecord {
+function mapToOpenRequestRecord(
+  request: RequestRecord,
+  viewerId: string | null,
+  joinedRequestIds: Set<string>,
+): OpenRequestRecord {
   const isOwner = request.travelerId != null && request.travelerId === viewerId;
   // PII-012: mask contact details in the free-text for every non-owner viewer.
   const maskedDescription = isOwner ? request.description : maskPii(request.description);
   return {
     id: request.id,
     isOwner,
+    isMember: joinedRequestIds.has(request.id),
     status: request.status === "booked" ? "matched" : "open",
     visibility: "public",
     createdAt: request.createdAt,
@@ -68,9 +73,23 @@ export default async function RequestsPage() {
     if (result.error) {
       loadError = true;
     } else if (result.data && result.data.length > 0) {
-      initialData = result.data
-        .filter((request) => request.mode === "assembly")
-        .map((request) => mapToOpenRequestRecord(request, viewerId));
+      const assemblyRequests = result.data.filter((request) => request.mode === "assembly");
+      const joinedRequestIds = new Set<string>();
+      if (viewerId && assemblyRequests.length > 0) {
+        const { data: memberships } = await supabase
+          .from("open_request_members")
+          .select("request_id")
+          .eq("traveler_id", viewerId)
+          .eq("status", "joined")
+          .is("left_at", null)
+          .in("request_id", assemblyRequests.map((request) => request.id));
+        for (const membership of memberships ?? []) {
+          if (membership.request_id) joinedRequestIds.add(membership.request_id as string);
+        }
+      }
+      initialData = assemblyRequests.map((request) =>
+        mapToOpenRequestRecord(request, viewerId, joinedRequestIds),
+      );
     }
   } catch {
     loadError = true;

--- a/src/components/shared/guide-offer-card.test.tsx
+++ b/src/components/shared/guide-offer-card.test.tsx
@@ -21,7 +21,6 @@ function renderCard(props: Partial<React.ComponentProps<typeof GuideOfferCard>> 
     <GuideOfferCard
       guide={baseGuide}
       name="Иван Петров"
-      perPersonPriceLabel="2 500 ₽"
       {...props}
     />,
   );
@@ -42,17 +41,6 @@ describe("GuideOfferCard", () => {
     expect(link).toHaveTextContent("Профиль →");
   });
 
-  it("renders requestBudgetLabel as muted text", () => {
-    renderCard({ requestBudgetLabel: "Бюджет заявки: 2 000 ₽" });
-    const budget = screen.getByText("Бюджет заявки: 2 000 ₽");
-    expect(budget).toBeInTheDocument();
-    expect(budget.className).toContain("text-muted-foreground");
-  });
-
-  it("renders groupTotalLabel below the per-person price", () => {
-    renderCard({ groupTotalLabel: "5 000 ₽ за группу" });
-    expect(screen.getByText(/5 000 ₽ за группу/)).toBeInTheDocument();
-  });
 
   it("shows the «Новый гид» note and suppresses the stats row for a new guide", () => {
     renderCard({
@@ -111,7 +99,6 @@ describe("GuideOfferCard", () => {
       <GuideOfferCard
         guide={baseGuide}
         name="Иван Петров"
-        perPersonPriceLabel="2 500 ₽"
         onReject={vi.fn()}
       />,
     );
@@ -124,8 +111,6 @@ describe("GuideOfferCard", () => {
       isLocal: true,
       responseTimeLabel: "Отвечает быстро",
       profileHref: "/guides/ivan",
-      requestBudgetLabel: "Бюджет: 2 000 ₽",
-      groupTotalLabel: "5 000 ₽ за группу",
       matchingSpecialties: ["История"],
       onSelect: vi.fn(),
       onReject: vi.fn(),

--- a/src/components/shared/guide-offer-card.tsx
+++ b/src/components/shared/guide-offer-card.tsx
@@ -23,7 +23,6 @@ type GuideOfferCardProps = {
   guide: GuideCardInfo;
   name: string;
   quote?: string | null;
-  perPersonPriceLabel: string;
   selected?: boolean;
   /** Whether to show the "Местный житель" badge (caller decides from real data). */
   isLocal?: boolean;
@@ -31,10 +30,6 @@ type GuideOfferCardProps = {
   responseTimeLabel?: string;
   /** Link to the guide's public profile → renders «Профиль →». */
   profileHref?: string;
-  /** Muted reminder of the traveler's per-person budget, shown above the price column. */
-  requestBudgetLabel?: string;
-  /** Group total, shown beneath the per-person price. */
-  groupTotalLabel?: string;
   /** Guide with too little history for social proof → note + suppressed stats row. */
   isNewGuide?: boolean;
   /** Specialties that match the request — rendered bold with a check. */
@@ -78,13 +73,10 @@ export function GuideOfferCard({
   guide,
   name,
   quote,
-  perPersonPriceLabel,
   selected = false,
   isLocal = false,
   responseTimeLabel,
   profileHref,
-  requestBudgetLabel,
-  groupTotalLabel,
   isNewGuide = false,
   matchingSpecialties,
   onSelect,
@@ -244,20 +236,8 @@ export function GuideOfferCard({
 
       </div>
 
-      {/* Action footer — price + centered full-width CTA under the card head (#33) */}
+      {/* Action footer — centered full-width CTA under the card head (#57) */}
       <div className="mt-5 flex flex-col items-center gap-3 border-t border-border pt-5 text-center">
-        <div className="flex flex-wrap items-baseline justify-center gap-x-2 gap-y-1">
-          {requestBudgetLabel ? (
-            <span className="text-[12px] text-muted-foreground">{requestBudgetLabel}</span>
-          ) : null}
-          <span className="text-[23px] font-bold leading-none tracking-[-0.02em] text-on-surface">
-            {perPersonPriceLabel}
-          </span>
-          <span className="text-[12.5px] text-on-surface-muted">с человека</span>
-          {groupTotalLabel ? (
-            <span className="text-[12.5px] text-on-surface-muted">· {groupTotalLabel}</span>
-          ) : null}
-        </div>
         <button
           type="button"
           className={cn(

--- a/src/components/shared/open-group-card.test.tsx
+++ b/src/components/shared/open-group-card.test.tsx
@@ -1,0 +1,27 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import { OpenGroupCard } from "./open-group-card";
+
+const baseProps = {
+  href: "/requests/req-1",
+  city: "Тбилиси",
+  imageUrl: "data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg'/%3E",
+  status: "waiting" as const,
+};
+
+describe("OpenGroupCard", () => {
+  it("shows joined state instead of join CTA for existing group members", () => {
+    render(<OpenGroupCard {...baseProps} member />);
+
+    expect(screen.getByRole("link", { name: "Вы в группе" })).toHaveAttribute("href", "/requests/req-1");
+    expect(screen.queryByRole("link", { name: "Присоединиться" })).not.toBeInTheDocument();
+  });
+
+  it("keeps owner state above member state", () => {
+    render(<OpenGroupCard {...baseProps} owner member />);
+
+    expect(screen.getByRole("link", { name: "Это ваша группа" })).toHaveAttribute("href", "/requests/req-1");
+    expect(screen.queryByRole("link", { name: "Вы в группе" })).not.toBeInTheDocument();
+  });
+});

--- a/src/components/shared/open-group-card.tsx
+++ b/src/components/shared/open-group-card.tsx
@@ -51,6 +51,8 @@ export interface OpenGroupCardProps {
   joinLabel?: string;
   /** Viewer created this request — replace the join CTA with "Это ваша группа". */
   owner?: boolean;
+  /** Viewer already joined this open group — replace the join CTA with "Вы в группе". */
+  member?: boolean;
   priority?: boolean;
 }
 
@@ -80,6 +82,7 @@ export function OpenGroupCard({
   joinHref,
   joinLabel = "Присоединиться",
   owner,
+  member,
   priority,
 }: OpenGroupCardProps) {
   const themes = (interests ?? [])
@@ -201,6 +204,10 @@ export function OpenGroupCard({
         {owner ? (
           <Button asChild variant="outline" className="mt-3 w-full">
             <Link href={href}>Это ваша группа</Link>
+          </Button>
+        ) : member ? (
+          <Button asChild variant="outline" className="mt-3 w-full">
+            <Link href={href}>Вы в группе</Link>
           </Button>
         ) : (
           <Button asChild className="mt-3 w-full">

--- a/src/data/open-requests/types.ts
+++ b/src/data/open-requests/types.ts
@@ -43,5 +43,7 @@ export type OpenRequestRecord = {
   members?: Array<{ id: string; displayName: string; initials: string; avatarUrl?: string }>;
   /** True when the current viewer created this request. */
   isOwner?: boolean;
+  /** True when the current viewer already joined this open group. */
+  isMember?: boolean;
 };
 

--- a/src/features/guide/components/requests/guide-requests-inbox-screen.tsx
+++ b/src/features/guide/components/requests/guide-requests-inbox-screen.tsx
@@ -43,7 +43,7 @@ async function fetchOfferedRequestIds(guideId: string): Promise<OffersByRequest>
   const supabase = createSupabaseBrowserClient();
   const { data, error } = await supabase
     .from("guide_offers")
-    .select("id, request_id, starts_at, capacity, price_minor")
+    .select("id, request_id, starts_at, capacity, price_minor, status")
     .eq("guide_id", guideId);
   if (error || !data) {
     return { offeredIds: new Set(), offerIdByRequestId: new Map(), error: error?.message ?? null };
@@ -57,6 +57,7 @@ async function fetchOfferedRequestIds(guideId: string): Promise<OffersByRequest>
         starts_at: (row.starts_at as string | null) ?? null,
         capacity: (row.capacity as number | null) ?? null,
         price_minor: (row.price_minor as number | null) ?? null,
+        status: (row.status as OfferMeta["status"]) ?? undefined,
       },
     ]),
   );
@@ -311,7 +312,9 @@ export function GuideRequestsInboxScreen() {
                   const matched = isMatchedRequest(item, specializations);
                   const offerMeta = offerIdByRequestId.get(item.id);
                   const offerId = offerMeta?.id;
-                  const showQaPanel = alreadyOffered && !!offerId;
+                  const offerStatus = offerMeta?.status ?? "pending";
+                  const isDeclinedOffer = offerStatus === "declined";
+                  const showQaPanel = alreadyOffered && !!offerId && !isDeclinedOffer;
                   const hasFlexibleDates = item.dateFlexibility === "few_days" || item.date_locked === false;
                   return (
                     <div key={item.id} className="space-y-3">
@@ -356,7 +359,9 @@ export function GuideRequestsInboxScreen() {
                         <div className="mt-4 flex flex-wrap items-center gap-3">
                           {alreadyOffered ? (
                             <div className="flex flex-col gap-2">
-                              <Badge variant="secondary">Предложение отправлено</Badge>
+                              <Badge variant={isDeclinedOffer ? "destructive" : "secondary"}>
+                                {isDeclinedOffer ? "Отклонено автором" : "Предложение отправлено"}
+                              </Badge>
                               {offerMeta && (offerMeta.starts_at != null || offerMeta.capacity != null || offerMeta.price_minor != null) ? (
                                 <p className="text-xs leading-relaxed text-muted-foreground">
                                   Вы предложили:

--- a/src/features/guide/components/requests/offer-meta.ts
+++ b/src/features/guide/components/requests/offer-meta.ts
@@ -1,7 +1,10 @@
+import type { OfferStatus } from "@/lib/supabase/types";
+
 export interface OfferMeta {
   id?: string;
   starts_at: string | null;
   capacity: number | null;
   price_minor: number | null;
   message?: string | null;
+  status?: OfferStatus;
 }

--- a/src/features/homepage-classic/components/homepage-shell2-classic.tsx
+++ b/src/features/homepage-classic/components/homepage-shell2-classic.tsx
@@ -12,6 +12,7 @@ interface Props {
   requests: RequestRecord[];
   viewerId?: string | null;
   preferredGuide?: { slug: string; name: string } | null;
+  joinedRequestIds?: Set<string>;
 }
 
 const HOW_IT_WORKS = [
@@ -25,7 +26,7 @@ const HOW_IT_WORKS = [
 
 const SECTION = "mx-auto w-full max-w-page px-gutter";
 
-export function HomePageShell2Classic({ destinations, requests, viewerId, preferredGuide }: Props) {
+export function HomePageShell2Classic({ destinations, requests, viewerId, preferredGuide, joinedRequestIds = new Set() }: Props) {
   const openGroups = requests.slice(0, 3);
 
   return (
@@ -63,6 +64,7 @@ export function HomePageShell2Classic({ destinations, requests, viewerId, prefer
                   members={req.members}
                   participantCount={req.groupSize}
                   owner={req.travelerId != null && req.travelerId === viewerId}
+                  member={joinedRequestIds.has(req.id)}
                   price={req.budgetRub ? `${formatRubNumber(req.budgetRub)} ₽ / чел` : undefined}
                   priority={index === 0}
                 />

--- a/src/features/requests/components/public-requests-marketplace-screen.tsx
+++ b/src/features/requests/components/public-requests-marketplace-screen.tsx
@@ -478,6 +478,7 @@ export function PublicRequestsMarketplaceScreen({ initialData }: Props) {
                     members={request.members}
                     participantCount={sizeCurrent}
                     owner={request.isOwner}
+                    member={request.isMember}
                     price={
                       request.budgetPerPersonRub
                         ? `${formatRubNumber(request.budgetPerPersonRub)} ₽ / чел`

--- a/src/features/requests/components/request-detail-screen.tsx
+++ b/src/features/requests/components/request-detail-screen.tsx
@@ -580,11 +580,6 @@ function OwnerDetailBranch({
   const enrollmentLabel = enrollmentOpen ? "Набор открыт" : "Набор закрыт";
 
   const requestInterests = ownerRequestRow.interests ?? [];
-  const requestBudgetLabel = ownerRequestRow.budget_minor
-    ? `Ваш бюджет ${formatRubNumber(
-        Math.round(kopecksToRub(ownerRequestRow.budget_minor)),
-      )} ₽ / чел.`
-    : undefined;
 
   const offerCount = (offer: GuideOfferRow): number =>
     offer.capacity > 0 ? offer.capacity : ownerRequestRow.participants_count ?? 1;
@@ -601,13 +596,6 @@ function OwnerDetailBranch({
       currency: offer.currency,
       maximumFractionDigits: 0,
     }).format(perPersonRub(offer));
-
-  const groupTotalLabel = (offer: GuideOfferRow): string | undefined => {
-    const count = offerCount(offer);
-    if (count <= 1) return undefined;
-    const total = perPersonRub(offer) * count;
-    return `${formatRubNumber(total)} ₽ за группу · ${count} чел.`;
-  };
 
   const cardInfo = (gi: OwnerOfferItem["guideInfo"]): GuideCardInfo => ({
     full_name: gi?.full_name ?? null,
@@ -665,10 +653,7 @@ function OwnerDetailBranch({
           guide={cardInfo(guideInfo)}
           name={guideName(guideInfo)}
           quote={offer.message}
-          perPersonPriceLabel={perPersonLabel(offer)}
           responseTimeLabel={formatResponseTime(offer.created_at)}
-          groupTotalLabel={groupTotalLabel(offer)}
-          requestBudgetLabel={requestBudgetLabel}
           profileHref={guideInfo?.slug ? `/guides/${guideInfo.slug}` : undefined}
           isNewGuide={trips == null || trips === 0}
           matchingSpecialties={matchingSpecialties(guideInfo)}

--- a/src/features/traveler/components/requests/offer-card.test.tsx
+++ b/src/features/traveler/components/requests/offer-card.test.tsx
@@ -254,13 +254,13 @@ describe("OfferCard", () => {
     // Гибкие даты — бейдж появляется когда travelerStartsOn=null
     expect(screen.getByText("Гибкие даты")).toBeInTheDocument();
     // Дата-бейдж (следующий после типа группы и "Гибкие даты") — синий (не error-семантика)
-    const groupBadge = screen.getByText("Своя группа").closest("[data-slot='badge']");
+    const groupBadge = screen.getByText(/Своя группа · 3 чел\./).closest("[data-slot='badge']");
     const badges = Array.from(groupBadge?.parentElement?.querySelectorAll("[data-slot='badge']") ?? []);
     const badgeTexts = badges.map((badge) => badge.textContent);
     const dateBadge = badges[2];
 
     expect(badgeTexts).toEqual([
-      "Своя группа",
+      "Своя группа · 3 чел.",
       "Гибкие даты",
       "15 июня",
       "10:30 – 12:00",

--- a/src/features/traveler/components/requests/offer-card.tsx
+++ b/src/features/traveler/components/requests/offer-card.tsx
@@ -2,7 +2,7 @@
 
 import * as React from "react";
 import Image from "next/image";
-import { BadgeCheck, CalendarDays, ChevronLeft, ChevronRight, Clock, Star, Users, Wallet, X } from "lucide-react";
+import { BadgeCheck, CalendarDays, ChevronLeft, ChevronRight, Clock, Lock, Star, Users, Wallet, X } from "lucide-react";
 
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
 import { Badge } from "@/components/ui/badge";
@@ -144,7 +144,8 @@ export function OfferCard({
     perPersonMinor > 0 && (travelerBudgetPerPersonRub == null || Math.round(perPersonMinor / 100) !== travelerBudgetPerPersonRub);
 
   const isCounterOffer = dateDeviates || timeDeviates || countDeviates || budgetDeviates;
-  const groupTypeLabel = travelerOpenToJoin ? "Сборная группа" : "Своя группа";
+  const privateGroupCount = travelerCount ?? offerCount;
+  const groupTypeLabel = travelerOpenToJoin ? "Сборная группа" : `Своя группа · ${privateGroupCount} чел.`;
 
   const routeStops = (Array.isArray(offer.route_stops) ? (offer.route_stops as RouteStop[]) : []).filter(
     (s) => s && typeof s === "object" && typeof s.photoUrl === "string",
@@ -243,6 +244,7 @@ export function OfferCard({
               : "border-border bg-surface-low text-muted-foreground",
           )}
         >
+          {travelerOpenToJoin ? null : <Lock className="size-3.5" />}
           {groupTypeLabel}
         </Badge>
         {travelerStartsOn == null ? (


### PR DESCRIPTION
## Summary
- show joined open-group cards as "Вы в группе" instead of "Присоединиться"
- remove the extra price row above traveler offer CTAs
- show declined guide offers as "Отклонено автором" instead of an active waiting state
- show private-group participant count with a lock icon in the guide offer sidebar
- fix admin page prop signatures that blocked production build

## Verification
- bun run typecheck
- bun run lint
- bun run test:run
- bunx next build --webpack