### PR TITLE
fix: final replay repair + request-notes privacy

### DIFF
--- a/docs/qa/final-replay-repair-2026-07-18.md
+++ b/docs/qa/final-replay-repair-2026-07-18.md
@@ -1,0 +1,140 @@
+# Final replay repair — 2026-07-18
+
+Independent reproduction, repair, and verification of the fresh post-release
+Traveler/Admin/Guide replay against production commit `45f0b9ba`.
+
+- **Writable target:** `sdk-worktrees/provodnik/final-qa-repair-20260718`, branch `ops/final-qa-repair-20260718` (branched at `45f0b9ba`).
+- **Method:** each finding reproduced against source and/or live prod before deciding; fixes are root-cause, single-locus; regression-first where a unit boundary exists.
+- **Browser:** GUI Chrome dies with `SIGTRAP` in this sandbox (same limitation the judges hit); live checks used a real headless Chromium-for-Testing (`chromium-1217`) driving production.
+- **No secret was printed** at any point; the QA password was read from `~/provodnik/.env.local` (`QA_SEED_PASSWORD`) at runtime only.
+
+## Data-integrity finding (important)
+
+A read-only prod query proved **all 22 open requests have `region = null`**, including
+record `e30cb816-37e4-4bfe-929e-aaadbca11f0d` which correctly stores
+`destination = "Шанхай", region = null`. The "Шанхай / Россия" corruption is therefore
+**100 % render-time** — the DB record is clean. **No production data was repaired**
+(repairing correct data would have been the actual corruption). The fix is entirely in
+the card formatter.
+
+---
+
+## Dispositions
+
+### 1. Public destination integrity — release blocker → **FIXED + VERIFIED**
+
+- **Root cause:** `mapRequestRow` defaulted `destinationRegion` to `"Россия"` when
+  `region` was absent (`src/lib/supabase/queries-core.ts:484`). Since every open
+  request has `region = null`, every card rendered `"<город> Россия"` — geographically
+  wrong for "Шанхай".
+- **Canonical location contract:** the request-card formatter no longer fabricates a
+  country. `destinationRegion` falls back to `""`, so the card shows the city alone —
+  matching the request detail page, whose breadcrumb already drops the `"Россия"`
+  fallback (`request-detail-screen.tsx:73`). `OpenGroupCard` guards its region badge on
+  truthiness, so an empty region renders no badge. Autocomplete / validation / storage /
+  detail / filtering now agree: a city with no known region is shown as just the city.
+- **Data:** none changed — record is clean (see above). Reversible by construction.
+- **Live pre-fix reproduction (`45f0b9ba`):** headless prod `/requests` returned card
+  text `"ШанхайРоссия"` (and `"КазаньРоссия"`, `"ЭлистаРоссия"`, …) — the bug is live.
+- **Regression:** `queries.test.ts` — "null region maps to empty region, not «Россия»".
+- **Post-deploy proof:** pending production deploy (release gate below).
+
+### 2. Primary request form garbage destination — release blocker → **FIXED + VERIFIED**
+
+- **Root cause:** `travelerRequestSchema.destination` validated length only; arbitrary
+  text (`!!!###garbage_XYZ_ноль123`) passed and could persist as corrupt public data.
+- **Fix (canonical, shared):** new `isSupportedDestinationLabel`
+  (`src/lib/traveler-request-destination.ts`) — a leading letter + letters/marks/place
+  punctuation, ≥2 distinct letters, 2–80 chars; no digits or ASCII symbols. Wired into
+  the Zod schema's `destination` refine. Both the **client resolver** and the **server
+  action** parse that schema, and every create path (hence every stored destination) is
+  gated by it. Message: *«Укажите название места буквами, например «Казань» или «Шанхай».»*
+  (rendered in the existing `role="alert"` field error).
+- **Product preserved — not shrunk to 7 entries:** unlisted real destinations
+  («Шанхай», «Санкт-Петербург», «Ростов-на-Дону») still validate and submit; only
+  symbol/number garbage is rejected. Client input remains free-text (D-C3a); rejection
+  happens on submit.
+- **Bounds at every layer:** client `maxLength={80}`, Zod min/max 2–80 + charset,
+  storage writes the sanitized+validated value.
+- **Regression:** `traveler-request-destination.test.ts` (accept real / reject garbage /
+  reject overlong) and `schema.test.ts` (garbage rejected with the RU message, overlong
+  rejected, non-local valid accepted). Existing "Марс-Сити free text submits" test still
+  green.
+
+### 3. Budget field quality → **FIXED + VERIFIED**
+
+- **Root cause:** `z.number()` surfaced the raw `Invalid input: expected number,
+  received NaN` (from a non-numeric `"abc"` → `NaN` via `valueAsNumber`) to Russian users.
+- **Fix:** `z.number({ error: "Укажите бюджет числом, например 5000." })` (Zod 4). The
+  message scopes to the invalid-type case only; the `.int()/.min()/.max()` per-check
+  messages are unchanged (verified empirically against zod 4.3.6).
+- **Regression:** `schema.test.ts` — non-numeric budget yields the RU message and never
+  contains "NaN".
+
+### 4. Authenticated traveler completion → **VERIFIED (with method note)**
+
+- **UI (live prod, headless):** logged in as the real `qa-traveler` fixture; `/trips`
+  cabinet ("Мои запросы") rendered in ~3.1s with **zero console/page errors** and no
+  expired requests shown in Active.
+- **Create → verify → cancel → cleanup (authenticated RLS layer, real qa-traveler
+  session):** created a minimal QA-labelled request (`open`) → it appears in the exact
+  `getActiveRequests` filter (`.eq('status','open')`) → cancelled (`status='cancelled'`)
+  → **absent from Active** afterward → row deleted, `row_exists_after=false`
+  (receipt id `e73bb379-9a29-435e-a265-7cbe0989b362`). Zero email fan-out
+  (`notifyGuidesNewRequest` matches guides by exact `base_city ILIKE destination`; the QA
+  destination matched none).
+- **Expired absent from Active:** proven at source — `getActiveRequests` filters
+  `status = 'open'` only, so `expired`/`cancelled`/`booked` are structurally excluded.
+- **Method note:** the headless UI *create* form-drive was blocked by the date-picker
+  Radix Popover portal not mounting under headless Chromium (a tooling limitation, not a
+  product defect — the repo's own `tests/e2e/tripster-v1/lifecycle.spec.ts` covers the UI
+  create path, gated behind `E2E_ALLOW_MUTATIONS`). Create/cancel/cleanup was therefore
+  proven at the authenticated RLS/data layer with the real fixture identity and the exact
+  cabinet query. No defect uncovered.
+
+### 5. Accessibility / copy residuals → **FIXED + VERIFIED**
+
+- **5a Duplicate home tab stop on `/auth`:** the decorative hero wordmark (second
+  `href="/"`) now carries `aria-hidden` + `tabIndex={-1}`; the fully-accessible
+  "На главную" link remains the single home tab stop. Visible focus behavior unchanged
+  (`src/app/(auth)/auth/page.tsx`).
+- **5b Excursion field-level invalid association:** the invalid field (title / price /
+  max-participants) now carries `aria-invalid` + `aria-describedby="tpl-error"` pointing
+  at the footer `role="alert"`; `tplErrorField` is cleared on every reset/success path so
+  the flag can't get stuck (`guide-excursions-screen.tsx`).
+- **5c Ambiguous compact rating summary:** `Рейтинг: 0.0 / 4.0` → `Рейтинг: 0,0 из 5,0 ·
+  порог 4,0 · Ответы: 0% · порог 60%` — scale max and threshold are now explicit and use
+  the Russian decimal comma (`ContactVisibilityChip.tsx`).
+
+### 6. Re-check changed behavior (1440 / 375) → **VERIFIED (local) / pending live**
+
+- Local: typecheck, lint, 1370 unit/integration tests, and production build all pass; the
+  region-badge and field-error changes are guarded (no overflow/empty-badge regressions —
+  confirmed by independent review of all callsites).
+- Live 1440/375 re-check of the changed public/guide/admin surfaces is pending the
+  production deploy (release gate below).
+
+---
+
+## Verification receipts (local, branch `ops/final-qa-repair-20260718`)
+
+```
+bun run typecheck   → 0 errors
+bun run lint        → 0 errors
+bun run test:run    → 242 files, 1370 tests passed
+bun run build       → Compiled successfully (exit 0)
+git diff --check    → clean
+```
+
+Independent adversarial code review (separate agent, full diff vs zod 4.3.6 + all
+callsites): **no critical/important findings; ship-ready.** Minor, accepted notes:
+digit-bearing historical ЗАТО names (e.g. «Арзамас-16») are rejected (plain city name
+still passes); `photoUrls` errors surface via the alert without a field-level flag.
+
+## Remaining count & terminal verdict
+
+- Findings requiring code repair: **6/6 fixed + locally verified.**
+- Open items: **production deploy + live post-deploy replay** of blockers #1/#2 and the
+  changed surfaces at 1440/375 (release gate — never force; protected `origin/main`).
+
+**Terminal verdict (pre-deploy): `verified` locally; production release gated on operator go.**

--- a/docs/qa/final-replay-repair-2026-07-18.md
+++ b/docs/qa/final-replay-repair-2026-07-18.md
@@ -106,6 +106,60 @@ the card formatter.
   порог 4,0 · Ответы: 0% · порог 60%` — scale max and threshold are now explicit and use
   the Russian decimal comma (`ContactVisibilityChip.tsx`).
 
+### 7. Request notes («Пожелания») public exposure — High privacy → **FIXED + VERIFIED (live pre-fix repro) / live post-fix pending deploy**
+
+Surfaced by a fresh authenticated-traveler continuation: the free-text notes field —
+whose own placeholder invites *«ограничения по здоровью»* (health restrictions) — was
+readable by **anonymous** visitors on the public request detail page.
+
+- **Root cause (two leaks, traced):**
+  1. **Anon (DB boundary):** `v_public_open_requests` projected
+     `mask_public_contact_info(notes) AS notes` — only emails/phones masked, so
+     health/personal free-text survived to `anon`. The anon detail/listing path falls
+     back to this view (`getRequestById`/`getOpenRequests`).
+  2. **Any authenticated non-owner (app):** RLS `traveler_requests_select` allows
+     `auth.uid() IS NOT NULL AND status='open'`, so any logged-in user reads the raw
+     row (incl. `notes`); the detail page then rendered it as the hero intro to
+     non-members (`request-detail-screen.tsx:314`).
+- **Canonical policy (new):** `canSeeRequestNotes` — notes are visible ONLY to the
+  owner, an admin, or an **approved** guide. Never to anon, logged-in
+  non-participants, prospective joiners, joined members; never in SEO metadata or the
+  public marketplace. Public discovery keeps destination, dates, budget, group size,
+  themes. (Members excluded deliberately — smallest safe choice for an underspecified
+  case; the group discussion thread remains for coordination.)
+- **Fix at every layer:**
+  - **DB / anon boundary + retroactive remediation:** migration
+    `20260719000000_privatize_request_notes.sql` reprojects the view's `notes` as
+    `NULL::text`. Because a view is a live projection, this instantly stops serving
+    **every already-public** request's notes to anon — the safe remediation for
+    previously-public content. Safe with the current prod code (null notes → `""`).
+  - **App / authenticated boundary:** the detail page gates `viewModel.notes` and the
+    guide intro via `canSeeRequestNotes`; the marketplace mapper drops notes for
+    non-owners; `generateMetadata` no longer echoes free-text into indexable `<meta>`.
+- **Live pre-fix reproduction (prod `45f0b9ba`, self-cleaning):** created an open QA
+  request with a marked sensitive note, then read it with a no-session client —
+  `v_public_open_requests.notes` returned the full note verbatim, and the anonymous
+  detail page rendered the marker. Both = **leak confirmed live**. Row deleted.
+- **Regression:** `request-notes-visibility.test.ts` (owner/admin/approved-guide see;
+  public/unapproved-guide/member do not) and the detail-page test now asserts a public
+  viewer's `viewModel.notes` is `""` even when the record carries notes.
+- **Note on RLS-vs-app:** the anon leak is closed at the DB boundary (the view — the
+  true security boundary). Postgres RLS is row-level, so per-column privacy for
+  authenticated discovery is inherently app-layer; that path is gated in the read model
+  and never serializes notes to unauthorized viewers.
+- **Live post-fix replay:** pending the operator-gated deploy (the view migration lands
+  through the normal pipeline; no ad-hoc prod DDL was applied — no DB connection string
+  in scope and prod DDL is itself gated).
+
+### Expired-absent-from-Active proof gap → **RESOLVED**
+
+The judge left this BLOCKED (no expired fixture; the UI blocks past dates). Resolved two
+ways: (1) the existing unit test `traveler-requests.test.ts` asserts `getActiveRequests`
+filters `status='open'` and never `.in([...])` that could re-admit `expired`; (2) a live
+RLS proof with a **real** seeded expired record (`status='expired'`) confirmed it is
+absent from the `status='open'` Active filter, then deleted. Legitimate non-production
+fixture, fully cleaned.
+
 ### 6. Re-check changed behavior (1440 / 375) → **VERIFIED (local) / pending live**
 
 - Local: typecheck, lint, 1370 unit/integration tests, and production build all pass; the
@@ -121,7 +175,7 @@ the card formatter.
 ```
 bun run typecheck   → 0 errors
 bun run lint        → 0 errors
-bun run test:run    → 242 files, 1370 tests passed
+bun run test:run    → 243 files, 1374 tests passed (incl. privacy + expired-Active)
 bun run build       → Compiled successfully (exit 0)
 git diff --check    → clean
 ```
@@ -133,8 +187,14 @@ still passes); `photoUrls` errors surface via the alert without a field-level fl
 
 ## Remaining count & terminal verdict
 
-- Findings requiring code repair: **6/6 fixed + locally verified.**
-- Open items: **production deploy + live post-deploy replay** of blockers #1/#2 and the
-  changed surfaces at 1440/375 (release gate — never force; protected `origin/main`).
+- Findings requiring code repair: **7/7 fixed + locally verified** (original 6 + the High
+  notes-privacy leak); the expired-Active proof gap is resolved.
+- Open items: **production deploy + live post-deploy replay** — blockers #1/#2, the anon
+  notes-privacy state, and the changed surfaces at 1440/375 (release gate — never force;
+  protected `origin/main`; the view migration lands via the normal pipeline).
 
-**Terminal verdict (pre-deploy): `verified` locally; production release gated on operator go.**
+**Terminal verdict (pre-deploy): `blocked`** — all engineering `verified` locally (full
+chain green, independent review clean, live pre-fix reproductions for blocker #1 and the
+notes leak, authenticated + expired-Active lifecycles proven). Final release proof is
+gated on operator go for the production deploy (a bad push takes the live site down; the
+project's hard rules reserve it for explicit instruction).

--- a/src/app/(auth)/auth/page.tsx
+++ b/src/app/(auth)/auth/page.tsx
@@ -93,8 +93,17 @@ export default async function AuthPage({ searchParams }: AuthPageProps) {
       </Link>
       <div className="mx-auto grid w-full max-w-5xl items-stretch gap-8 lg:grid-cols-2">
         <aside className="hidden flex-col justify-center gap-8 rounded-glass bg-gradient-to-br from-brand-900 to-brand-950 p-[clamp(2rem,4vw,3.5rem)] text-white shadow-glass lg:flex">
+          {/*
+            The "На главную" utility link above already provides an accessible,
+            focusable route to "/". This hero wordmark is the same destination, so
+            it is decorative here: aria-hidden + tabIndex=-1 keep it clickable by
+            mouse without adding a second, redundant keyboard/screen-reader tab stop
+            to "/" (both were focusable before — a duplicate home-destination stop).
+          */}
           <Link
             href="/"
+            aria-hidden
+            tabIndex={-1}
             className="inline-flex items-center gap-2 text-lg font-semibold tracking-tight text-white transition-colors hover:text-white/80"
           >
             <ArrowLeft className="size-4" aria-hidden />

--- a/src/app/(site)/requests/[requestId]/page.test.tsx
+++ b/src/app/(site)/requests/[requestId]/page.test.tsx
@@ -179,9 +179,38 @@ describe("RequestDetailPage", () => {
       memberCount: 4,
       organizerName: "Айгуль",
       themes: ["history_culture", "nature"],
-      notes: "Едем небольшой компанией.",
+      // Private «Пожелания» must NOT reach a public / prospective viewer, even one
+      // logged in and able to join. The free-text is withheld from the view model.
+      notes: "",
       joinState: "can-join",
     });
+  });
+
+  it("withholds the private notes from a public viewer even when the record has them", async () => {
+    const supabaseClient = {
+      auth: { getUser: vi.fn().mockResolvedValue({ data: { user: null } }) },
+      from: vi.fn(() => ({
+        select: vi.fn(() => ({
+          eq: vi.fn(() => ({
+            maybeSingle: vi.fn().mockResolvedValue({ data: { traveler_id: "owner" } }),
+          })),
+        })),
+      })),
+    };
+    createSupabaseServerClient.mockResolvedValue(supabaseClient);
+    getRequestById.mockResolvedValue({
+      data: requestRecord({ id: "assembly-request", description: "Аллергия на арахис." }),
+    });
+    hasSupabaseEnv.mockReturnValue(true);
+    isRequestMember.mockResolvedValue(false);
+    cityImage.mockReturnValue("https://images.unsplash.com/photo-city");
+
+    const rendered = await RequestDetailPage({
+      params: Promise.resolve({ requestId: "assembly-request" }),
+      searchParams: Promise.resolve({}),
+    });
+
+    expect(rendered.props.viewModel.notes).toBe("");
   });
 
   it("returns notFound for private requests", async () => {

--- a/src/app/(site)/requests/[requestId]/page.tsx
+++ b/src/app/(site)/requests/[requestId]/page.tsx
@@ -14,6 +14,7 @@ import {
   type PublicRequestJoinState,
   RequestDetailScreen,
 } from "@/features/requests/components/request-detail-screen";
+import { canSeeRequestNotes } from "@/features/requests/request-notes-visibility";
 import { getRequestViewerContext, viewerRoleForRequest } from "@/lib/auth/viewer-role-for-request";
 import { cityImage } from "@/lib/city-image";
 import { friendlyError } from "@/lib/errors";
@@ -64,19 +65,20 @@ export async function generateMetadata({
 
   return {
     title: `${result.data.destination} — ${result.data.dateLabel}`,
-    // Public metadata must mask contacts (same rule the body applies) and never
-    // echo unbounded free-text into an indexable <meta>; fall back when empty.
-    description: sanitizeMetaDescription(result.data.description),
+    // SEO metadata is public (search engines), so it must NEVER echo the private
+    // free-text notes — only non-sensitive discovery facts (destination + dates).
+    description: buildRequestMetaDescription(result.data),
     alternates: { canonical: `/requests/${requestId}` },
   };
 }
 
 const META_DESCRIPTION_FALLBACK = "Подробности открытой группы путешественников.";
 
-function sanitizeMetaDescription(raw: string | null | undefined): string {
-  const cleaned = maskPii(raw ?? "").replace(/\s+/g, " ").trim();
-  if (!cleaned) return META_DESCRIPTION_FALLBACK;
-  return cleaned.length > 160 ? `${cleaned.slice(0, 159).trimEnd()}…` : cleaned;
+function buildRequestMetaDescription(request: RequestRecord): string {
+  const dest = request.destination?.trim();
+  if (!dest) return META_DESCRIPTION_FALLBACK;
+  const when = request.dateLabel?.trim() ? `, ${request.dateLabel.trim()}` : "";
+  return `Открытая группа путешественников: ${dest}${when}. Присоединяйтесь или предложите свой маршрут.`;
 }
 
 // PII-012: everyone except the owner sees the request free-text with contact
@@ -113,11 +115,16 @@ function buildViewModel({
   currentUserId,
   isMember,
   ownerId,
+  includeNotes,
 }: {
   request: RequestRecord;
   currentUserId: string | null;
   isMember: boolean;
   ownerId: string | null;
+  // The free-text «Пожелания» is private (health/PII risk). Only authorized
+  // viewers get it in the model; everyone else gets an empty string so no render
+  // path (hero intro, member brief) can surface it. See canSeeRequestNotes.
+  includeNotes: boolean;
 }): PublicRequestDetailViewModel {
   const organizerFallback = request.requesterName || "Путешественник";
   const members =
@@ -144,7 +151,7 @@ function buildViewModel({
     members,
     organizerName: members[0]?.displayName ?? organizerFallback,
     themes: request.interests,
-    notes: request.description,
+    notes: includeNotes ? request.description : "",
     joinState: getJoinState({ request, currentUserId, isMember, ownerId }),
   };
 }
@@ -458,6 +465,7 @@ export default async function RequestDetailPage({
       currentUserId,
       isMember,
       ownerId,
+      includeNotes: true,
     });
 
     const ownerGroupThread = await getRequestGroupThread(requestId as Uuid);
@@ -483,11 +491,20 @@ export default async function RequestDetailPage({
 
   if (viewerRole === "guide") {
     const guideData = await getGuideDetailData(requestId, currentUserId);
+    // Only an APPROVED guide (one who can legitimately act on the request) sees the
+    // private notes; an unverified guide gets the request without the free-text.
+    const guideRequest = maskRequestContacts(result.data);
+    const guideRequestForView = canSeeRequestNotes({
+      viewerRole: "guide",
+      isApprovedGuide: guideData.isApproved,
+    })
+      ? guideRequest
+      : { ...guideRequest, description: "" };
 
     return (
       <RequestDetailScreen
         viewerRole="guide"
-        request={maskRequestContacts(result.data)}
+        request={guideRequestForView}
         isApproved={guideData.isApproved}
         existingOfferId={guideData.existingOfferId}
         offerMeta={guideData.offerMeta}
@@ -503,6 +520,11 @@ export default async function RequestDetailPage({
     currentUserId,
     isMember,
     ownerId,
+    // Admins keep moderation visibility; public / prospective / member viewers do
+    // not see the private free-text notes.
+    includeNotes: canSeeRequestNotes({
+      viewerRole: viewerRole === "admin" ? "admin" : "public",
+    }),
   });
 
   let biddingGuides: BiddingGuide[] = [];

--- a/src/app/(site)/requests/page.tsx
+++ b/src/app/(site)/requests/page.tsx
@@ -8,7 +8,6 @@ import type { OpenRequestRecord } from "@/data/open-requests/types";
 import { getOpenRequests, type RequestRecord } from "@/data/supabase/queries";
 import { PublicRequestsMarketplaceScreen } from "@/features/requests/components/public-requests-marketplace-screen";
 import { cityImage } from "@/lib/city-image";
-import { maskPii } from "@/lib/pii/mask";
 import { createSupabaseServerClient } from "@/lib/supabase/server";
 
 // In-page skeleton replaces the removed (site)/loading.tsx boundary for this
@@ -41,8 +40,10 @@ function mapToOpenRequestRecord(
   joinedRequestIds: Set<string>,
 ): OpenRequestRecord {
   const isOwner = request.travelerId != null && request.travelerId === viewerId;
-  // PII-012: mask contact details in the free-text for every non-owner viewer.
-  const maskedDescription = isOwner ? request.description : maskPii(request.description);
+  // The free-text «Пожелания» is private (health/PII). The public marketplace is a
+  // discovery surface — it never carries the notes for a non-owner (not even
+  // contact-masked). The owner still sees their own brief on their own card.
+  const maskedDescription = isOwner ? request.description : "";
   return {
     id: request.id,
     isOwner,

--- a/src/components/guide/ContactVisibilityChip.tsx
+++ b/src/components/guide/ContactVisibilityChip.tsx
@@ -36,8 +36,8 @@ export function ContactVisibilityChip({
       </Badge>
       {!unlocked ? (
         <p className="text-ink-3 text-xs font-normal normal-case tracking-normal">
-          Рейтинг: {averageRating != null ? averageRating.toFixed(1) : "–"} / 4.0 ·
-          Ответы: {Math.round((responseRate ?? 0) * 100)}% / 60%
+          Рейтинг: {averageRating != null ? averageRating.toFixed(1).replace(".", ",") : "–"} из
+          5,0 · порог 4,0 · Ответы: {Math.round((responseRate ?? 0) * 100)}% · порог 60%
         </p>
       ) : null}
     </div>

--- a/src/data/traveler-request/schema.test.ts
+++ b/src/data/traveler-request/schema.test.ts
@@ -46,6 +46,90 @@ describe("travelerRequestSchema", () => {
     );
   });
 
+  it("rejects garbage destination text with a clear Russian message", () => {
+    const result = travelerRequestSchema.safeParse({
+      mode: "private",
+      interests: ["history_culture"],
+      startTime: "10:00",
+      endTime: "18:00",
+      destination: "!!!###garbage_XYZ_ноль123",
+      startDate: "2026-05-10",
+      dateFlexibility: "exact",
+      groupSize: 2,
+      allowGuideSuggestionsOutsideConstraints: true,
+      budgetPerPersonRub: 1500,
+      notes: "",
+    });
+
+    expect(result.success).toBe(false);
+    if (result.success) throw new Error("Expected garbage destination to fail");
+    expect(result.error.flatten().fieldErrors.destination).toContain(
+      "Укажите название места буквами, например «Казань» или «Шанхай».",
+    );
+  });
+
+  it("rejects an overlong destination past 80 characters", () => {
+    const result = travelerRequestSchema.safeParse({
+      mode: "private",
+      interests: ["history_culture"],
+      startTime: "10:00",
+      endTime: "18:00",
+      destination: "Ё".repeat(81),
+      startDate: "2026-05-10",
+      dateFlexibility: "exact",
+      groupSize: 2,
+      allowGuideSuggestionsOutsideConstraints: true,
+      budgetPerPersonRub: 1500,
+      notes: "",
+    });
+
+    expect(result.success).toBe(false);
+    if (result.success) throw new Error("Expected overlong destination to fail");
+    expect(result.error.flatten().fieldErrors.destination).toContain("Не больше 80 символов.");
+  });
+
+  it("accepts unlisted but real non-local destinations (Shanghai, St. Petersburg)", () => {
+    for (const destination of ["Шанхай", "Санкт-Петербург", "Ростов-на-Дону"]) {
+      const parsed = travelerRequestSchema.parse({
+        mode: "private",
+        interests: ["history_culture"],
+        startTime: "10:00",
+        endTime: "18:00",
+        destination,
+        startDate: "2026-05-10",
+        dateFlexibility: "exact",
+        groupSize: 2,
+        allowGuideSuggestionsOutsideConstraints: true,
+        budgetPerPersonRub: 1500,
+        notes: "",
+      });
+      expect(parsed.destination).toBe(destination);
+    }
+  });
+
+  it("shows a Russian message (not raw NaN) for non-numeric budget input", () => {
+    const result = travelerRequestSchema.safeParse({
+      mode: "private",
+      interests: ["history_culture"],
+      startTime: "10:00",
+      endTime: "18:00",
+      destination: "Москва",
+      startDate: "2026-05-10",
+      dateFlexibility: "exact",
+      groupSize: 2,
+      allowGuideSuggestionsOutsideConstraints: true,
+      // Number("abc") from valueAsNumber / server Number(...) coercion.
+      budgetPerPersonRub: Number.NaN,
+      notes: "",
+    });
+
+    expect(result.success).toBe(false);
+    if (result.success) throw new Error("Expected NaN budget to fail");
+    const messages = result.error.flatten().fieldErrors.budgetPerPersonRub ?? [];
+    expect(messages).toContain("Укажите бюджет числом, например 5000.");
+    expect(messages.join(" ")).not.toMatch(/NaN/);
+  });
+
   it("defaults date flexibility and accepts an unset budget", () => {
     const parsed = travelerRequestSchema.parse({
       mode: "private",

--- a/src/data/traveler-request/schema.ts
+++ b/src/data/traveler-request/schema.ts
@@ -1,7 +1,12 @@
 import { z } from "zod";
 
 import { THEMES, type ThemeSlug } from "@/data/themes";
-import { sanitizeTravelerRequestDestinationLabel } from "@/lib/traveler-request-destination";
+import {
+  DESTINATION_MAX_LENGTH,
+  DESTINATION_MIN_LENGTH,
+  isSupportedDestinationLabel,
+  sanitizeTravelerRequestDestinationLabel,
+} from "@/lib/traveler-request-destination";
 
 export const travelerRequestModes = ["assembly", "private"] as const;
 
@@ -24,8 +29,11 @@ export const travelerRequestSchema = z
       .pipe(
         z
           .string()
-          .min(2, "Укажите город или направление.")
-          .max(80, "Не больше 80 символов."),
+          .min(DESTINATION_MIN_LENGTH, "Укажите город или направление.")
+          .max(DESTINATION_MAX_LENGTH, "Не больше 80 символов.")
+          .refine(isSupportedDestinationLabel, {
+            message: "Укажите название места буквами, например «Казань» или «Шанхай».",
+          }),
       ),
     startDate: z.string().min(1, "Укажите дату начала."),
     endDate: z.string().optional().or(z.literal("")),
@@ -49,7 +57,11 @@ export const travelerRequestSchema = z
     allowGuideSuggestionsOutsideConstraints: z.boolean(),
     openToJoin: z.boolean().optional(),
     budgetPerPersonRub: z
-      .number()
+      // `{ error }` supplies the invalid-type message (e.g. NaN from a non-numeric
+      // "abc" entry via valueAsNumber) — the raw "expected number, received NaN"
+      // leaked to Russian users otherwise. The per-check messages below still win
+      // for int/min/max.
+      .number({ error: "Укажите бюджет числом, например 5000." })
       .int("Укажите целое число.")
       .min(1_000, "Бюджет должен быть не меньше 1 000 ₽.")
       .max(2_000_000, "Бюджет выглядит слишком высоким.")

--- a/src/features/guide/components/excursions/guide-excursions-screen.tsx
+++ b/src/features/guide/components/excursions/guide-excursions-screen.tsx
@@ -64,6 +64,9 @@ export function GuideExcursionsScreen() {
   >([]);
   const [tplSaving, setTplSaving] = useState(false);
   const [tplError, setTplError] = useState<string | null>(null);
+  // Which field the current tplError belongs to, so the invalid input carries
+  // aria-invalid + aria-describedby pointing at the footer alert (id="tpl-error").
+  const [tplErrorField, setTplErrorField] = useState<string | null>(null);
   const [deletingTemplateId, setDeletingTemplateId] = useState<string | null>(null);
   const [deleteError, setDeleteError] = useState<string | null>(null);
   const [activeTab, setActiveTab] = useState<"excursions" | "photos">("excursions");
@@ -131,7 +134,7 @@ export function GuideExcursionsScreen() {
   function openCreateSheet() {
     setEditingTemplate(null);
     reset(defaultExcursionFormValues);
-    setTplError(null);
+    clearTplError();
     setSheetOpen(true);
   }
 
@@ -153,36 +156,43 @@ export function GuideExcursionsScreen() {
       region: template.region ?? "",
       category: template.category ?? "",
     });
-    setTplError(null);
+    clearTplError();
     setSheetOpen(true);
   }
 
+  // Point the alert at the first invalid field (title → price → max → photos), so
+  // that field can announce itself as invalid, not just the shared alert text.
+  function reportTplError(candidates: Array<[field: string, message: string | undefined]>) {
+    const hit = candidates.find(([, message]) => Boolean(message));
+    setTplErrorField(hit?.[0] ?? null);
+    setTplError(hit?.[1] ?? "Ошибка сохранения.");
+  }
+
+  function clearTplError() {
+    setTplErrorField(null);
+    setTplError(null);
+  }
+
   const handleTemplateValidationError: SubmitErrorHandler<ExcursionFormInput> = (errors) => {
-    setTplError(
-      errors.title?.message ??
-        errors.priceRub?.message ??
-        errors.maxParticipants?.message ??
-        errors.photoUrls?.message ??
-        "Ошибка сохранения.",
-    );
+    reportTplError([
+      ["title", errors.title?.message],
+      ["priceRub", errors.priceRub?.message],
+      ["maxParticipants", errors.maxParticipants?.message],
+      ["photoUrls", errors.photoUrls?.message],
+    ]);
   };
 
   function handleSaveTemplateClick() {
     const parsed = excursionFormSchema.safeParse(getValues());
     if (!parsed.success) {
-      const titleIssue = parsed.error.issues.find((issue) => issue.path[0] === "title");
-      const priceIssue = parsed.error.issues.find((issue) => issue.path[0] === "priceRub");
-      const maxParticipantsIssue = parsed.error.issues.find(
-        (issue) => issue.path[0] === "maxParticipants",
-      );
-      const photoUrlsIssue = parsed.error.issues.find((issue) => issue.path[0] === "photoUrls");
-      setTplError(
-        titleIssue?.message ??
-          priceIssue?.message ??
-          maxParticipantsIssue?.message ??
-          photoUrlsIssue?.message ??
-          "Ошибка сохранения.",
-      );
+      const messageFor = (field: string) =>
+        parsed.error.issues.find((issue) => issue.path[0] === field)?.message;
+      reportTplError([
+        ["title", messageFor("title")],
+        ["priceRub", messageFor("priceRub")],
+        ["maxParticipants", messageFor("maxParticipants")],
+        ["photoUrls", messageFor("photoUrls")],
+      ]);
       return;
     }
 
@@ -191,7 +201,7 @@ export function GuideExcursionsScreen() {
 
   async function handleSaveTemplate(values: ExcursionFormValues) {
     setTplSaving(true);
-    setTplError(null);
+    clearTplError();
     try {
       if (editingTemplate) {
         const updated = await updateGuideTemplate(editingTemplate.id, {
@@ -226,6 +236,8 @@ export function GuideExcursionsScreen() {
       }
       setSheetOpen(false);
     } catch (err) {
+      // A save-time failure is not tied to one field — clear any field flag.
+      setTplErrorField(null);
       setTplError(err instanceof Error ? err.message : "Ошибка сохранения.");
     } finally {
       setTplSaving(false);
@@ -357,6 +369,8 @@ export function GuideExcursionsScreen() {
                 maxLength={120}
                 placeholder="Например: Прогулка по центру Казани"
                 className="mt-1.5"
+                aria-invalid={tplErrorField === "title" || undefined}
+                aria-describedby={tplErrorField === "title" ? "tpl-error" : undefined}
                 {...register("title")}
               />
             </div>
@@ -390,6 +404,8 @@ export function GuideExcursionsScreen() {
                 step={1}
                 placeholder="Например: 5000"
                 className="mt-1.5"
+                aria-invalid={tplErrorField === "priceRub" || undefined}
+                aria-describedby={tplErrorField === "priceRub" ? "tpl-error" : undefined}
                 {...register("priceRub")}
               />
             </div>
@@ -413,6 +429,8 @@ export function GuideExcursionsScreen() {
                 max={500}
                 placeholder="10"
                 className="mt-1.5"
+                aria-invalid={tplErrorField === "maxParticipants" || undefined}
+                aria-describedby={tplErrorField === "maxParticipants" ? "tpl-error" : undefined}
                 {...register("maxParticipants")}
               />
             </div>
@@ -572,7 +590,7 @@ export function GuideExcursionsScreen() {
                 the bottom of the scrollable body and could be scrolled out of view,
                 making a rejected save look silent. */}
             {tplError && (
-              <p role="alert" className="mb-3 text-sm text-destructive">
+              <p id="tpl-error" role="alert" className="mb-3 text-sm text-destructive">
                 {tplError}
               </p>
             )}

--- a/src/features/requests/request-notes-visibility.test.ts
+++ b/src/features/requests/request-notes-visibility.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from "vitest";
+
+import { canSeeRequestNotes } from "./request-notes-visibility";
+
+describe("canSeeRequestNotes", () => {
+  it("lets the owner and admins read the private notes", () => {
+    expect(canSeeRequestNotes({ viewerRole: "owner" })).toBe(true);
+    expect(canSeeRequestNotes({ viewerRole: "admin" })).toBe(true);
+  });
+
+  it("lets only an APPROVED guide read the notes", () => {
+    expect(canSeeRequestNotes({ viewerRole: "guide", isApprovedGuide: true })).toBe(true);
+    expect(canSeeRequestNotes({ viewerRole: "guide", isApprovedGuide: false })).toBe(false);
+    expect(canSeeRequestNotes({ viewerRole: "guide" })).toBe(false);
+  });
+
+  it("never exposes notes to the public (anon, prospective joiner, member)", () => {
+    expect(canSeeRequestNotes({ viewerRole: "public" })).toBe(false);
+  });
+});

--- a/src/features/requests/request-notes-visibility.ts
+++ b/src/features/requests/request-notes-visibility.ts
@@ -1,0 +1,22 @@
+export type RequestNotesViewer = {
+  viewerRole: "owner" | "guide" | "admin" | "public";
+  /** Only meaningful for `viewerRole: "guide"`. */
+  isApprovedGuide?: boolean;
+};
+
+/**
+ * The traveler's free-text «Пожелания» (request notes) can carry sensitive
+ * personal or medical details — the field's own placeholder invites «ограничения
+ * по здоровью» (health restrictions). It is therefore private, not public
+ * discovery data.
+ *
+ * Readable only by the owner, an admin, or an APPROVED guide who can legitimately
+ * act on the request. Anonymous visitors, logged-in non-participants, prospective
+ * joiners, joined members and unverified guides must not see it — public discovery
+ * stays limited to destination, dates, budget, group size and themes.
+ */
+export function canSeeRequestNotes(viewer: RequestNotesViewer): boolean {
+  if (viewer.viewerRole === "owner" || viewer.viewerRole === "admin") return true;
+  if (viewer.viewerRole === "guide") return viewer.isApprovedGuide === true;
+  return false;
+}

--- a/src/lib/supabase/queries-core.ts
+++ b/src/lib/supabase/queries-core.ts
@@ -481,7 +481,12 @@ export function mapRequestRow(
     travelerId: (row.traveler_id as string | null) ?? null,
     destination: destinationLabel,
     destinationSlug: normalizeSlug(dest),
-    destinationRegion: (meta.regionLabel as string) ?? (row.region as string) ?? "Россия",
+    // Never fabricate a country. `region` is optional and, in practice, null for
+    // every open request (the request form does not capture it), so defaulting to
+    // "Россия" invented a country badge — and rendered "Шанхай / Россия" on the
+    // public card. Fall back to empty so the card shows the city alone, matching
+    // the detail page (which already drops the "Россия" fallback in its breadcrumb).
+    destinationRegion: (meta.regionLabel as string) ?? (row.region as string) ?? "",
     title: destinationLabel,
     dateLabel: (meta.dateRangeLabel as string | null) ?? formatRussianDateRange(
       (row.starts_on as string) ?? "",

--- a/src/lib/supabase/queries.test.ts
+++ b/src/lib/supabase/queries.test.ts
@@ -375,6 +375,24 @@ describe("PII-safe Supabase query mapping", () => {
     });
   });
 
+  it("never fabricates a country: a null region maps to an empty region, not «Россия»", () => {
+    const row: Record<string, unknown> = {
+      id: "request-shanghai",
+      destination: "Шанхай",
+      region: null,
+      budget_minor: null,
+      participants_count: 2,
+      status: "open",
+      created_at: "2026-06-03T00:00:00Z",
+      format_preference: "group",
+    };
+
+    const mapped = mapRequestRow(row);
+    expect(mapped.destination).toBe("Шанхай");
+    expect(mapped.destinationRegion).toBe("");
+    expect(mapped.destinationRegion).not.toBe("Россия");
+  });
+
   it("maps private format preference to private mode even when open_to_join is true", () => {
     const row: Record<string, unknown> = {
       id: "request-1",

--- a/src/lib/traveler-request-destination.test.ts
+++ b/src/lib/traveler-request-destination.test.ts
@@ -1,6 +1,9 @@
 import { describe, expect, it } from "vitest";
 
-import { sanitizeTravelerRequestDestinationLabel } from "@/lib/traveler-request-destination";
+import {
+  isSupportedDestinationLabel,
+  sanitizeTravelerRequestDestinationLabel,
+} from "@/lib/traveler-request-destination";
 
 describe("sanitizeTravelerRequestDestinationLabel", () => {
   it("removes leaked attribute fragments from destination labels", () => {
@@ -25,5 +28,40 @@ describe("sanitizeTravelerRequestDestinationLabel", () => {
 
   it("falls back when the label is empty", () => {
     expect(sanitizeTravelerRequestDestinationLabel(" placeholder=Москва")).toBe("Маршрут");
+  });
+});
+
+describe("isSupportedDestinationLabel", () => {
+  it("accepts real place names, including unlisted and multi-word ones", () => {
+    for (const name of [
+      "Москва",
+      "Шанхай",
+      "Казань",
+      "Санкт-Петербург",
+      "Ростов-на-Дону",
+      "Нижний Новгород",
+      "Астраханский край",
+      "Марс-Сити",
+      "Paris",
+    ]) {
+      expect(isSupportedDestinationLabel(name), name).toBe(true);
+    }
+  });
+
+  it("rejects symbol/number garbage", () => {
+    for (const junk of [
+      "!!!###garbage_XYZ_ноль123",
+      "12345",
+      "<script>alert(1)</script>",
+      "___",
+      "a", // too short
+      "ЁЁЁЁЁЁ", // one distinct letter repeated
+    ]) {
+      expect(isSupportedDestinationLabel(junk), junk).toBe(false);
+    }
+  });
+
+  it("rejects overlong input past the 80-char bound", () => {
+    expect(isSupportedDestinationLabel("Ё".repeat(81))).toBe(false);
   });
 });

--- a/src/lib/traveler-request-destination.ts
+++ b/src/lib/traveler-request-destination.ts
@@ -3,6 +3,40 @@ const DEFAULT_DESTINATION_LABEL = "Маршрут";
 const LEAKED_ATTRIBUTE_RE = /(^|[\s,;])(?:placeholder|aria-autocomplete|autocomplete)\s*=/i;
 const DUPLICATED_WORD_RE = /(^|[^\p{L}])(\p{L}{2,})\2(?=$|[^\p{L}])/gu;
 
+/** Shared destination length bounds — client input cap, Zod, and DB column agree. */
+export const DESTINATION_MIN_LENGTH = 2;
+export const DESTINATION_MAX_LENGTH = 80;
+
+// A place name a human types: a leading letter, then letters/marks, whitespace and
+// the punctuation real toponyms use — hyphen, dashes, apostrophes, period, comma,
+// parentheses, ellipsis. No digits, no ASCII symbols (! # _ / = …). This is the
+// canonical destination shape check. It is wired into the traveler-request Zod
+// schema, which both the client resolver and the server action parse — so every
+// create path (and therefore every stored destination) is gated by it. It accepts
+// unlisted but real destinations ("Шанхай", "Санкт-Петербург", "Ростов-на-Дону")
+// and rejects symbol/number garbage ("!!!###garbage_XYZ_ноль123") without shrinking
+// the field to a fixed allow-list.
+const SUPPORTED_DESTINATION_RE = /^\p{L}[\p{L}\p{M}\s.,'’()…–—-]*$/u;
+
+/**
+ * True when a (already-sanitized) label reads as a real place name. Used by the
+ * traveler-request schema so the same rule holds on the client resolver, the
+ * server action, and anything that persists a destination.
+ */
+export function isSupportedDestinationLabel(value: string): boolean {
+  const label = value.trim();
+  if (label.length < DESTINATION_MIN_LENGTH || label.length > DESTINATION_MAX_LENGTH) {
+    return false;
+  }
+  if (!SUPPORTED_DESTINATION_RE.test(label)) return false;
+  // Guard the degenerate "single letter repeated" case (e.g. 80×"Ё"): every real
+  // toponym has at least two distinct letters, garbage padding does not.
+  const distinctLetters = new Set(
+    (label.match(/\p{L}/gu) ?? []).map((ch) => ch.toLocaleLowerCase("ru")),
+  );
+  return distinctLetters.size >= 2;
+}
+
 export function sanitizeTravelerRequestDestinationLabel(
   value: unknown,
   options: { fallback?: boolean } = {},

--- a/supabase/migrations/20260719000000_privatize_request_notes.sql
+++ b/supabase/migrations/20260719000000_privatize_request_notes.sql
@@ -1,0 +1,44 @@
+-- The anonymous-safe projection exposed the traveler's free-text «Пожелания»
+-- (notes) to any unauthenticated visitor with only contact info masked. That
+-- field's own placeholder invites «ограничения по здоровью» (health restrictions),
+-- so masking phones/emails is not enough — the free text itself is private
+-- (owner / authorized guide / admin only). Drop it from the public projection
+-- entirely; public discovery keeps destination, dates, budget, group size and
+-- themes. Because a view is a live projection, this is retroactive: every
+-- already-public request's notes stop being served to anon the moment it lands —
+-- the safe remediation for content that was previously public.
+CREATE OR REPLACE VIEW "public"."v_public_open_requests"
+WITH ("security_invoker" = false) AS
+  SELECT
+    "tr"."id",
+    "tr"."destination",
+    "tr"."region",
+    "tr"."interests",
+    "tr"."starts_on",
+    "tr"."ends_on",
+    "tr"."start_time",
+    "tr"."end_time",
+    "tr"."budget_minor",
+    "tr"."currency",
+    "tr"."participants_count",
+    "tr"."format_preference",
+    -- Private free-text is never projected to the public. Column kept (as NULL) so
+    -- `select *` consumers and the row shape stay stable. Note: `notes` also carries
+    -- an optional JSON display blob (hero image, labels) on some rows; nulling the
+    -- whole column drops those cosmetics for anon too — a deliberate safety-over-
+    -- cosmetics choice (parsing to keep only the safe keys risks re-leaking the
+    -- sensitive free-text). Anon falls back to computed labels + city image.
+    NULL::"text" AS "notes",
+    "tr"."open_to_join",
+    "tr"."group_capacity",
+    "tr"."status",
+    "tr"."created_at",
+    "tr"."date_flexibility",
+    "tr"."date_locked",
+    "tr"."time_locked",
+    "tr"."requested_languages"
+  FROM "public"."traveler_requests" "tr"
+  WHERE "tr"."status" = 'open'::"public"."request_status";
+
+COMMENT ON VIEW "public"."v_public_open_requests" IS
+  'Anonymous-safe projection of open traveler requests: no traveler_id, no free-text notes (private to owner/authorized guide/admin). Public discovery reads this instead of the raw table.';


### PR DESCRIPTION
Independent reproduction + repair of the fresh post-release replay against production 45f0b9ba, plus a High-severity privacy fix surfaced during the authenticated continuation.

## Fixes
1. **Public card «Шанхай / Россия» (blocker)** — request cards no longer default an absent region to «Россия» (all open requests have region=null; the record is clean, no data repair). Shows the city alone, like the detail breadcrumb.
2. **Garbage destination accepted (blocker)** — shared `isSupportedDestinationLabel` wired into the traveler-request Zod schema (client resolver + server action); rejects symbol/number garbage with a Russian message while keeping unlisted real places (Шанхай, Санкт-Петербург). No shrink to a fixed list.
3. **Budget «received NaN»** — Russian message via `z.number({ error })`; int/min/max messages unchanged.
4. **A11y/copy** — duplicate `/` tab stop on `/auth` removed; excursion invalid field gets `aria-invalid`/`aria-describedby`; rating summary states the 5,0 scale and labels the 4,0/60% thresholds.
5. **High privacy — request «Пожелания» exposed to anonymous visitors** — the free-text notes (placeholder invites health details) were public. `v_public_open_requests` now projects `notes` as NULL (retroactive remediation), and a `canSeeRequestNotes` policy gates the detail view-model, guide intro (approved only), marketplace mapper and SEO `<meta>` to owner/admin/approved-guide only.

## Verification
- typecheck, lint (ratchet +0/+0), 1374 tests, build — all green; `git diff --check` clean.
- Two independent adversarial reviews — no unresolved critical/important issues.
- Live pre-fix reproductions (region bug; notes leak via view + rendered page); authenticated create→cancel→cleanup lifecycle; expired-absent proven with a real expired record. All self-cleaning.

Full disposition: `docs/qa/final-replay-repair-2026-07-18.md`.