### PR TITLE
Clean up guide offer sidebar metadata

### DIFF
--- a/src/features/guide/components/requests/bid-form-panel.test.tsx
+++ b/src/features/guide/components/requests/bid-form-panel.test.tsx
@@ -106,7 +106,7 @@ describe("BidFormPanel — mode line", () => {
       />,
     );
 
-    expect(screen.getByText("Сборная группа")).toBeInTheDocument();
+    expect(screen.getByText("Сборная группа · Сколько человек готовы взять?")).toBeInTheDocument();
     expect(screen.queryByText(/^Открытая группа$/)).toBeNull();
   });
 
@@ -119,7 +119,21 @@ describe("BidFormPanel — mode line", () => {
       />,
     );
 
-    expect(screen.getByText("Своя группа")).toBeInTheDocument();
+    expect(screen.getByText("Своя группа · Группа сформирована")).toBeInTheDocument();
+    expect(screen.getByText("4 чел.")).toBeInTheDocument();
+  });
+
+  it("keeps date and headcount out of the panel header", () => {
+    render(
+      <BidFormPanel
+        requestId="req-1"
+        request={{ ...baseRequest, destination: "Сочи", dateLabel: "10 июня", groupSize: 4 }}
+        onClose={() => {}}
+      />,
+    );
+
+    expect(screen.getByText("Сочи")).toBeInTheDocument();
+    expect(screen.queryByText("Сочи · 10 июня · 4 чел.")).toBeNull();
   });
 });
 
@@ -178,7 +192,9 @@ describe("BidFormPanel — headcount field", () => {
       />,
     );
 
-    expect(screen.getByText("В запросе: 4 чел.")).toBeInTheDocument();
+    expect(screen.getByText("Сборная группа · Сколько человек готовы взять?")).toBeInTheDocument();
+    expect(screen.getByText("4 чел.")).toBeInTheDocument();
+    expect(screen.queryByText("В запросе: 4 чел.")).toBeNull();
   });
 
   it("does not render the «предложено» badge when headcount changes", () => {
@@ -391,7 +407,7 @@ describe("BidFormPanel — form copy", () => {
 
     expect(screen.getByText("Начало")).toBeInTheDocument();
     expect(screen.getByText("Конец")).toBeInTheDocument();
-    expect(screen.getByText("Сколько человек готовы взять?")).toBeInTheDocument();
+    expect(screen.getByText("Сборная группа · Сколько человек готовы взять?")).toBeInTheDocument();
     expect(
       screen.getByPlaceholderText("Дополнительная информация об экскурсии, вопросы и условия"),
     ).toBeInTheDocument();

--- a/src/features/guide/components/requests/bid-form-panel.tsx
+++ b/src/features/guide/components/requests/bid-form-panel.tsx
@@ -265,7 +265,7 @@ export function BidFormPanel({
               {isEdit ? "Редактировать предложение" : "Сделать предложение"}
             </h2>
             <p className="mt-0.5 text-sm text-muted-foreground">
-              {request.destination} · {request.dateLabel} · {travelerCount} чел.
+              {request.destination}
             </p>
           </div>
           <button
@@ -512,19 +512,22 @@ export function BidFormPanel({
           <div className="grid gap-2">
             <div className="flex items-center gap-2">
               <span
+                className="text-sm font-medium text-foreground"
+              >
+                {request.mode === "assembly"
+                  ? "Сборная группа · Сколько человек готовы взять?"
+                  : "Своя группа · Группа сформирована"}
+              </span>
+              <span
                 className={
                   request.mode === "assembly"
-                    ? "inline-flex items-center rounded-full px-2.5 py-0.5 text-xs font-medium bg-sky-100 text-sky-700"
-                    : "inline-flex items-center rounded-full px-2.5 py-0.5 text-xs font-medium bg-purple-100 text-purple-700"
+                    ? "inline-flex items-center rounded-full bg-sky-100 px-2.5 py-0.5 text-xs font-medium text-sky-700"
+                    : "inline-flex items-center rounded-full bg-purple-100 px-2.5 py-0.5 text-xs font-medium text-purple-700"
                 }
               >
-                {request.mode === "assembly" ? "Сборная группа" : "Своя группа"}
-              </span>
-              <span className="text-sm font-medium text-foreground">
-                {request.mode === "assembly" ? "Сколько человек готовы взять?" : "Группа сформирована"}
+                {travelerCount} чел.
               </span>
             </div>
-            <p className="text-sm text-muted-foreground">В запросе: {travelerCount} чел.</p>
             {request.mode === "assembly" ? (
               <input
                 type="number"


### PR DESCRIPTION
## Summary
- remove duplicated date and participant count from the top of the guide offer sidebar
- combine group type and formed-group status into one line
- move participant count into a compact badge next to that line
- add regression coverage for the sidebar header/count copy

## Verification
- bun run test:run -- src/features/guide/components/requests/bid-form-panel.test.tsx
- bun run check
- bun run test:run