### PR TITLE
fix(rls): block offers and joins on requests directed to another guide

### DIFF
--- a/supabase/migrations/20260719000500_directed_request_write_isolation.sql
+++ b/supabase/migrations/20260719000500_directed_request_write_isolation.sql
@@ -1,0 +1,59 @@
+-- Items 8 & 9 follow-up — directed-request privacy must hold on the WRITE side too.
+--
+-- 20260719000400 tightened SELECT so a request addressed to a specific guide
+-- (target_guide_id set) is visible only to owner, that guide, and admins. But the
+-- INSERT policies on guide_offers and open_request_members were left unchanged:
+-- they check only "am I an approved guide / the traveler", never whether the target
+-- request is addressed to someone else. An actor who obtains the request id can thus
+-- offer on, or join, a private request addressed to a different guide — contradicting
+-- the privacy guarantee. RLS is the security boundary, so close it at the write side.
+--
+-- Both policies below reproduce the CURRENT production predicate verbatim and add a
+-- single AND-guard: the target request must not be directed to a different party.
+-- Non-directed (target_guide_id IS NULL) open requests are unaffected — legitimate
+-- offers and assembly joins continue to work exactly as before.
+
+-- guide_offers: an approved, active, non-blocked guide may offer only on a request
+-- that is either open to anyone (target_guide_id IS NULL) or addressed to them.
+DROP POLICY IF EXISTS "guide_offers_insert" ON public.guide_offers;
+CREATE POLICY "guide_offers_insert"
+  ON public.guide_offers
+  FOR INSERT
+  WITH CHECK (
+    (
+      ((SELECT auth.uid()) = guide_id)
+      AND (public.profile_account_status_for(guide_id) = 'active'::public.account_status)
+      AND EXISTS (
+        SELECT 1 FROM public.guide_profiles gp
+        WHERE gp.user_id = guide_offers.guide_id
+          AND gp.verification_status = 'approved'::public.guide_verification_status
+          AND gp.is_available = true
+      )
+      AND (NOT public.guide_interval_blocked(guide_id, starts_at, ends_at))
+      AND EXISTS (
+        SELECT 1 FROM public.traveler_requests tr
+        WHERE tr.id = guide_offers.request_id
+          AND (tr.target_guide_id IS NULL OR tr.target_guide_id = (SELECT auth.uid()))
+      )
+    )
+    OR public.is_admin()
+  );
+
+-- open_request_members: a traveler may join only a request that is open to everyone.
+-- A directed (private) request is never an assembly group and must not be joinable.
+DROP POLICY IF EXISTS "open_request_members_insert" ON public.open_request_members;
+CREATE POLICY "open_request_members_insert"
+  ON public.open_request_members
+  FOR INSERT
+  WITH CHECK (
+    (
+      ((SELECT auth.uid()) = traveler_id)
+      AND (public.profile_account_status_for(traveler_id) = 'active'::public.account_status)
+      AND EXISTS (
+        SELECT 1 FROM public.traveler_requests tr
+        WHERE tr.id = open_request_members.request_id
+          AND tr.target_guide_id IS NULL
+      )
+    )
+    OR public.is_admin()
+  );


### PR DESCRIPTION
Follow-up to the directed-request privacy work (20260719000400).

**Problem.** That migration tightened SELECT so a request addressed to a specific guide (target_guide_id set) is visible only to owner, addressed guide, and admins. But the write-side policies were left permissive: guide_offers_insert only checks "am I an approved, active, non-blocked guide" and open_request_members_insert only checks "am I this traveler" — neither consults target_guide_id. An actor holding the request id could therefore offer on, or join, a private request addressed to a different guide. RLS is the security boundary, so this must be closed server-side.

**Fix.** 20260719000500 reproduces each current production predicate verbatim and adds one guard: the target request must not be directed to a different party (target_guide_id IS NULL, or equal to the actor for offers). Open/non-directed requests are unaffected.

**Verified live (production DB):** before → an approved non-addressed guide could insert both an offer and a membership on a directed request; after → both are rejected by RLS, while (a) the addressed guide can still offer on the directed request, (b) any approved guide can still offer on open requests, and (c) travelers can still join open assembly requests. Unit suites for direct-request visibility, the inbox directed-request filter, and the per-group price formatter pass (20 tests).