### PR TITLE
test(discovery): lock empty-array approved-guide discoverability + per_group scope

### DIFF
--- a/src/lib/supabase/guide-template-listings.test.ts
+++ b/src/lib/supabase/guide-template-listings.test.ts
@@ -105,6 +105,26 @@ describe("getPublishedTemplateListings", () => {
     expect(rec.groupSize).toBe(8);
   });
 
+  it("surfaces a per_group tour from an approved guide with empty regions/languages (final live-QA 2026-07-19)", async () => {
+    // The reported defect: an approved guide with empty regions/languages is
+    // silently absent from public listings. This path never reads regions/languages,
+    // so empty arrays cannot drop the tour — only guide approval and a non-QA slug
+    // gate it. Locked here alongside the per_group «за группу» scope so a future
+    // empty-array exclusion would fail this test.
+    const client = fakeClient({
+      guide_templates: [{ ...TEMPLATE, price_scope: "per_group" }],
+      guide_profiles: [{ ...APPROVED_GUIDE, regions: [], languages: [] }],
+    });
+
+    const [rec] = await getPublishedTemplateListings(client);
+
+    expect(rec).toBeDefined();
+    expect(rec.title).toBe("Степь и хурул");
+    expect(rec.priceScope).toBe("per_group");
+    expect(rec.format).toBe("group");
+    expect(rec.groupSize).toBe(8);
+  });
+
   it("drops templates whose guide is not approved", async () => {
     const client = fakeClient({
       guide_templates: [TEMPLATE],

--- a/src/lib/supabase/queries-core.test.ts
+++ b/src/lib/supabase/queries-core.test.ts
@@ -61,6 +61,36 @@ describe("applyGuideFilters QA hiding (F-10)", () => {
   });
 });
 
+// Final live-QA repair (2026-07-19): an independent prod replay reported that an
+// approved+available guide with EMPTY regions/languages is silently absent from
+// public discovery. Source trace + a read-only prod query proved the real cause
+// was the guide's `qa-` seed slug, not the empty arrays: the only approved guide
+// with empty regions/languages was also the only one with a `qa-` slug, so the two
+// variables were confounded. The public gate (verification_status='approved' +
+// is_available=true + role='guide' + active account + non-`qa-` slug) never
+// requires non-empty regions/languages. These tests lock that invariant at the JS
+// boundary where an empty-array exclusion could realistically be re-introduced.
+describe("empty optional profile arrays keep an approved guide discoverable (final live-QA 2026-07-19)", () => {
+  it("applyGuideFilters keeps a non-QA guide whose regions are empty", () => {
+    const guides = [{ slug: "real-guide", destinations: [] } as unknown as GuideRecord];
+    expect(applyGuideFilters(guides).map((g) => g.slug)).toEqual(["real-guide"]);
+  });
+
+  it("mapGuideRow yields a valid discoverable record when regions AND languages are empty", () => {
+    const record = mapGuideRow(
+      { user_id: "u1", slug: "real-guide", display_name: "Гид", regions: [], languages: [] },
+      { full_name: "Гид ФИО" },
+    );
+    // The record is fully formed — nothing about empty arrays drops or breaks it.
+    expect(record.slug).toBe("real-guide");
+    expect(record.fullName).toBe("Гид");
+    expect(record.destinations).toEqual([]);
+    expect(record.languages).toEqual([]);
+    // A guide with no declared region still gets a sane home-base label.
+    expect(record.homeBase).toBe("Россия");
+  });
+});
+
 // Item 13, the two-field name standard: guide_profiles.display_name is the PUBLIC name;
 // profiles.full_name is the private, admin-only FIO. Getting this precedence backwards
 // is not cosmetic — it published every guide's legal name on /guides/[slug], the request


### PR DESCRIPTION
## Final live-QA repair (2026-07-19)

An independent authenticated production replay reported that an approved+available guide with empty `regions`/`languages` is silently absent from anonymous guide pages and public listings.

**Finding: misdiagnosis.** Source trace + a read-only production query proved the only approved+available guide with empty regions AND languages was also the only one with a `qa-` seed slug — the two variables were perfectly confounded. The public gate (`search_guides` / `get_public_guide_by_slug`: `approved` + `is_available` + `role=guide` + active account + non-`qa-` slug) never requires non-empty arrays. The `qa-` slug guard — not the empty arrays — is the sole, intentional reason the QA fixture is hidden. Confirmed four ways (source read, discovery-path trace, live prod DB, adversarial review).

**Change: regression lock only, no runtime change** (the invariant already holds):
- `queries-core.test.ts` — `applyGuideFilters` keeps an empty-`regions` non-QA guide; `mapGuideRow` yields a valid discoverable record with empty regions AND languages.
- `guide-template-listings.test.ts` — a per_group tour from an approved guide with empty arrays still surfaces, with «за группу» scope pinned to the group tour-type badge (item 2).

Verify chain green: typecheck, lint, 1395 tests, build, `git diff --check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)