### PR TITLE
fix(a11y): guide offer form is a real modal — reuse the existing Radix Dialog primitive

### DIFF
--- a/src/features/guide/components/requests/bid-form-panel.tsx
+++ b/src/features/guide/components/requests/bid-form-panel.tsx
@@ -8,6 +8,12 @@ import { z } from "zod";
 import { Lock, X } from "lucide-react";
 
 import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogTitle,
+} from "@/components/ui/dialog";
 import { INTEREST_CHIPS } from "@/data/interests";
 import { kopecksToRub } from "@/data/money";
 import type { RequestRecord } from "@/data/supabase/queries";
@@ -246,19 +252,15 @@ export function BidFormPanel({
   );
 
   return (
-    <>
-      <div
-        className="fixed inset-0 z-[110] bg-foreground/40 backdrop-blur-[2px]"
-        onClick={onClose}
-        aria-hidden
-      />
-
-      <div
-        role="dialog"
-        aria-modal="true"
-        aria-label="Отправить предложение"
-        className="fixed bottom-0 right-0 z-[120] flex h-full w-full max-w-[480px] flex-col overflow-y-auto bg-surface shadow-xl max-md:max-w-full max-md:h-[90dvh] max-md:rounded-t-2xl md:top-0 md:bottom-auto"
+    <Dialog open onOpenChange={(o) => { if (!o) onClose(); }}>
+      <DialogContent
+        showCloseButton={false}
+        className="flex h-full w-full max-w-[480px] translate-x-0 translate-y-0 flex-col gap-0 overflow-y-auto rounded-none bg-surface p-0 shadow-xl ring-0 top-0 bottom-0 left-auto right-0 sm:max-w-[480px] max-md:top-auto max-md:bottom-0 max-md:left-0 max-md:right-0 max-md:h-[90dvh] max-md:max-w-full max-md:rounded-t-2xl data-open:zoom-in-100 data-closed:zoom-out-100"
       >
+        <DialogTitle className="sr-only">Отправить предложение</DialogTitle>
+        <DialogDescription className="sr-only">
+          Форма отправки предложения гидом
+        </DialogDescription>
         <div className="flex items-center justify-between border-b border-border/60 px-6 py-4">
           <div>
             <h2 className="font-sans text-base font-semibold text-foreground">
@@ -640,7 +642,7 @@ export function BidFormPanel({
                   : "Отправить предложение"}
           </Button>
         </form>
-      </div>
-    </>
+      </DialogContent>
+    </Dialog>
   );
 }

--- a/src/features/guide/components/requests/bid-form-panel.tsx
+++ b/src/features/guide/components/requests/bid-form-panel.tsx
@@ -98,6 +98,7 @@ export function BidFormPanel({
   onSuccess,
 }: BidFormPanelProps) {
   const isEdit = !!editOffer;
+  const [open, setOpen] = React.useState(true);
   const [serverError, setServerError] = React.useState<string | null>(null);
   const [submitted, setSubmitted] = React.useState(false);
   const submitInFlight = React.useRef(false);
@@ -252,9 +253,10 @@ export function BidFormPanel({
   );
 
   return (
-    <Dialog open onOpenChange={(o) => { if (!o) onClose(); }}>
+    <Dialog open={open} onOpenChange={(o) => { if (!o) setOpen(false); }}>
       <DialogContent
         showCloseButton={false}
+        onCloseAutoFocus={() => onClose()}
         className="flex h-full w-full max-w-[480px] translate-x-0 translate-y-0 flex-col gap-0 overflow-y-auto rounded-none bg-surface p-0 shadow-xl ring-0 top-0 bottom-0 left-auto right-0 sm:max-w-[480px] max-md:top-auto max-md:bottom-0 max-md:left-0 max-md:right-0 max-md:h-[90dvh] max-md:max-w-full max-md:rounded-t-2xl data-open:zoom-in-100 data-closed:zoom-out-100"
       >
         <DialogTitle className="sr-only">Отправить предложение</DialogTitle>
@@ -272,7 +274,7 @@ export function BidFormPanel({
           </div>
           <button
             type="button"
-            onClick={onClose}
+            onClick={() => setOpen(false)}
             aria-label="Закрыть панель"
             className="flex size-8 items-center justify-center rounded-full text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
           >

--- a/src/features/guide/components/requests/bid-form-panel.tsx
+++ b/src/features/guide/components/requests/bid-form-panel.tsx
@@ -98,6 +98,10 @@ export function BidFormPanel({
   onSuccess,
 }: BidFormPanelProps) {
   const isEdit = !!editOffer;
+  const previouslyFocused = React.useRef<HTMLElement | null>(null);
+  React.useEffect(() => {
+    previouslyFocused.current = document.activeElement as HTMLElement | null;
+  }, []);
   const [open, setOpen] = React.useState(true);
   const [serverError, setServerError] = React.useState<string | null>(null);
   const [submitted, setSubmitted] = React.useState(false);
@@ -256,7 +260,13 @@ export function BidFormPanel({
     <Dialog open={open} onOpenChange={(o) => { if (!o) setOpen(false); }}>
       <DialogContent
         showCloseButton={false}
-        onCloseAutoFocus={() => onClose()}
+        onCloseAutoFocus={(event) => {
+          event.preventDefault();
+          if (previouslyFocused.current?.isConnected) {
+            previouslyFocused.current.focus();
+          }
+          onClose();
+        }}
         className="flex h-full w-full max-w-[480px] translate-x-0 translate-y-0 flex-col gap-0 overflow-y-auto rounded-none bg-surface p-0 shadow-xl ring-0 top-0 bottom-0 left-auto right-0 sm:max-w-[480px] max-md:top-auto max-md:bottom-0 max-md:left-0 max-md:right-0 max-md:h-[90dvh] max-md:max-w-full max-md:rounded-t-2xl data-open:zoom-in-100 data-closed:zoom-out-100"
       >
         <DialogTitle className="sr-only">Отправить предложение</DialogTitle>


### PR DESCRIPTION
## The defect (measured, not theorised)

`bid-form-panel.tsx` — the guide's **«Отправить предложение»** form, the single most important action in a request-first marketplace — hand-rolled its modal: a `fixed inset-0` backdrop `<div onClick={onClose}>` plus `<div role="dialog" aria-modal="true">`.

Driven in Chromium at **1280px and 375px**:

```
scroll lock       : body overflow="visible"  -> NOT LOCKED, page scrolls behind
focus into dialog : NO   -> focus stays on the page behind
focus TRAPPED     : NO   -> escaped after 1 Tab onto "Открыть полный запрос: Элиста" (a link BEHIND the modal)
Escape closes     : NO   -> a keyboard user cannot close the offer form at all
```

`aria-modal="true"` promises assistive tech that the rest of the page is inert. It was not. WCAG 2.1.1 (Keyboard) and 4.1.2 failures.

## The fix — reuse, not addition

Routed the panel through **`src/components/ui/dialog.tsx`**, the Radix Dialog primitive **already in this repo** (16 other files already use these primitives; this was one of 4 outliers).

- **Zero new dependencies.** `package.json` and `bun.lock` untouched. Unified `radix-ui` base preserved — no `base-ui`, no individual `@radix-ui/react-*`.
- No `shadcn init`/`add`. `components.json`, the `radix-nova` preset, `globals.css`, and `src/components/ui/**` all untouched.
- **One file changed.**

### Why Dialog and not Sheet
A first attempt used `SheetContent side="right"` and **silently broke the mobile layout** — `data-[side=right]:w-3/4` / `sm:max-w-sm` / `inset-y-0` cannot be overridden by plain utilities (different variant prefix ⇒ `tailwind-merge` won't dedupe ⇒ the data-variant wins on specificity). Measured regression: desktop 480→384px, mobile bottom-sheet → 75%-width full-height drawer. **Every gate passed anyway.** That attempt was discarded. `DialogContent`'s base classes are all plain, so the override resolves cleanly.

### Focus restore
Radix's modal `onCloseAutoFocus` does `preventDefault(); triggerRef.current?.focus()`. This panel has no `<DialogTrigger>` (the trigger lives in the parent), so `triggerRef` is null and focus fell to `<body>`. Restored explicitly from the element focused at mount, guarded on `isConnected`.

## Verification — every interaction, both viewports

| | desktop 1280 | mobile 375 |
|---|---|---|
| accessible name «Отправить предложение» | ✓ | ✓ |
| scroll lock (`body overflow: hidden`) | ✓ | ✓ |
| focus moves into dialog on open | ✓ | ✓ |
| focus trapped (30 Tabs) | ✓ | ✓ |
| **Escape** closes | ✓ | ✓ |
| **click-outside** closes | ✓ | ✓ |
| focus restored to trigger on close | ✓ | ✓ |

**Geometry pixel-identical** to before — desktop `x=800 y=0 w=480 h=900`; mobile `x=0 y=81 w=375 h=731, radius-top 16px`. The responsive right-drawer → bottom-sheet behaviour is preserved exactly.

Gates: `check` exit 0 · **1195/1195 tests** · clean build · audit 4 moderate / 0 high · E2E 11 passed · request-first lifecycle **6/6** (which asserts the dialog's accessible name).

## Known, deliberately NOT shipped

`day-panel.tsx` and `booking-ticket.tsx` have the **same defect class** (verified by inspection: no Escape, no focus trap, no scroll lock, yet `aria-modal="true"`). They are **not browser-reachable** in the seeded environment (the calendar day panel needs a listing wired into its data path; `/bookings` has no bookings). Given the Sheet regression above passed every automated gate, shipping a UI change I cannot see would be reckless. Filed as a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)