### PR TITLE
Hide duplicate create-request CTA on homepage

### DIFF
--- a/src/components/shared/site-header.test.tsx
+++ b/src/components/shared/site-header.test.tsx
@@ -56,6 +56,20 @@ describe("SiteHeader desktop account menu", () => {
     ).toBeInTheDocument();
   });
 
+  it("does not duplicate the create-request CTA on the homepage", () => {
+    mockPathname = "/";
+    renderAuthenticatedHeader("traveler");
+
+    expect(screen.queryByRole("link", { name: "Создать запрос" })).toBeNull();
+  });
+
+  it("keeps the create-request CTA on non-home pages", () => {
+    mockPathname = "/destinations";
+    renderAuthenticatedHeader("traveler");
+
+    expect(screen.getByRole("link", { name: "Создать запрос" })).toHaveAttribute("href", "/");
+  });
+
   it.each(["/requests", "/destinations", "/how-it-works"])(
     "shows the account trigger on public route %s when authenticated",
     (pathname) => {

--- a/src/components/shared/site-header.tsx
+++ b/src/components/shared/site-header.tsx
@@ -87,6 +87,7 @@ export function SiteHeader({
 
   const primaryCtaHref = role === "guide" ? "/requests" : "/";
   const primaryCtaLabel = role === "guide" ? "Смотреть запросы" : "Создать запрос";
+  const showPrimaryCta = isAuthenticated && role !== "admin" && role !== "guide" && pathname !== "/";
   const accountLabel = fullName?.trim().split(/\s+/)[0] || (role ? roleLabels[role] : "Аккаунт");
   const messagesLabel =
     unreadCount > 0 ? `Сообщения, непрочитанных: ${unreadCount}` : "Сообщения";
@@ -215,7 +216,7 @@ export function SiteHeader({
               </Button>
             </div>
           )}
-          {isAuthenticated && role !== "admin" && role !== "guide" && (
+          {showPrimaryCta && (
             <Button asChild className="max-md:hidden">
               <Link href={primaryCtaHref}>{primaryCtaLabel}</Link>
             </Button>


### PR DESCRIPTION
## Summary
- hide the authenticated traveler "Создать запрос" header CTA on the homepage because the request form is already visible there
- keep the same CTA on other pages where it still navigates back to the request form
- add regression coverage for both homepage and non-home header behavior

## Verification
- bun run test:run -- src/components/shared/site-header.test.tsx
- bun run check
- bun run test:run