### PR TITLE
Fix request visibility and guide moderation notifications

### DIFF
--- a/src/app/(protected)/admin/bookings/[id]/page.tsx
+++ b/src/app/(protected)/admin/bookings/[id]/page.tsx
@@ -6,6 +6,7 @@ import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { kopecksToRub } from "@/data/money";
+import { COPY } from "@/lib/copy";
 import { formatRussianDateTime } from "@/lib/dates";
 import { requireAdminSession } from "@/lib/supabase/moderation";
 
@@ -96,7 +97,7 @@ export default async function AdminBookingDetailPage({
                 label="Путешественник"
                 value={resolveName(booking.traveler_id)}
               />
-              <DetailRow label="Гид" value={resolveName(booking.guide_id)} />
+              <DetailRow label={COPY.guide} value={resolveName(booking.guide_id)} />
               <DetailRow
                 label="Участников"
                 value={booking.party_size ?? "—"}

--- a/src/app/(protected)/admin/users/actions.ts
+++ b/src/app/(protected)/admin/users/actions.ts
@@ -16,6 +16,7 @@ import {
   type AdminActionResult,
   type BulkActionResult,
 } from "@/data/admin-users";
+import { COPY } from "@/lib/copy";
 import { createSupabaseServerClient } from "@/lib/supabase/server";
 import {
   countOtherActiveAdmins,
@@ -60,7 +61,7 @@ async function syncRoleSideEffects(input: {
   nextRole: string;
 }) {
   if (input.nextRole === "guide") {
-    const fallbackName = input.targetEmail?.split("@")[0]?.trim() || "Гид";
+    const fallbackName = input.targetEmail?.split("@")[0]?.trim() || COPY.guide;
     const { error } = await input.adminClient.from("guide_profiles").upsert(
       {
         user_id: input.targetId,

--- a/src/app/(protected)/guide/profile/page.tsx
+++ b/src/app/(protected)/guide/profile/page.tsx
@@ -433,7 +433,7 @@ export default async function GuideProfilePage() {
                 <div className="space-y-4">
                   {verificationStatus === "rejected" ? (
                     <div className="rounded-lg bg-destructive/10 px-4 py-3 text-sm text-destructive">
-                      <strong className="block text-foreground">Проверка отклонена.</strong>
+                      <strong className="block text-foreground">Нужны правки по анкете.</strong>
                       {verificationNotes ?? "Исправьте документы и отправьте их снова."}
                     </div>
                   ) : null}

--- a/src/components/shared/bidding-guides-teaser.tsx
+++ b/src/components/shared/bidding-guides-teaser.tsx
@@ -1,6 +1,7 @@
 import { BadgeCheck, Star } from "lucide-react";
 
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
+import { resolveDisplayName } from "@/lib/profile/resolve-display-name";
 import type { BiddingGuide } from "@/lib/supabase/requests-public";
 import { pluralize } from "@/lib/utils";
 
@@ -41,47 +42,49 @@ export function BiddingGuidesTeaser({ guides }: { guides: BiddingGuide[] }) {
         предлагают программу
       </p>
       <div className="flex flex-wrap gap-3">
-        {guides.map((guide) => (
-          <div
-            key={guide.user_id}
-            className="flex items-center gap-3 rounded-[14px] border border-border bg-surface-lowest px-4 py-3"
-          >
-            <Avatar className="size-10">
-              <AvatarImage src={guide.avatar_url ?? undefined} alt={guide.full_name ?? "Гид"} />
-              <AvatarFallback className="bg-surface-low font-semibold text-on-surface-muted">
-                {initialsFromName(guide.full_name)}
-              </AvatarFallback>
-            </Avatar>
-            <div className="flex flex-col gap-0.5">
-              <div className="flex items-center gap-2">
-                <span className="text-[14px] font-semibold text-on-surface">
-                  {guide.full_name ?? "Гид"}
-                </span>
-                <span className="inline-flex items-center gap-1 text-[12px] font-medium text-success">
-                  <BadgeCheck className="size-3.5" />
-                  Проверен
-                </span>
+        {guides.map((guide) => {
+          const displayName = resolveDisplayName("guide", { full_name: guide.full_name });
+
+          return (
+            <div
+              key={guide.user_id}
+              className="flex items-center gap-3 rounded-[14px] border border-border bg-surface-lowest px-4 py-3"
+            >
+              <Avatar className="size-10">
+                <AvatarImage src={guide.avatar_url ?? undefined} alt={displayName} />
+                <AvatarFallback className="bg-surface-low font-semibold text-on-surface-muted">
+                  {initialsFromName(guide.full_name)}
+                </AvatarFallback>
+              </Avatar>
+              <div className="flex flex-col gap-0.5">
+                <div className="flex items-center gap-2">
+                  <span className="text-[14px] font-semibold text-on-surface">{displayName}</span>
+                  <span className="inline-flex items-center gap-1 text-[12px] font-medium text-success">
+                    <BadgeCheck className="size-3.5" />
+                    Проверен
+                  </span>
+                </div>
+                {guide.average_rating != null || guide.review_count != null ? (
+                  <span className="inline-flex items-center gap-1 text-[12.5px] text-on-surface-muted">
+                    {guide.average_rating != null ? (
+                      <>
+                        <Star className="size-3.5 fill-current text-gold" />
+                        {guide.average_rating}
+                      </>
+                    ) : null}
+                    {guide.average_rating != null && guide.review_count != null ? " · " : null}
+                    {guide.review_count != null ? (
+                      <>
+                        {guide.review_count}{" "}
+                        {pluralize(guide.review_count, "отзыв", "отзыва", "отзывов")}
+                      </>
+                    ) : null}
+                  </span>
+                ) : null}
               </div>
-              {guide.average_rating != null || guide.review_count != null ? (
-                <span className="inline-flex items-center gap-1 text-[12.5px] text-on-surface-muted">
-                  {guide.average_rating != null ? (
-                    <>
-                      <Star className="size-3.5 fill-current text-gold" />
-                      {guide.average_rating}
-                    </>
-                  ) : null}
-                  {guide.average_rating != null && guide.review_count != null ? " · " : null}
-                  {guide.review_count != null ? (
-                    <>
-                      {guide.review_count}{" "}
-                      {pluralize(guide.review_count, "отзыв", "отзыва", "отзывов")}
-                    </>
-                  ) : null}
-                </span>
-              ) : null}
             </div>
-          </div>
-        ))}
+          );
+        })}
       </div>
     </section>
   );

--- a/src/data/admin-users/schema.ts
+++ b/src/data/admin-users/schema.ts
@@ -1,5 +1,6 @@
 import { z } from "zod";
 
+import { COPY } from "@/lib/copy";
 import type { AppRole } from "@/lib/auth/types";
 
 /**
@@ -18,7 +19,7 @@ export const ACCOUNT_STATUS_LABELS: Record<AccountStatus, string> = {
 
 export const ROLE_LABELS: Record<AppRole, string> = {
   traveler: "Путешественник",
-  guide: "Гид",
+  guide: COPY.guide,
   admin: "Администратор",
 };
 

--- a/src/features/admin/components/disputes/disputes-queue.tsx
+++ b/src/features/admin/components/disputes/disputes-queue.tsx
@@ -3,6 +3,7 @@ import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/com
 import { PageHeader } from "@/components/shared/page-header";
 import { ListRow } from "@/components/shared/list-row";
 import { formatRussianDateTime } from "@/lib/dates";
+import { resolveDisplayName } from "@/lib/profile/resolve-display-name";
 import type { DisputeListItem } from "@/lib/supabase/disputes";
 
 type DisputeStatus = DisputeListItem["status"];
@@ -60,13 +61,15 @@ export function DisputesQueue({ disputes }: { disputes: DisputeListItem[] }) {
             const meta = STATUS_META[item.status];
             const booking = item.booking;
             const route = booking?.listingTitle ?? booking?.destination ?? "—";
+            const travelerName = booking?.travelerName?.trim() || "Турист";
+            const guideName = resolveDisplayName("guide", { full_name: booking?.guideName });
 
             return (
               <ListRow
                 key={item.id}
                 href={`/admin/disputes/${item.id}`}
                 leading={<Badge variant={meta.variant}>{meta.label}</Badge>}
-                title={`${booking?.travelerName ?? "Путешественник"} vs ${booking?.guideName ?? "Гид"}`}
+                title={`${travelerName} vs ${guideName}`}
                 subtitle={`${route} · ${formatRussianDateTime(item.createdAt)}`}
                 badge={<span className="font-mono text-xs text-muted-foreground">#{item.id.slice(0, 8)}</span>}
               />

--- a/src/features/bookings/components/booking-detail-screen.tsx
+++ b/src/features/bookings/components/booking-detail-screen.tsx
@@ -34,6 +34,7 @@ import { GuideBookingStatusBadge } from "@/features/guide/components/bookings/gu
 import { FourAxisReviewForm } from "@/features/reviews/components/FourAxisReviewForm";
 import type { GuideBookingStatus } from "@/data/guide-booking/types";
 import type { BookingStatus } from "@/lib/bookings/state-machine";
+import { COPY } from "@/lib/copy";
 import { formatRussianDateRange, formatRussianTime } from "@/lib/dates";
 import { flags } from "@/lib/flags";
 import { resolveDisplayName } from "@/lib/profile/resolve-display-name";
@@ -451,7 +452,7 @@ function TravelerBookingDetailView({
                       confirmedAt={paymentAgreement.travelerConfirmedAt}
                     />
                     <PaymentAgreementRow
-                      label="Гид"
+                      label={COPY.guide}
                       confirmedAt={paymentAgreement.guideConfirmedAt}
                     />
                   </div>

--- a/src/features/disputes/components/DisputeThread.tsx
+++ b/src/features/disputes/components/DisputeThread.tsx
@@ -7,6 +7,7 @@ import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Textarea } from "@/components/ui/textarea";
 import { EmptyState } from "@/components/shared/empty-state";
 import { PageHeader } from "@/components/shared/page-header";
+import { COPY } from "@/lib/copy";
 import { formatRussianDateTime } from "@/lib/dates";
 import { maskPii } from "@/lib/pii/mask";
 import { cn } from "@/lib/utils";
@@ -53,7 +54,7 @@ function formatEventLabel(eventType: string | null): string {
 
 const COMMENT_ROLE_LABELS: Record<string, string> = {
   traveler: "Путешественник",
-  guide: "Гид",
+  guide: COPY.guide,
   admin: "Поддержка",
 };
 

--- a/src/features/guide/components/requests/bid-form-panel.test.tsx
+++ b/src/features/guide/components/requests/bid-form-panel.test.tsx
@@ -169,6 +169,18 @@ describe("BidFormPanel — request context", () => {
 });
 
 describe("BidFormPanel — headcount field", () => {
+  it("shows the request traveler count in the offer sidebar", () => {
+    render(
+      <BidFormPanel
+        requestId="req-1"
+        request={{ ...baseRequest, groupSize: 4 }}
+        onClose={() => {}}
+      />,
+    );
+
+    expect(screen.getByText("В запросе: 4 чел.")).toBeInTheDocument();
+  });
+
   it("does not render the «предложено» badge when headcount changes", () => {
     render(
       <BidFormPanel

--- a/src/features/guide/components/requests/bid-form-panel.tsx
+++ b/src/features/guide/components/requests/bid-form-panel.tsx
@@ -524,6 +524,7 @@ export function BidFormPanel({
                 {request.mode === "assembly" ? "Сколько человек готовы взять?" : "Группа сформирована"}
               </span>
             </div>
+            <p className="text-sm text-muted-foreground">В запросе: {travelerCount} чел.</p>
             {request.mode === "assembly" ? (
               <input
                 type="number"

--- a/src/features/requests/components/request-group-thread.test.tsx
+++ b/src/features/requests/components/request-group-thread.test.tsx
@@ -1,6 +1,7 @@
 import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
+import { COPY } from "@/lib/copy";
 import { RequestGroupThread } from "./request-group-thread";
 import type { GroupMessage } from "@/lib/supabase/request-thread";
 
@@ -40,7 +41,7 @@ describe("RequestGroupThread", () => {
     expect(screen.getByText("Всем привет, я организатор.")).toBeInTheDocument();
     expect(screen.getByText("Готов показать маршрут.")).toBeInTheDocument();
     expect(screen.getByText("Вы")).toBeInTheDocument();
-    expect(screen.getByText("Гид")).toBeInTheDocument();
+    expect(screen.getByText(COPY.guide)).toBeInTheDocument();
 
     // Composer is disabled until there is text, then posts the trimmed body.
     const submit = screen.getByRole("button", { name: "Отправить" });

--- a/src/features/requests/components/request-group-thread.tsx
+++ b/src/features/requests/components/request-group-thread.tsx
@@ -5,6 +5,7 @@ import { useRouter } from "next/navigation";
 
 import { Button } from "@/components/ui/button";
 import { Textarea } from "@/components/ui/textarea";
+import { COPY } from "@/lib/copy";
 import { formatRussianDateTime } from "@/lib/dates";
 import type { GroupMessage } from "@/lib/supabase/request-thread";
 import type { MessageSenderRole } from "@/lib/supabase/types";
@@ -17,7 +18,7 @@ function senderLabel(
   if (senderId && senderId === currentUserId) return "Вы";
   switch (senderRole) {
     case "guide":
-      return "Гид";
+      return COPY.guide;
     case "admin":
       return "Администратор";
     default:

--- a/src/lib/email/templates/notification-emails.ts
+++ b/src/lib/email/templates/notification-emails.ts
@@ -84,3 +84,27 @@ export function renderBookingCancelledEmail(args: {
     `,
   };
 }
+
+export function renderAdminAlertEmail(args: {
+  title: string;
+  body: string;
+  url: string;
+}): EmailTemplate {
+  const title = escapeHtml(args.title);
+  const body = escapeHtml(args.body);
+  const url = escapeHtml(args.url);
+
+  return {
+    subject: `${args.title} — Provodnik`,
+    html: `
+      <div style="font-family: sans-serif; max-width: 480px; margin: 0 auto; padding: 24px;">
+        <h2 style="font-size: 20px; font-weight: 600; margin-bottom: 16px;">${title}</h2>
+        <p style="color: #555; margin-bottom: 24px; white-space: pre-line;">${body}</p>
+        <a href="${url}"
+           style="display:inline-block;background:#000;color:#fff;text-decoration:none;padding:12px 24px;border-radius:9999px;font-size:14px;font-weight:500;">
+          Открыть кабинет
+        </a>
+      </div>
+    `,
+  };
+}

--- a/src/lib/supabase/moderation.test.ts
+++ b/src/lib/supabase/moderation.test.ts
@@ -5,6 +5,11 @@ const { createSupabaseAdminClient, createSupabaseServerClient } = vi.hoisted(() 
   createSupabaseServerClient: vi.fn(),
 }));
 
+const { createNotification, sendNotificationEmail } = vi.hoisted(() => ({
+  createNotification: vi.fn(),
+  sendNotificationEmail: vi.fn(),
+}));
+
 vi.mock("@/lib/supabase/admin", () => ({
   createSupabaseAdminClient,
 }));
@@ -14,13 +19,23 @@ vi.mock("@/lib/supabase/server", () => ({
 }));
 
 vi.mock("@/lib/notifications/create-notification", () => ({
-  createNotification: vi.fn(),
+  createNotification,
+}));
+
+vi.mock("@/lib/email/send-notification-email", () => ({
+  sendNotificationEmail,
+}));
+
+vi.mock("@/lib/env", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("@/lib/env")>()),
+  getSiteUrl: () => "https://provodnik.app",
 }));
 
 import {
   buildGuideApprovalUpdate,
   getGuideReviewQueue,
   getPendingListingReviews,
+  performModerationAction,
 } from "./moderation";
 import type { GuideProfileRow, ListingRow, Uuid } from "./types";
 
@@ -324,6 +339,143 @@ describe("getGuideReviewQueue", () => {
 
     expect(queue).toHaveLength(1);
     expect(queue[0]?.profile.user_id).toBe("submitted-guide");
+  });
+});
+
+describe("performModerationAction", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("puts requested guide changes into cabinet notifications and email", async () => {
+    const adminId = "11111111-1111-4111-8111-111111111111";
+    const guideId = "22222222-2222-4222-8222-222222222222";
+    const caseId = "33333333-3333-4333-8333-333333333333";
+    const actionId = "44444444-4444-4444-8444-444444444444";
+    const note = "Добавьте фото лицензии.";
+    const guideProfileUpdateEq = vi.fn().mockResolvedValue({ error: null });
+    const guideProfileUpdate = vi.fn(() => ({ eq: guideProfileUpdateEq }));
+    const moderationCaseUpdateEq = vi.fn().mockResolvedValue({ error: null });
+    const moderationCaseUpdate = vi.fn(() => ({ eq: moderationCaseUpdateEq }));
+
+    createSupabaseServerClient.mockResolvedValue({
+      auth: {
+        getUser: vi.fn().mockResolvedValue({
+          data: { user: { id: adminId, app_metadata: { role: "admin" } } },
+          error: null,
+        }),
+      },
+      from: vi.fn(() =>
+        makeQuery({
+          data: {
+            id: adminId,
+            role: "admin",
+            full_name: "Admin",
+            email: "admin@example.com",
+            avatar_url: null,
+          },
+          error: null,
+        }),
+      ),
+    });
+
+    createSupabaseAdminClient.mockReturnValue({
+      from: vi.fn((table: string) => {
+        if (table === "moderation_cases") {
+          return {
+            select: vi.fn().mockReturnThis(),
+            eq: vi.fn().mockReturnThis(),
+            maybeSingle: vi.fn().mockResolvedValue({
+              data: {
+                id: caseId,
+                subject_type: "guide_profile",
+                guide_id: guideId,
+                listing_id: null,
+                review_id: null,
+                opened_by: null,
+                assigned_admin_id: null,
+                status: "open",
+                queue_reason: "Проверка анкеты гида",
+                risk_flags: [],
+                created_at: "2026-07-10T00:00:00.000Z",
+                updated_at: "2026-07-10T00:00:00.000Z",
+              },
+              error: null,
+            }),
+            update: moderationCaseUpdate,
+          };
+        }
+        if (table === "moderation_actions") {
+          return {
+            select: vi.fn(() => ({
+              eq: vi.fn(() => ({
+                order: vi.fn().mockResolvedValue({ data: [], error: null }),
+              })),
+            })),
+            insert: vi.fn(() => ({
+              select: vi.fn(() => ({
+                single: vi.fn().mockResolvedValue({
+                  data: {
+                    id: actionId,
+                    case_id: caseId,
+                    admin_id: adminId,
+                    decision: "request_changes",
+                    note,
+                    created_at: "2026-07-10T00:01:00.000Z",
+                  },
+                  error: null,
+                }),
+              })),
+            })),
+          };
+        }
+        if (table === "guide_profiles") {
+          return {
+            update: guideProfileUpdate,
+            select: vi.fn(() => ({
+              in: vi.fn().mockResolvedValue({
+                data: [makeGuideProfile(guideId, "submitted", "2026-07-10T00:00:00.000Z")],
+                error: null,
+              }),
+            })),
+          };
+        }
+        if (table === "profiles") {
+          return {
+            select: vi.fn(() => ({
+              in: vi.fn().mockResolvedValue({
+                data: [{ id: guideId, full_name: "Анна", email: "anna@example.com", avatar_url: null }],
+                error: null,
+              }),
+            })),
+          };
+        }
+        throw new Error(`Unexpected table: ${table}`);
+      }),
+    });
+
+    await performModerationAction(caseId, adminId, "request_changes", note);
+
+    expect(guideProfileUpdate).toHaveBeenCalledWith({
+      verification_status: "rejected",
+      is_available: false,
+      verification_notes: note,
+    });
+    expect(createNotification).toHaveBeenCalledWith(
+      expect.objectContaining({
+        userId: guideId,
+        kind: "admin_alert",
+        href: "/guide/profile#verification",
+        body: expect.stringContaining(note),
+      }),
+    );
+    expect(sendNotificationEmail).toHaveBeenCalledWith(
+      expect.objectContaining({
+        kind: "admin_alert",
+        entityId: actionId,
+        to: "anna@example.com",
+      }),
+    );
   });
 });
 

--- a/src/lib/supabase/moderation.ts
+++ b/src/lib/supabase/moderation.ts
@@ -2,6 +2,9 @@ import "server-only";
 
 import { z } from "zod";
 
+import { renderAdminAlertEmail } from "@/lib/email/templates/notification-emails";
+import { sendNotificationEmail } from "@/lib/email/send-notification-email";
+import { getSiteUrl } from "@/lib/env";
 import { hasAdminRole } from "@/lib/auth/admin-access";
 import { logError } from "@/lib/log";
 import { createNotification } from "@/lib/notifications/create-notification";
@@ -395,7 +398,13 @@ async function getReviewById(
 async function getNotificationRecipient(
   adminClient: ReturnType<typeof createSupabaseAdminClient>,
   moderationCase: ModerationCaseRow,
-): Promise<{ userId: Uuid | null; href: string | null; title: string; body: string } | null> {
+): Promise<{
+  userId: Uuid | null;
+  email: string | null;
+  href: string | null;
+  title: string;
+  body: string;
+} | null> {
   if (moderationCase.subject_type === "guide_profile" && moderationCase.guide_id) {
     const [guideProfiles, profiles] = await Promise.all([
       getGuideProfilesByIds(adminClient, [moderationCase.guide_id]),
@@ -407,6 +416,7 @@ async function getNotificationRecipient(
 
     return {
       userId: moderationCase.guide_id,
+      email: account?.email ?? null,
       href: "/guide/profile#verification",
       title: "Обновление по проверке гида",
       body: `Администратор обновил статус проверки анкеты ${name}.`,
@@ -420,6 +430,7 @@ async function getNotificationRecipient(
 
     return {
       userId: listing.guide_id,
+      email: null,
       href: "/guide/listings",
       title: "Обновление по проверке листинга",
       body: `Проверка листинга «${listing.title}» была обновлена администратором.`,
@@ -432,6 +443,7 @@ async function getNotificationRecipient(
 
     return {
       userId: review.traveler_id,
+      email: review.traveler?.email ?? null,
       href: review.listing_id ? `/listings/${review.listing_id}` : null,
       title: "Обновление по отзыву",
       body: "Администратор обновил статус вашего отзыва.",
@@ -650,6 +662,8 @@ export async function performModerationAction(
 ): Promise<ModerationActionRow> {
   const input = performModerationActionSchema.parse({ caseId, adminId, decision, note });
   const { adminId: currentAdminId, adminClient } = await requireAdminSession();
+  const requestChangesNote =
+    input.note?.trim() || "Администратор запросил правки. Обновите анкету и отправьте её повторно.";
 
   if (currentAdminId !== input.adminId) {
     throw new Error("Администратор сессии не совпадает с adminId действия.");
@@ -686,11 +700,14 @@ export async function performModerationAction(
   if (caseError) throw caseError;
 
   if (moderationCase.subject_type === "guide_profile" && moderationCase.guide_id) {
-    if (input.decision === "reject") {
-      // Reject always hides the guide from the catalog.
+    if (input.decision === "reject" || input.decision === "request_changes") {
       const { error } = await adminClient
         .from("guide_profiles")
-        .update({ verification_status: "rejected", is_available: false })
+        .update({
+          verification_status: "rejected",
+          is_available: false,
+          verification_notes: requestChangesNote,
+        })
         .eq("user_id", moderationCase.guide_id);
 
       if (error) throw error;
@@ -745,13 +762,42 @@ export async function performModerationAction(
 
   const recipient = await getNotificationRecipient(adminClient, moderationCase);
   if (recipient?.userId) {
+    const body =
+      input.decision === "request_changes"
+        ? `${recipient.body}\n\nКомментарий администратора: ${requestChangesNote}`
+        : input.note?.trim()
+          ? `${recipient.body}\n\nКомментарий администратора: ${input.note.trim()}`
+          : recipient.body;
+
     await createNotification({
       userId: recipient.userId,
       kind: "admin_alert" satisfies NotificationKindDb,
       title: recipient.title,
-      body: recipient.body,
+      body,
       href: recipient.href ?? undefined,
     });
+
+    if (recipient.email && recipient.href) {
+      try {
+        const { subject, html } = renderAdminAlertEmail({
+          title: recipient.title,
+          body,
+          url: `${getSiteUrl()}${recipient.href}`,
+        });
+        await sendNotificationEmail({
+          kind: "admin_alert",
+          entityId: (action as ModerationActionRow).id,
+          to: recipient.email,
+          subject,
+          html,
+        });
+      } catch (error) {
+        logError("moderation.notificationEmail", error, {
+          actionId: (action as ModerationActionRow).id,
+          moderationCaseId: moderationCase.id,
+        });
+      }
+    }
   }
 
   return action as ModerationActionRow;

--- a/src/lib/supabase/queries.test.ts
+++ b/src/lib/supabase/queries.test.ts
@@ -172,6 +172,7 @@ describe("public Supabase query helpers", () => {
             budget_minor: 100_000,
             status: "open",
             created_at: "2026-06-03T00:00:00Z",
+            format_preference: "group",
           },
         ],
         guide_offers: [{ request_id: "request-1" }],
@@ -391,6 +392,42 @@ describe("PII-safe Supabase query mapping", () => {
 
     expect(result.data).toEqual([]);
     expect(result.error).toBe(offerError);
+  });
+
+  it("keeps private requests out of homepage open groups", async () => {
+    const client = createFakeClient({
+      traveler_requests: [
+        {
+          id: "private-request",
+          destination: "Москва",
+          budget_minor: 100_000,
+          participants_count: 2,
+          status: "open",
+          category: "city",
+          created_at: "2026-06-04T00:00:00Z",
+          traveler_id: "traveler-1",
+          format_preference: "private",
+        },
+        {
+          id: "group-request",
+          destination: "Казань",
+          budget_minor: 80_000,
+          participants_count: 1,
+          group_capacity: 4,
+          status: "open",
+          category: "city",
+          created_at: "2026-06-03T00:00:00Z",
+          traveler_id: "traveler-2",
+          format_preference: "group",
+        },
+      ],
+      guide_offers: [],
+    });
+
+    const result = await getHomepageRequests(client);
+
+    expect(result.error).toBeNull();
+    expect(result.data?.map((request) => request.id)).toEqual(["group-request"]);
   });
 
   it("surfaces open request member query errors instead of dropping member rows silently", async () => {
@@ -738,6 +775,7 @@ describe("getOpenRequestsByDestination", () => {
           status: "open",
           created_at: "2026-06-03T00:00:00Z",
           traveler_id: "traveler-1",
+          format_preference: "group",
         },
         {
           id: "request-2",
@@ -748,6 +786,7 @@ describe("getOpenRequestsByDestination", () => {
           status: "open",
           created_at: "2026-06-02T00:00:00Z",
           traveler_id: "traveler-2",
+          format_preference: "group",
         },
       ],
     });
@@ -780,6 +819,7 @@ describe("getOpenRequestsByDestination", () => {
           status: "open",
           created_at: "2026-06-03T00:00:00Z",
           traveler_id: "traveler-1",
+          format_preference: "group",
         },
         {
           id: "request-2",
@@ -790,6 +830,7 @@ describe("getOpenRequestsByDestination", () => {
           status: "open",
           created_at: "2026-06-02T00:00:00Z",
           traveler_id: "traveler-2",
+          format_preference: "group",
         },
       ],
       guide_offers: [
@@ -805,6 +846,42 @@ describe("getOpenRequestsByDestination", () => {
     const byId = new Map(result.data?.map((rec) => [rec.id, rec]));
     expect(byId.get("request-1")?.offerCount).toBe(2);
     expect(byId.get("request-2")?.offerCount).toBe(1);
+  });
+
+  it("keeps private requests out of destination open groups", async () => {
+    const client = createFakeClient({
+      traveler_requests: [
+        {
+          id: "private-request",
+          destination: "Элиста",
+          region: "Калмыкия",
+          budget_minor: 100_000,
+          participants_count: 2,
+          status: "open",
+          created_at: "2026-06-04T00:00:00Z",
+          traveler_id: "traveler-1",
+          format_preference: "private",
+        },
+        {
+          id: "group-request",
+          destination: "Элиста",
+          region: "Калмыкия",
+          budget_minor: 80_000,
+          participants_count: 1,
+          group_capacity: 4,
+          status: "open",
+          created_at: "2026-06-03T00:00:00Z",
+          traveler_id: "traveler-2",
+          format_preference: "group",
+        },
+      ],
+      guide_offers: [],
+    });
+
+    const result = await getOpenRequestsByDestination(client, "Калмыкия");
+
+    expect(result.error).toBeNull();
+    expect(result.data?.map((request) => request.id)).toEqual(["group-request"]);
   });
 
   it("surfaces guide_offers count errors instead of returning zero offers", async () => {

--- a/src/lib/supabase/queries.test.ts
+++ b/src/lib/supabase/queries.test.ts
@@ -1021,6 +1021,8 @@ describe("anonymous public request access uses the sanitized view", () => {
           budget_minor: 80_000,
           participants_count: 1,
           status: "open",
+          format_preference: "group",
+          open_to_join: true,
           created_at: "2026-06-03T00:00:00Z",
         },
       ],

--- a/src/lib/supabase/queries.ts
+++ b/src/lib/supabase/queries.ts
@@ -52,6 +52,12 @@ function decodeSlug(slug: string): string {
   }
 }
 
+function isPublicOpenGroupRequest(rec: RequestRecord): boolean {
+  if (rec.mode !== "assembly") return false;
+  if (rec.capacity == null) return true;
+  return rec.capacity - rec.groupSize > 0 || rec.offerCount > 0;
+}
+
 export async function getDestinations(client: SupabaseClient): Promise<QueryResult<DestinationRecord[]>> {
   try {
     const { data, error } = await client.from("destinations").select("*").order("listing_count", { ascending: false }).limit(12);
@@ -308,7 +314,7 @@ export async function getOpenRequestsByDestination(
       rec.members = membersMap.get(rec.id) ?? [];
     }
 
-    return { data: records, error: null };
+    return { data: records.filter(isPublicOpenGroupRequest), error: null };
   } catch (error) {
     return { data: [], error: makeError(error) };
   }
@@ -893,12 +899,7 @@ export async function getHomepageRequests(
       rec.members = membersMap.get(rec.id) ?? [];
     }
 
-    const filtered = records.filter((rec) => {
-      if (rec.mode !== "assembly") return true;
-      if (rec.capacity == null) return true;
-      const remaining = rec.capacity - rec.groupSize;
-      return remaining > 0 || rec.offerCount > 0;
-    });
+    const filtered = records.filter(isPublicOpenGroupRequest);
 
     filtered.sort(
       (a, b) =>


### PR DESCRIPTION
## Summary
- hide private requests from public open-group blocks
- notify guides in cabinet and email when admin requests profile changes
- source guide labels from shared copy catalog so checks pass on main

## Verification
- bun run check
- bun run test:run