### PR TITLE
fix(listings): ready-tour tour-type badge correct with per-group pricing

### DIFF
--- a/src/app/(site)/guides/[slug]/page.tsx
+++ b/src/app/(site)/guides/[slug]/page.tsx
@@ -128,7 +128,7 @@ export default async function PublicGuideProfilePage({
     href: l.detailHref ?? `/listings/${l.slug}`,
     title: l.title,
     coverImageUrl: l.imageUrl,
-    price: formatExcursionPriceFrom(rubToKopecks(l.priceRub), l.format, l.groupSize),
+    price: formatExcursionPriceFrom(rubToKopecks(l.priceRub), l.format, l.groupSize, l.priceScope),
   }));
 
   const reviews = reviewRecords.map((r) => ({

--- a/src/components/listing-detail/excursion-price.test.ts
+++ b/src/components/listing-detail/excursion-price.test.ts
@@ -49,4 +49,17 @@ describe("formatExcursionPriceFrom", () => {
   it("omits the suffix for an unknown (non-enum) format string", () => {
     expect(formatExcursionPriceFrom(500_000, "history_culture", 6)).toBe(base(500_000));
   });
+
+  it("uses an explicit per_group price scope regardless of the format badge (item 2)", () => {
+    // A ready tour keeps its "group" tour-type badge but prices «за группу».
+    expect(formatExcursionPriceFrom(500_000, "group", 8, "per_group")).toBe(
+      `${base(500_000)} за группу до 8 человек`,
+    );
+  });
+
+  it("uses an explicit per_person price scope even when format is private", () => {
+    expect(formatExcursionPriceFrom(500_000, "private", 8, "per_person")).toBe(
+      `${base(500_000)} за одного`,
+    );
+  });
 });

--- a/src/components/listing-detail/excursion-price.ts
+++ b/src/components/listing-detail/excursion-price.ts
@@ -12,16 +12,23 @@ export function formatExcursionPriceFrom(
   priceFromMinor: number,
   format: string | null | undefined,
   maxGroupSize?: number | null,
+  // Ready tours (guide_templates) carry an explicit price scope that is independent of
+  // the tour-type `format` badge. When given it decides the suffix; otherwise fall back
+  // to the format convention (private → whole group, group/combo → per person).
+  priceScope?: "per_person" | "per_group" | null,
 ): string {
   const rub = formatRubNumber(Math.round(priceFromMinor / 100));
   const base = `от ${rub} ₽`;
-  if (format === "private") {
+  const perGroup = priceScope ? priceScope === "per_group" : format === "private";
+  if (perGroup) {
     const cap =
       maxGroupSize && maxGroupSize > 0
         ? ` до ${maxGroupSize} ${pluralizePeopleGenitive(maxGroupSize)}`
         : "";
     return `${base} за группу${cap}`;
   }
-  if (format === "group" || format === "combo") return `${base} за одного`;
+  if (priceScope === "per_person" || format === "group" || format === "combo") {
+    return `${base} за одного`;
+  }
   return base;
 }

--- a/src/components/shared/listing-card.tsx
+++ b/src/components/shared/listing-card.tsx
@@ -27,6 +27,7 @@ export function ListingCard({ listing, priority }: ListingCardProps) {
     rubToKopecks(listing.priceRub),
     listing.format,
     listing.groupSize,
+    listing.priceScope,
   );
   const showRating = listing.rating > 0;
   const showReviews = listing.reviewCount > 0;

--- a/src/features/admin/components/TemplateModerationItem.tsx
+++ b/src/features/admin/components/TemplateModerationItem.tsx
@@ -76,8 +76,9 @@ function TemplateModerationItem({
     template.price_from_kopecks != null
       ? formatExcursionPriceFrom(
           template.price_from_kopecks,
-          template.price_scope === "per_group" ? "private" : "group",
+          "group",
           template.max_participants,
+          template.price_scope,
         )
       : null;
   const subtitle = [template.region, priceLabel].filter(Boolean).join(" · ");

--- a/src/features/destinations/components/listings-filter.tsx
+++ b/src/features/destinations/components/listings-filter.tsx
@@ -67,6 +67,7 @@ export function ListingsFilter({ listings }: ListingsFilterProps) {
                 rubToKopecks(listing.priceRub),
                 listing.format,
                 listing.groupSize,
+                listing.priceScope,
               )}
             />
           ))}

--- a/src/lib/supabase/guide-template-listings.test.ts
+++ b/src/lib/supabase/guide-template-listings.test.ts
@@ -75,9 +75,10 @@ describe("getPublishedTemplateListings", () => {
     expect(rec.id).toBe(TEMPLATE.id);
     expect(rec.title).toBe("Степь и хурул");
     expect(rec.priceRub).toBe(4500);
-    // A legacy row (no price_scope) is per-person → format "group" → «за одного».
+    // Tour-type badge stays "group"; a legacy row (no price_scope) is per-person.
     // Legacy meaning is never silently reinterpreted.
     expect(rec.format).toBe("group");
+    expect(rec.priceScope).toBe("per_person");
     expect(rec.groupSize).toBe(8);
     expect(rec.imageUrl).toBe("https://cdn.example/photo.jpg");
     expect(rec.destinationRegion).toBe("Калмыкия");
@@ -90,7 +91,7 @@ describe("getPublishedTemplateListings", () => {
     expect(rec.reviewCount).toBe(0);
   });
 
-  it("maps a per_group tour to the «за группу» format (item 2)", async () => {
+  it("carries per_group price scope without changing the tour-type badge (item 2)", async () => {
     const client = fakeClient({
       guide_templates: [{ ...TEMPLATE, price_scope: "per_group" }],
       guide_profiles: [APPROVED_GUIDE],
@@ -98,8 +99,9 @@ describe("getPublishedTemplateListings", () => {
 
     const [rec] = await getPublishedTemplateListings(client);
 
-    // "private" is what formatExcursionPriceFrom renders as «от X ₽ за группу до N человек».
-    expect(rec.format).toBe("private");
+    // Price scope drives «за группу»; the badge stays "group" (not mislabeled "private").
+    expect(rec.priceScope).toBe("per_group");
+    expect(rec.format).toBe("group");
     expect(rec.groupSize).toBe(8);
   });
 

--- a/src/lib/supabase/guide-template-listings.ts
+++ b/src/lib/supabase/guide-template-listings.ts
@@ -15,11 +15,11 @@
 // It is a read path only: no schema, no bridge table, no duplicated content, and no
 // migration (guide_templates_select_published already exposes published rows to anon).
 //
-// Moderation: templates carry only draft|published — the guide self-publishes, and
-// there is no per-excursion review. So the gate here is the guide: approved
-// verification_status and a non-QA slug, the same allow-list the homepage already
-// applies to its other blocks. A template from an unapproved or seed guide is never
-// public.
+// Moderation: templates now pass admin review (draft → pending_review → published/rejected,
+// enforced by the guide_templates trigger), and this read path only ever returns published
+// rows. The extra gate here is the guide: approved verification_status and a non-QA slug,
+// the same allow-list the homepage already applies to its other blocks. A template from an
+// unapproved or seed guide is never public.
 import type { SupabaseClient } from "@supabase/supabase-js";
 
 import { kopecksToRub } from "@/data/money";
@@ -57,10 +57,11 @@ function mapTemplate(row: GuideTemplateRow, guide: TemplateGuide): ListingRecord
     groupSize: row.max_participants ?? 0,
     difficulty: "",
     departure: row.meeting_point ?? region,
-    // Price scope drives the public suffix through the shared formatter:
-    //   per_group  → format "private"  → «от X ₽ за группу до N человек» (item 2, new tours)
-    //   per_person → format "group"    → «от X ₽ за одного» (legacy amounts, unchanged)
-    format: row.price_scope === "per_group" ? "private" : "group",
+    // A template has no private/group tour type — keep the historical "group" badge and
+    // carry the price scope separately (item 2) so the price says «за группу»/«за одного»
+    // without mislabeling the tour-type badge on the card.
+    format: "group",
+    priceScope: (row.price_scope ?? "per_person") as "per_person" | "per_group",
     category: row.category ?? "",
     description: row.description ?? "",
     inclusions: [],

--- a/src/lib/supabase/queries-core.ts
+++ b/src/lib/supabase/queries-core.ts
@@ -39,6 +39,8 @@ export type ListingRecord = {
   departure: string;
   /** Real booking format enum from listings.format: private | group | combo (or ""). */
   format: string;
+  /** Ready-tour price scope (guide_templates only); independent of the format badge. */
+  priceScope?: "per_person" | "per_group";
   /** Catalog/theme category from listings.category (drives theme-slug mapping). */
   category: string;
   description: string;


### PR DESCRIPTION
Follow-up from independent review of #300: price_scope drove ListingRecord.format (which also renders the visible tour-type badge), mislabelling per-group tours. Price scope now travels on its own field. Tests: 1392 pass.