### PR TITLE
Add pending feedback to admin action buttons

### DIFF
--- a/src/app/(protected)/admin/_components/pending-submit-button.test.tsx
+++ b/src/app/(protected)/admin/_components/pending-submit-button.test.tsx
@@ -1,0 +1,41 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+const { useFormStatusMock } = vi.hoisted(() => ({
+  useFormStatusMock: vi.fn(() => ({ pending: false })),
+}));
+
+vi.mock("react-dom", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("react-dom")>()),
+  useFormStatus: useFormStatusMock,
+}));
+
+import { PendingMenuSubmitButton, PendingSubmitButton } from "./pending-submit-button";
+
+describe("admin pending submit buttons", () => {
+  it("disables and relabels regular submit buttons while their form is pending", () => {
+    useFormStatusMock.mockReturnValueOnce({ pending: true });
+
+    render(
+      <PendingSubmitButton pendingLabel="Сохраняем…">Сохранить</PendingSubmitButton>,
+    );
+
+    const button = screen.getByRole("button", { name: /сохраняем/i });
+    expect(button).toBeDisabled();
+    expect(button).toHaveAttribute("aria-busy", "true");
+  });
+
+  it("disables and relabels dropdown submit items while their form is pending", () => {
+    useFormStatusMock.mockReturnValueOnce({ pending: true });
+
+    render(
+      <PendingMenuSubmitButton pendingLabel="Одобряем…">
+        Одобрить
+      </PendingMenuSubmitButton>,
+    );
+
+    const button = screen.getByRole("button", { name: /одобряем/i });
+    expect(button).toBeDisabled();
+    expect(button).toHaveAttribute("aria-busy", "true");
+  });
+});

--- a/src/app/(protected)/admin/_components/pending-submit-button.tsx
+++ b/src/app/(protected)/admin/_components/pending-submit-button.tsx
@@ -1,0 +1,56 @@
+"use client";
+
+import * as React from "react";
+import { useFormStatus } from "react-dom";
+
+import { Button } from "@/components/ui/button";
+import { cn } from "@/lib/utils";
+
+type PendingSubmitButtonProps = React.ComponentProps<typeof Button> & {
+  pendingLabel: React.ReactNode;
+};
+
+export function PendingSubmitButton({
+  children,
+  disabled,
+  pendingLabel,
+  ...props
+}: PendingSubmitButtonProps) {
+  const { pending } = useFormStatus();
+
+  return (
+    <Button
+      {...props}
+      type="submit"
+      disabled={disabled || pending}
+      loading={pending}
+      aria-live="polite"
+    >
+      {pending ? pendingLabel : children}
+    </Button>
+  );
+}
+
+export function PendingMenuSubmitButton({
+  children,
+  className,
+  pendingLabel,
+}: {
+  children: React.ReactNode;
+  className?: string;
+  pendingLabel: React.ReactNode;
+}) {
+  const { pending } = useFormStatus();
+
+  return (
+    <button
+      type="submit"
+      disabled={pending}
+      aria-busy={pending || undefined}
+      aria-live="polite"
+      className={cn("w-full cursor-pointer disabled:cursor-wait disabled:opacity-60", className)}
+    >
+      {pending ? pendingLabel : children}
+    </button>
+  );
+}

--- a/src/app/(protected)/admin/bookings/[id]/page.tsx
+++ b/src/app/(protected)/admin/bookings/[id]/page.tsx
@@ -3,13 +3,13 @@ import { notFound } from "next/navigation";
 
 import { PageHeader } from "@/components/shared/page-header";
 import { Badge } from "@/components/ui/badge";
-import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { kopecksToRub } from "@/data/money";
 import { COPY } from "@/lib/copy";
 import { formatRussianDateTime } from "@/lib/dates";
 import { requireAdminSession } from "@/lib/supabase/moderation";
 
+import { PendingSubmitButton } from "../../_components/pending-submit-button";
 import { confirmBookingAction } from "./actions";
 import { STATUS_LABELS } from "../status-labels";
 
@@ -133,9 +133,13 @@ export default async function AdminBookingDetailPage({
             </CardHeader>
             <CardContent>
               <form action={confirmBookingAction.bind(null, booking.id)}>
-                <Button type="submit" size="default" className="min-h-[44px]">
+                <PendingSubmitButton
+                  size="default"
+                  className="min-h-[44px]"
+                  pendingLabel="Подтверждаем…"
+                >
                   Подтвердить
-                </Button>
+                </PendingSubmitButton>
               </form>
             </CardContent>
           </Card>

--- a/src/app/(protected)/admin/bookings/page.tsx
+++ b/src/app/(protected)/admin/bookings/page.tsx
@@ -14,6 +14,7 @@ import { kopecksToRub } from "@/data/money";
 import { formatRussianDateTime } from "@/lib/dates";
 import { requireAdminSession } from "@/lib/supabase/moderation";
 
+import { PendingSubmitButton } from "../_components/pending-submit-button";
 import { confirmPaymentAction } from "./actions";
 import { STATUS_LABELS } from "./status-labels";
 
@@ -152,13 +153,13 @@ export default async function BookingsPage({
                 actions={
                   booking.status === "awaiting_guide_confirmation" ? (
                     <form action={confirmPaymentAction.bind(null, booking.id)}>
-                      <Button
-                        type="submit"
+                      <PendingSubmitButton
                         size="default"
                         className="min-h-[44px]"
+                        pendingLabel="Подтверждаем…"
                       >
                         Подтвердить
-                      </Button>
+                      </PendingSubmitButton>
                     </form>
                   ) : undefined
                 }

--- a/src/app/(protected)/admin/guides/[id]/guide-approval-form.tsx
+++ b/src/app/(protected)/admin/guides/[id]/guide-approval-form.tsx
@@ -11,18 +11,19 @@ import { approveGuide, rejectGuide, requestChanges, type ActionState } from "./a
 const INITIAL: ActionState = { error: null };
 
 export function GuideApprovalForm({ guideId }: { guideId: string }) {
-  const [approveState, approveAction] = React.useActionState(
+  const [approveState, approveAction, approvePending] = React.useActionState(
     approveGuide.bind(null, guideId),
     INITIAL,
   );
-  const [rejectState, rejectAction] = React.useActionState(
+  const [rejectState, rejectAction, rejectPending] = React.useActionState(
     rejectGuide.bind(null, guideId),
     INITIAL,
   );
-  const [changesState, changesAction] = React.useActionState(
+  const [changesState, changesAction, changesPending] = React.useActionState(
     requestChanges.bind(null, guideId),
     INITIAL,
   );
+  const anyPending = approvePending || rejectPending || changesPending;
 
   const error = approveState.error ?? rejectState.error ?? changesState.error;
   const success =
@@ -58,24 +59,30 @@ export function GuideApprovalForm({ guideId }: { guideId: string }) {
           type="submit"
           variant="default"
           className="w-full"
+          disabled={anyPending}
+          loading={approvePending}
         >
-          Одобрить гида
+          {approvePending ? "Одобряем…" : "Одобрить гида"}
         </Button>
         <Button
           formAction={changesAction}
           type="submit"
           variant="outline"
           className="w-full"
+          disabled={anyPending}
+          loading={changesPending}
         >
-          Запросить изменения
+          {changesPending ? "Запрашиваем…" : "Запросить изменения"}
         </Button>
         <Button
           formAction={rejectAction}
           type="submit"
           variant="destructive"
           className="w-full"
+          disabled={anyPending}
+          loading={rejectPending}
         >
-          Отклонить
+          {rejectPending ? "Отклоняем…" : "Отклонить"}
         </Button>
       </div>
     </form>

--- a/src/app/(protected)/admin/guides/[id]/guide-availability-control.tsx
+++ b/src/app/(protected)/admin/guides/[id]/guide-availability-control.tsx
@@ -15,7 +15,7 @@ export function GuideAvailabilityControl({
   guideId: string;
   available: boolean;
 }) {
-  const [state, action] = React.useActionState(
+  const [state, action, pending] = React.useActionState(
     setGuideAvailability.bind(null, guideId, !available),
     INITIAL,
   );
@@ -27,8 +27,18 @@ export function GuideAvailabilityControl({
       </p>
       {state.error ? <p className="text-sm text-destructive">{state.error}</p> : null}
       {state.success ? <p className="text-sm text-success">{state.success}</p> : null}
-      <Button formAction={action} type="submit" variant={available ? "outline" : "default"}>
-        {available ? "Приостановить приём заявок" : "Возобновить приём заявок"}
+      <Button
+        formAction={action}
+        type="submit"
+        variant={available ? "outline" : "default"}
+        disabled={pending}
+        loading={pending}
+      >
+        {pending
+          ? "Сохраняем…"
+          : available
+            ? "Приостановить приём заявок"
+            : "Возобновить приём заявок"}
       </Button>
     </form>
   );

--- a/src/app/(protected)/admin/guides/page.tsx
+++ b/src/app/(protected)/admin/guides/page.tsx
@@ -26,6 +26,8 @@ import type {
 } from "@/lib/supabase/moderation";
 import { resolveDisplayName } from "@/lib/profile/resolve-display-name";
 
+import { PendingMenuSubmitButton } from "../_components/pending-submit-button";
+
 export const metadata: Metadata = {
   title: "Очередь верификации",
 };
@@ -290,12 +292,12 @@ export default async function AdminGuidesPage({
                             )}
                           >
                             <DropdownMenuItem asChild>
-                              <button
-                                type="submit"
+                              <PendingMenuSubmitButton
                                 className="w-full cursor-pointer text-success focus:text-success"
+                                pendingLabel="Одобряем…"
                               >
                                 Одобрить
-                              </button>
+                              </PendingMenuSubmitButton>
                             </DropdownMenuItem>
                           </form>
                           <form
@@ -305,9 +307,9 @@ export default async function AdminGuidesPage({
                             )}
                           >
                             <DropdownMenuItem asChild variant="destructive">
-                              <button type="submit" className="w-full cursor-pointer">
+                              <PendingMenuSubmitButton pendingLabel="Отклоняем…">
                                 Отклонить
-                              </button>
+                              </PendingMenuSubmitButton>
                             </DropdownMenuItem>
                           </form>
                         </DropdownMenuContent>

--- a/src/app/(protected)/admin/users/[id]/_components/account-actions.tsx
+++ b/src/app/(protected)/admin/users/[id]/_components/account-actions.tsx
@@ -130,8 +130,8 @@ function StatusActionDialog({
             <Button type="button" variant="ghost" onClick={() => setOpen(false)}>
               Отмена
             </Button>
-            <Button type="submit" variant={variant} disabled={pending}>
-              Подтвердить
+            <Button type="submit" variant={variant} disabled={pending} loading={pending}>
+              {pending ? "Сохраняем…" : "Подтвердить"}
             </Button>
           </DialogFooter>
         </form>
@@ -224,8 +224,8 @@ export function RoleControls({
         <Textarea id="role-reason" name="reason" required placeholder="Причина смены роли" />
       </div>
       <ResultLine result={state} />
-      <Button type="submit" disabled={pending || role === currentRole}>
-        Сменить роль
+      <Button type="submit" disabled={pending || role === currentRole} loading={pending}>
+        {pending ? "Сохраняем…" : "Сменить роль"}
       </Button>
     </form>
   );
@@ -249,8 +249,8 @@ export function GuideVerificationControls({ guideId }: { guideId: string }) {
     <div className="space-y-3">
       <div className="flex flex-wrap gap-2">
         <form action={approve}>
-          <Button type="submit" variant="default" size="sm" disabled={approvePending}>
-            Одобрить анкету
+          <Button type="submit" variant="default" size="sm" disabled={approvePending || rejectPending} loading={approvePending}>
+            {approvePending ? "Одобряем…" : "Одобрить анкету"}
           </Button>
         </form>
         <form action={reject} className="flex flex-1 flex-wrap items-end gap-2">
@@ -260,8 +260,8 @@ export function GuideVerificationControls({ guideId }: { guideId: string }) {
             </Label>
             <Textarea id="reject-reason" name="reason" rows={2} />
           </div>
-          <Button type="submit" variant="destructive" size="sm" disabled={rejectPending}>
-            Отклонить
+          <Button type="submit" variant="destructive" size="sm" disabled={approvePending || rejectPending} loading={rejectPending}>
+            {rejectPending ? "Отклоняем…" : "Отклонить"}
           </Button>
         </form>
       </div>
@@ -318,8 +318,8 @@ export function HardDeleteControl({ userId }: { userId: string }) {
           </div>
           <AlertDialogFooter>
             <AlertDialogCancel type="button">Отмена</AlertDialogCancel>
-            <Button type="submit" variant="destructive" disabled={pending}>
-              Удалить навсегда
+            <Button type="submit" variant="destructive" disabled={pending} loading={pending}>
+              {pending ? "Удаляем…" : "Удалить навсегда"}
             </Button>
           </AlertDialogFooter>
         </form>

--- a/src/app/(protected)/admin/users/_components/users-console.tsx
+++ b/src/app/(protected)/admin/users/_components/users-console.tsx
@@ -364,7 +364,7 @@ export function UsersConsole({
                                 })
                               }
                             >
-                              Одобрить гида
+                              {rowPending ? "Одобряем…" : "Одобрить гида"}
                             </DropdownMenuItem>
                           </DropdownMenuContent>
                         </DropdownMenu>
@@ -449,6 +449,7 @@ export function UsersConsole({
                     : "default"
                 }
                 disabled={bulkPending}
+                loading={bulkPending}
               >
                 {bulkPending ? "Применяем…" : "Подтвердить"}
               </Button>

--- a/src/features/admin/components/disputes/dispute-case-detail.tsx
+++ b/src/features/admin/components/disputes/dispute-case-detail.tsx
@@ -161,8 +161,13 @@ export function DisputeCaseDetail({
                   variant="outline"
                   className="w-full"
                   disabled={(isAssignedToMe && dispute.status !== "open") || assignPending}
+                  loading={assignPending}
                 >
-                  {isAssignedToMe ? "Уже назначен на вас" : "Назначить себе"}
+                  {assignPending
+                    ? "Назначаем…"
+                    : isAssignedToMe
+                      ? "Уже назначен на вас"
+                      : "Назначить себе"}
                 </Button>
                 {assignState?.error ? (
                   <Alert variant="destructive">
@@ -188,9 +193,15 @@ export function DisputeCaseDetail({
                     required
                   />
                 </div>
-                <Button type="submit" variant="ghost" className="w-full" disabled={notePending}>
+                <Button
+                  type="submit"
+                  variant="ghost"
+                  className="w-full"
+                  disabled={notePending}
+                  loading={notePending}
+                >
                   <MessageSquareText className="mr-1 size-4" />
-                  Сохранить заметку
+                  {notePending ? "Сохраняем…" : "Сохранить заметку"}
                 </Button>
                 {noteState?.error ? (
                   <Alert variant="destructive">
@@ -215,8 +226,13 @@ export function DisputeCaseDetail({
                     required
                   />
                 </div>
-                <Button type="submit" className="w-full" disabled={dispute.status === "resolved" || resolvePending}>
-                  Закрыть спор
+                <Button
+                  type="submit"
+                  className="w-full"
+                  disabled={dispute.status === "resolved" || resolvePending}
+                  loading={resolvePending}
+                >
+                  {resolvePending ? "Закрываем…" : "Закрыть спор"}
                 </Button>
                 {resolveState?.error ? (
                   <Alert variant="destructive">


### PR DESCRIPTION
## Summary
- show loading/pending labels on guide approval, rejection, request-changes, and availability actions
- disable sibling guide moderation buttons while one action is in flight to prevent duplicate audit writes
- apply the same pending feedback pattern to similar admin actions: booking confirmation, user account actions, bulk actions, and dispute actions
- add coverage for shared pending submit buttons

## Verification
- bun run check
- bun run test:run