### PR TITLE
feat(admin): reusable destination media with published city covers

### DIFF
--- a/docs/plans/2026-07-20-destination-media.md
+++ b/docs/plans/2026-07-20-destination-media.md
@@ -1,0 +1,39 @@
+# Destination Media Administration Implementation Plan
+
+> **For Hermes:** Use subagent-driven-development task-by-task; the execution pass is delegated to Opus.
+
+**Goal:** Give administrators one reusable, safe media workspace for every canonical location/destination, so a published city cover replaces blue request-card and request-detail placeholders without duplicating uploads.
+
+**Architecture:** Extend the existing `/admin/locations` catalogue rather than creating a parallel media section. Location media is a first-class data record with editorial metadata and a published primary cover; public request surfaces resolve that published cover and retain the existing branded fallback only when no published cover exists.
+
+**Non-goals:** Do not invent or download city photography. Do not repurpose guide-owned Photobank. Do not alter existing public text, request privacy, pricing, or moderation behavior.
+
+**Acceptance checks:**
+1. An admin can open a canonical location, upload a JPG/PNG/WebP, see dimensions/file size/type, add alt text/caption/source, select a role, set it as primary, publish/unpublish, and delete it.
+2. Only administrators can mutate location media; public users receive only published URLs.
+3. A published primary cover for a location is used on public open-request cards and individual request heroes; a missing cover retains the exact existing branded fallback.
+4. Existing location lifecycle (add/archive) remains intact; no duplicate destination catalogue is introduced.
+5. At least focused unit/component tests cover validation, authorization boundary, primary/published selection, fallback, and admin interactions.
+6. `bun run test:run`, `bun run check`, `bun run build`, and fresh DB tests pass. Live deployment/replay is performed by the managing agent after independent review.
+
+## Task 1 — Data and access boundary
+- Add the smallest destination/location media schema needed for original path plus displayed metadata: location relation, role, enabled/published state, primary flag, alt/caption/source, MIME, byte size, width/height, ordering, uploader and timestamps.
+- Provision a dedicated storage bucket and admin-only object write policy. Public read must be limited to published media URLs, not unrestricted management APIs.
+- Preserve auditability and use the existing storage/upload conventions.
+
+## Task 2 — Server data layer and public image resolution
+- Add focused location-media query/mutation helpers under `src/lib/supabase/`.
+- Replace request-card/detail image resolution with active primary location media when present.
+- Preserve `cityImage()` branded fallback exactly when media is absent, disabled, unpublished, or invalid.
+
+## Task 3 — Admin location media workspace
+- Keep the entry point under `/admin/locations`.
+- Add a location detail/media route or equivalent focused editor reachable from each row.
+- Provide upload, asset metadata, primary selection, publish/enable toggle, reorder where justified, and delete actions with clear loading/error states.
+- Include image file validation before upload and server-side validation after submission.
+
+## Task 4 — Tests and verification
+- Follow TDD where possible. Cover success and rejection behavior.
+- Update generated/local database types consistently with migration strategy.
+- Run focused checks before the full suite.
+- Commit all implementation and plan changes using a conventional human commit message; do not push.

--- a/src/app/(protected)/admin/locations/[locationId]/_components/location-media-console.test.tsx
+++ b/src/app/(protected)/admin/locations/[locationId]/_components/location-media-console.test.tsx
@@ -1,0 +1,227 @@
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { LocationMediaRecord } from "@/lib/supabase/location-media";
+
+vi.mock("next/navigation", () => ({ useRouter: () => ({ refresh: vi.fn() }) }));
+vi.mock("@/lib/storage/client-upload", () => ({
+  uploadFileToSignedUrl: vi.fn().mockResolvedValue(undefined),
+}));
+vi.mock("@/app/(protected)/admin/locations/[locationId]/actions", () => ({
+  cancelLocationMediaUploadAction: vi.fn(),
+  confirmLocationMediaUploadAction: vi.fn(),
+  deleteLocationMediaAction: vi.fn(),
+  startLocationMediaUploadAction: vi.fn(),
+  updateLocationMediaAction: vi.fn(),
+}));
+
+import {
+  LocationMediaConsole,
+  validateLocationMediaFile,
+} from "./location-media-console";
+import { readImageDimensions } from "./read-image-dimensions";
+import { uploadFileToSignedUrl } from "@/lib/storage/client-upload";
+import {
+  cancelLocationMediaUploadAction,
+  confirmLocationMediaUploadAction,
+  startLocationMediaUploadAction,
+  updateLocationMediaAction,
+} from "@/app/(protected)/admin/locations/[locationId]/actions";
+
+const MEDIA: LocationMediaRecord = {
+  id: "22222222-2222-4222-8222-222222222222",
+  locationId: "11111111-1111-4111-8111-111111111111",
+  bucketId: "location-media",
+  objectPath: "admin/cover.webp",
+  signedUrl: "https://signed.test/location-media/admin/cover.webp",
+  role: "cover",
+  status: "draft",
+  isPrimary: false,
+  altText: "Казанский кремль",
+  caption: "Вид с реки",
+  source: "Куратор",
+  mimeType: "image/webp",
+  byteSize: 204_800,
+  width: 1600,
+  height: 900,
+  sortOrder: 0,
+  createdAt: "2026-07-20T00:00:00Z",
+};
+
+function renderConsole(media: LocationMediaRecord[]) {
+  return render(
+    <LocationMediaConsole
+      locationId={MEDIA.locationId}
+      locationName="Казань"
+      media={media}
+    />,
+  );
+}
+
+describe("validateLocationMediaFile", () => {
+  it("accepts the allowed image types", () => {
+    for (const type of ["image/jpeg", "image/png", "image/webp"]) {
+      expect(validateLocationMediaFile({ type, size: 1024 })).toBeNull();
+    }
+  });
+
+  it("rejects a PDF before any byte leaves the browser", () => {
+    expect(validateLocationMediaFile({ type: "application/pdf", size: 1024 })).toBe(
+      "Разрешены только JPG, PNG или WEBP.",
+    );
+  });
+
+  it("rejects a file above the 5 МБ bucket limit", () => {
+    expect(
+      validateLocationMediaFile({ type: "image/png", size: 5 * 1024 * 1024 + 1 }),
+    ).toBe("Файл превышает лимит 5 МБ.");
+  });
+});
+
+describe("readImageDimensions", () => {
+  it("returns null when the browser cannot decode the blob", async () => {
+    // jsdom has no createImageBitmap — the same path a corrupt upload takes.
+    expect(await readImageDimensions(new Blob(["not-an-image"]))).toBeNull();
+  });
+});
+
+describe("LocationMediaConsole", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(uploadFileToSignedUrl).mockResolvedValue(undefined);
+  });
+
+  it("warns that the branded gradient stays while no primary cover is published", () => {
+    renderConsole([MEDIA]);
+
+    expect(
+      screen.getByText(/остаётся фирменный\s+градиент/),
+    ).toBeInTheDocument();
+  });
+
+  it("drops the warning once a published primary cover exists", () => {
+    renderConsole([{ ...MEDIA, status: "published", isPrimary: true }]);
+
+    expect(screen.queryByText(/остаётся фирменный\s+градиент/)).toBeNull();
+    expect(screen.getByText("Главная")).toBeInTheDocument();
+    expect(screen.getByText("Опубликовано")).toBeInTheDocument();
+  });
+
+  it("shows the file facts an editor needs to judge a cover", () => {
+    renderConsole([MEDIA]);
+
+    expect(screen.getByText(/WEBP · 200 КБ · 1600×900/)).toBeInTheDocument();
+  });
+
+  it("keeps stored metadata editable rather than read-only", () => {
+    renderConsole([MEDIA]);
+
+    expect(screen.getByLabelText("Описание (alt)", { selector: "textarea" })).toHaveValue(
+      "Казанский кремль",
+    );
+    expect(screen.getByDisplayValue("Вид с реки")).toBeInTheDocument();
+    expect(screen.getByDisplayValue("Куратор")).toBeInTheDocument();
+  });
+
+  it("reserves the record with the selected gallery role, then confirms it", async () => {
+    vi.mocked(startLocationMediaUploadAction).mockResolvedValue({
+      ok: true,
+      mediaId: MEDIA.id,
+      signedUrl: "https://storage.test/upload",
+    });
+    vi.mocked(confirmLocationMediaUploadAction).mockResolvedValue({ ok: true });
+    renderConsole([]);
+
+    fireEvent.change(screen.getByLabelText("Роль изображения"), { target: { value: "gallery" } });
+    fireEvent.change(screen.getByLabelText("Файл изображения"), {
+      target: { files: [new File(["image"], "gallery.webp", { type: "image/webp" })] },
+    });
+
+    await waitFor(() =>
+      expect(startLocationMediaUploadAction).toHaveBeenCalledWith(
+        expect.objectContaining({ role: "gallery", fileName: "gallery.webp" }),
+      ),
+    );
+    await waitFor(() =>
+      expect(confirmLocationMediaUploadAction).toHaveBeenCalledWith(
+        MEDIA.locationId,
+        MEDIA.id,
+      ),
+    );
+  });
+
+  it("cancels the reservation when the upload itself fails — no orphaned object", async () => {
+    vi.mocked(startLocationMediaUploadAction).mockResolvedValue({
+      ok: true,
+      mediaId: MEDIA.id,
+      signedUrl: "https://storage.test/upload",
+    });
+    vi.mocked(uploadFileToSignedUrl).mockRejectedValueOnce(new Error("сеть недоступна"));
+    vi.mocked(cancelLocationMediaUploadAction).mockResolvedValue({ ok: true });
+    renderConsole([]);
+
+    fireEvent.change(screen.getByLabelText("Файл изображения"), {
+      target: { files: [new File(["image"], "cover.webp", { type: "image/webp" })] },
+    });
+
+    await waitFor(() =>
+      expect(cancelLocationMediaUploadAction).toHaveBeenCalledWith(
+        MEDIA.locationId,
+        MEDIA.id,
+      ),
+    );
+    expect(confirmLocationMediaUploadAction).not.toHaveBeenCalled();
+  });
+
+  it("offers cancel — and nothing else — for a record still uploading", () => {
+    renderConsole([{ ...MEDIA, status: "uploading", signedUrl: null }]);
+
+    expect(screen.getByRole("button", { name: "Отменить загрузку" })).toBeEnabled();
+    expect(screen.getByRole("button", { name: "Опубликовать" })).toBeDisabled();
+    expect(screen.getByRole("button", { name: "Сделать главной" })).toBeDisabled();
+    expect(screen.getByRole("button", { name: "Удалить" })).toBeDisabled();
+    expect(screen.getByText("Загружается")).toBeInTheDocument();
+  });
+
+  it("renders a placeholder instead of a broken image when nothing was uploaded", () => {
+    renderConsole([{ ...MEDIA, status: "uploading", signedUrl: null }]);
+
+    expect(screen.getByText("Файл не загружен")).toBeInTheDocument();
+    expect(screen.queryByRole("img")).toBeNull();
+  });
+
+  it("renders the signed URL, never a public bucket URL", () => {
+    renderConsole([MEDIA]);
+
+    expect(screen.getByRole("img")).toHaveAttribute("src", MEDIA.signedUrl);
+  });
+
+  it("saves a revised role for a non-primary asset", async () => {
+    vi.mocked(updateLocationMediaAction).mockResolvedValue({ ok: true });
+    renderConsole([MEDIA]);
+
+    fireEvent.change(screen.getByLabelText("Роль"), { target: { value: "gallery" } });
+    fireEvent.click(screen.getByRole("button", { name: "Сохранить" }));
+
+    await waitFor(() =>
+      expect(updateLocationMediaAction).toHaveBeenCalledWith(MEDIA.locationId, MEDIA.id, {
+        altText: MEDIA.altText,
+        caption: MEDIA.caption,
+        source: MEDIA.source,
+        role: "gallery",
+      }),
+    );
+  });
+
+  it("does not allow a primary asset to stop being a cover", () => {
+    renderConsole([{ ...MEDIA, status: "published", isPrimary: true }]);
+
+    expect(screen.getByLabelText("Роль")).toBeDisabled();
+  });
+
+  it("offers an empty state instead of a bare page when nothing is uploaded", () => {
+    renderConsole([]);
+
+    expect(screen.getByText("Медиа нет")).toBeInTheDocument();
+  });
+});

--- a/src/app/(protected)/admin/locations/[locationId]/_components/location-media-console.tsx
+++ b/src/app/(protected)/admin/locations/[locationId]/_components/location-media-console.tsx
@@ -1,0 +1,443 @@
+"use client";
+
+import * as React from "react";
+import { useRouter } from "next/navigation";
+
+import { Alert, AlertDescription } from "@/components/ui/alert";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Textarea } from "@/components/ui/textarea";
+import { EmptyState } from "@/components/shared/empty-state";
+import { getStorageBucketConfig } from "@/lib/storage/buckets";
+import { uploadFileToSignedUrl } from "@/lib/storage/client-upload";
+import {
+  LOCATION_MEDIA_BUCKET,
+  type LocationMediaRecord,
+} from "@/lib/supabase/location-media";
+import {
+  cancelLocationMediaUploadAction,
+  confirmLocationMediaUploadAction,
+  deleteLocationMediaAction,
+  startLocationMediaUploadAction,
+  updateLocationMediaAction,
+} from "@/app/(protected)/admin/locations/[locationId]/actions";
+import { readImageDimensions } from "./read-image-dimensions";
+
+const bucket = getStorageBucketConfig(LOCATION_MEDIA_BUCKET);
+
+/** The server action owns the canonical mime union; mirror it instead of restating it. */
+type LocationMediaMime = Parameters<typeof startLocationMediaUploadAction>[0]["mimeType"];
+
+function formatBytes(byteSize: number) {
+  return byteSize < 1024 * 1024
+    ? `${Math.round(byteSize / 1024)} КБ`
+    : `${(byteSize / (1024 * 1024)).toFixed(1)} МБ`;
+}
+
+function trimmedOrNull(value: string) {
+  const trimmed = value.trim();
+  return trimmed === "" ? null : trimmed;
+}
+
+/** Same rules as the server action, run before a byte leaves the browser. */
+export function validateLocationMediaFile(file: {
+  type: string;
+  size: number;
+}): string | null {
+  if (!bucket.allowedMimeTypes.includes(file.type as never)) {
+    return "Разрешены только JPG, PNG или WEBP.";
+  }
+  if (file.size > bucket.maxBytes) {
+    return "Файл превышает лимит 5 МБ.";
+  }
+  return null;
+}
+
+export function LocationMediaConsole({
+  locationId,
+  locationName,
+  media,
+}: {
+  locationId: string;
+  locationName: string;
+  media: LocationMediaRecord[];
+}) {
+  const router = useRouter();
+  const inputRef = React.useRef<HTMLInputElement | null>(null);
+  const [busy, setBusy] = React.useState(false);
+  const [error, setError] = React.useState<string | null>(null);
+  const [draft, setDraft] = React.useState({
+    altText: "",
+    caption: "",
+    source: "",
+    role: "cover" as LocationMediaRecord["role"],
+  });
+
+  const primary = media.find((item) => item.isPrimary && item.status === "published");
+
+  async function handleFileChange(event: React.ChangeEvent<HTMLInputElement>) {
+    const file = event.target.files?.[0];
+    event.target.value = "";
+    if (!file) return;
+
+    const invalid = validateLocationMediaFile(file);
+    if (invalid) {
+      setError(invalid);
+      return;
+    }
+
+    setError(null);
+    setBusy(true);
+    try {
+      const dimensions = await readImageDimensions(file);
+      // Reserve the row first: from here on, every outcome — success, failure, a closed
+      // tab — is represented in the database rather than as a stray storage object.
+      const upload = await startLocationMediaUploadAction({
+        locationId,
+        fileName: file.name,
+        // Narrowed by validateLocationMediaFile above and re-validated server-side.
+        mimeType: file.type as LocationMediaMime,
+        byteSize: file.size,
+        width: dimensions?.width ?? null,
+        height: dimensions?.height ?? null,
+        role: draft.role,
+        altText: trimmedOrNull(draft.altText) ?? `${locationName} — обложка`,
+        caption: trimmedOrNull(draft.caption),
+        source: trimmedOrNull(draft.source),
+      });
+      if (!upload.ok) {
+        setError(upload.error);
+        return;
+      }
+
+      try {
+        await uploadFileToSignedUrl({ signedUrl: upload.signedUrl, file });
+      } catch (e) {
+        await cancelLocationMediaUploadAction(locationId, upload.mediaId);
+        throw e;
+      }
+
+      const confirmed = await confirmLocationMediaUploadAction(locationId, upload.mediaId);
+      if (!confirmed.ok) {
+        setError(confirmed.error);
+        return;
+      }
+      setDraft({ altText: "", caption: "", source: "", role: "cover" });
+      router.refresh();
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "Не удалось загрузить файл.");
+    } finally {
+      setBusy(false);
+      router.refresh();
+    }
+  }
+
+  async function run(action: () => Promise<{ ok: true } | { ok: false; error: string }>) {
+    setError(null);
+    setBusy(true);
+    try {
+      const result = await action();
+      if (!result.ok) {
+        setError(result.error);
+        return;
+      }
+      router.refresh();
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  return (
+    <div className="flex flex-col gap-6">
+      <div className="rounded-card border border-border bg-surface-high p-5">
+        <h2 className="text-base font-semibold text-foreground">Загрузить изображение</h2>
+        <p className="mt-1 text-sm text-muted-foreground">
+          JPG, PNG или WEBP до 5 МБ. Описание и источник можно заполнить до загрузки — они
+          сохранятся вместе с файлом.
+        </p>
+        <div className="mt-4 grid gap-3 sm:grid-cols-4">
+          <div>
+            <Label htmlFor="media-alt">Описание (alt)</Label>
+            <Input
+              id="media-alt"
+              className="mt-1.5"
+              maxLength={300}
+              value={draft.altText}
+              placeholder={`${locationName} — обложка`}
+              onChange={(e) => setDraft((d) => ({ ...d, altText: e.target.value }))}
+            />
+          </div>
+          <div>
+            <Label htmlFor="media-caption">Подпись</Label>
+            <Input
+              id="media-caption"
+              className="mt-1.5"
+              maxLength={300}
+              value={draft.caption}
+              onChange={(e) => setDraft((d) => ({ ...d, caption: e.target.value }))}
+            />
+          </div>
+          <div>
+            <Label htmlFor="media-source">Источник / права</Label>
+            <Input
+              id="media-source"
+              className="mt-1.5"
+              maxLength={300}
+              value={draft.source}
+              onChange={(e) => setDraft((d) => ({ ...d, source: e.target.value }))}
+            />
+          </div>
+          <div>
+            <Label htmlFor="media-role">Роль изображения</Label>
+            <select
+              id="media-role"
+              className="mt-1.5 flex h-9 w-full rounded-md border border-input bg-transparent px-3 py-1 text-sm shadow-xs outline-none focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/40"
+              value={draft.role}
+              onChange={(e) =>
+                setDraft((d) => ({ ...d, role: e.target.value as "cover" | "gallery" }))
+              }
+            >
+              <option value="cover">Обложка</option>
+              <option value="gallery">Галерея</option>
+            </select>
+          </div>
+        </div>
+        <input
+          ref={inputRef}
+          type="file"
+          aria-label="Файл изображения"
+          accept="image/jpeg,image/png,image/webp"
+          className="sr-only"
+          onChange={(e) => void handleFileChange(e)}
+        />
+        <Button
+          type="button"
+          className="mt-4"
+          loading={busy}
+          disabled={busy}
+          onClick={() => inputRef.current?.click()}
+        >
+          Выбрать файл
+        </Button>
+        {error ? (
+          <Alert role="alert" variant="destructive" className="mt-3">
+            <AlertDescription>{error}</AlertDescription>
+          </Alert>
+        ) : null}
+      </div>
+
+      {primary ? null : (
+        <Alert>
+          <AlertDescription>
+            Главная обложка не опубликована — на публичных страницах остаётся фирменный
+            градиент.
+          </AlertDescription>
+        </Alert>
+      )}
+
+      {media.length === 0 ? (
+        <EmptyState
+          title="Медиа нет"
+          description="Загрузите изображение локации, чтобы заменить фирменный градиент на публичных карточках запросов."
+        />
+      ) : (
+        <div className="flex flex-col gap-4">
+          {media.map((item) => (
+            <MediaCard
+              key={item.id}
+              item={item}
+              locationId={locationId}
+              busy={busy}
+              onRun={run}
+            />
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}
+
+function MediaCard({
+  item,
+  locationId,
+  busy,
+  onRun,
+}: {
+  item: LocationMediaRecord;
+  locationId: string;
+  busy: boolean;
+  onRun: (action: () => Promise<{ ok: true } | { ok: false; error: string }>) => Promise<void>;
+}) {
+  const [fields, setFields] = React.useState({
+    altText: item.altText ?? "",
+    caption: item.caption ?? "",
+    source: item.source ?? "",
+    role: item.role,
+  });
+  const uploading = item.status === "uploading";
+  const dirty =
+    (item.altText ?? "") !== fields.altText ||
+    (item.caption ?? "") !== fields.caption ||
+    (item.source ?? "") !== fields.source ||
+    item.role !== fields.role;
+
+  return (
+    <article className="flex flex-col gap-4 rounded-card border border-border bg-card p-4 sm:flex-row">
+      {item.signedUrl ? (
+        /* eslint-disable-next-line @next/next/no-img-element */
+        <img
+          src={item.signedUrl}
+          alt={item.altText ?? ""}
+          className="h-32 w-full shrink-0 rounded-step object-cover sm:w-48"
+        />
+      ) : (
+        <div className="flex h-32 w-full shrink-0 items-center justify-center rounded-step border border-dashed border-border text-xs text-muted-foreground sm:w-48">
+          Файл не загружен
+        </div>
+      )}
+      <div className="flex min-w-0 flex-1 flex-col gap-3">
+        <div className="flex flex-wrap items-center gap-2">
+          <Badge variant={item.status === "published" ? "default" : "secondary"}>
+            {item.status === "published"
+              ? "Опубликовано"
+              : uploading
+                ? "Загружается"
+                : "Черновик"}
+          </Badge>
+          <Badge variant="secondary">{item.role === "cover" ? "Обложка" : "Галерея"}</Badge>
+          {item.isPrimary ? <Badge>Главная</Badge> : null}
+          <span className="text-sm text-muted-foreground">
+            {item.mimeType.replace("image/", "").toUpperCase()} · {formatBytes(item.byteSize)}
+            {item.width && item.height ? ` · ${item.width}×${item.height}` : ""}
+          </span>
+        </div>
+
+        <div className="grid gap-3 sm:grid-cols-2">
+          <div className="sm:col-span-2">
+            <Label htmlFor={`alt-${item.id}`}>Описание (alt)</Label>
+            <Textarea
+              id={`alt-${item.id}`}
+              className="mt-1.5"
+              rows={2}
+              maxLength={300}
+              value={fields.altText}
+              onChange={(e) => setFields((f) => ({ ...f, altText: e.target.value }))}
+            />
+          </div>
+          <div>
+            <Label htmlFor={`caption-${item.id}`}>Подпись</Label>
+            <Input
+              id={`caption-${item.id}`}
+              className="mt-1.5"
+              maxLength={300}
+              value={fields.caption}
+              onChange={(e) => setFields((f) => ({ ...f, caption: e.target.value }))}
+            />
+          </div>
+          <div>
+            <Label htmlFor={`source-${item.id}`}>Источник / права</Label>
+            <Input
+              id={`source-${item.id}`}
+              className="mt-1.5"
+              maxLength={300}
+              value={fields.source}
+              onChange={(e) => setFields((f) => ({ ...f, source: e.target.value }))}
+            />
+          </div>
+          <div>
+            <Label htmlFor={`role-${item.id}`}>Роль</Label>
+            <select
+              id={`role-${item.id}`}
+              className="mt-1.5 flex h-9 w-full rounded-md border border-input bg-transparent px-3 py-1 text-sm shadow-xs outline-none focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/40 disabled:cursor-not-allowed disabled:opacity-50"
+              value={fields.role}
+              disabled={item.isPrimary || uploading}
+              onChange={(e) =>
+                setFields((f) => ({ ...f, role: e.target.value as "cover" | "gallery" }))
+              }
+            >
+              <option value="cover">Обложка</option>
+              <option value="gallery">Галерея</option>
+            </select>
+            {item.isPrimary ? (
+              <p className="mt-1 text-xs text-muted-foreground">
+                Главная обложка всегда опубликована и имеет роль «Обложка».
+              </p>
+            ) : null}
+          </div>
+        </div>
+
+        <div className="flex flex-wrap gap-2">
+          {uploading ? (
+            <Button
+              type="button"
+              size="sm"
+              variant="outline"
+              disabled={busy}
+              onClick={() =>
+                void onRun(() => cancelLocationMediaUploadAction(locationId, item.id))
+              }
+            >
+              Отменить загрузку
+            </Button>
+          ) : null}
+          <Button
+            type="button"
+            size="sm"
+            disabled={busy || uploading || !dirty}
+            onClick={() =>
+              void onRun(() =>
+                updateLocationMediaAction(locationId, item.id, {
+                  altText: trimmedOrNull(fields.altText),
+                  caption: trimmedOrNull(fields.caption),
+                  source: trimmedOrNull(fields.source),
+                  role: fields.role,
+                }),
+              )
+            }
+          >
+            Сохранить
+          </Button>
+          <Button
+            type="button"
+            size="sm"
+            variant="outline"
+            disabled={busy || uploading}
+            onClick={() =>
+              void onRun(() =>
+                updateLocationMediaAction(locationId, item.id, {
+                  status: item.status === "published" ? "draft" : "published",
+                }),
+              )
+            }
+          >
+            {item.status === "published" ? "Снять с публикации" : "Опубликовать"}
+          </Button>
+          <Button
+            type="button"
+            size="sm"
+            variant="outline"
+            disabled={busy || uploading || item.isPrimary}
+            onClick={() =>
+              void onRun(() =>
+                updateLocationMediaAction(locationId, item.id, { isPrimary: true }),
+              )
+            }
+          >
+            Сделать главной
+          </Button>
+          <Button
+            type="button"
+            size="sm"
+            variant="outline"
+            disabled={busy || uploading}
+            onClick={() => void onRun(() => deleteLocationMediaAction(locationId, item.id))}
+          >
+            Удалить
+          </Button>
+        </div>
+      </div>
+    </article>
+  );
+}

--- a/src/app/(protected)/admin/locations/[locationId]/_components/read-image-dimensions.ts
+++ b/src/app/(protected)/admin/locations/[locationId]/_components/read-image-dimensions.ts
@@ -1,0 +1,18 @@
+/**
+ * Pixel dimensions of a picked image, or null when the browser cannot decode it.
+ * Null is not an error: the record stores dimensions as optional metadata and the
+ * server still validates type and size.
+ */
+export async function readImageDimensions(
+  file: Blob,
+): Promise<{ width: number; height: number } | null> {
+  if (typeof createImageBitmap !== "function") return null;
+  try {
+    const bitmap = await createImageBitmap(file);
+    const { width, height } = bitmap;
+    bitmap.close?.();
+    return width > 0 && height > 0 ? { width, height } : null;
+  } catch {
+    return null;
+  }
+}

--- a/src/app/(protected)/admin/locations/[locationId]/actions.test.ts
+++ b/src/app/(protected)/admin/locations/[locationId]/actions.test.ts
@@ -1,0 +1,274 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const {
+  requireAdminSession,
+  beginLocationMediaUpload,
+  confirmLocationMediaUpload,
+  cancelLocationMediaUpload,
+  updateLocationMedia,
+  deleteLocationMedia,
+  getPresignedUploadUrl,
+} = vi.hoisted(() => ({
+  requireAdminSession: vi.fn(),
+  beginLocationMediaUpload: vi.fn(),
+  confirmLocationMediaUpload: vi.fn(),
+  cancelLocationMediaUpload: vi.fn(),
+  updateLocationMedia: vi.fn(),
+  deleteLocationMedia: vi.fn(),
+  getPresignedUploadUrl: vi.fn(),
+}));
+
+vi.mock("next/cache", () => ({ revalidatePath: vi.fn() }));
+vi.mock("@/lib/supabase/moderation", () => ({ requireAdminSession }));
+vi.mock("@/lib/storage/upload", () => ({ getPresignedUploadUrl }));
+vi.mock("@/lib/supabase/location-media", async () => {
+  const actual = await vi.importActual<typeof import("@/lib/supabase/location-media")>(
+    "@/lib/supabase/location-media",
+  );
+  return {
+    ...actual,
+    beginLocationMediaUpload,
+    confirmLocationMediaUpload,
+    cancelLocationMediaUpload,
+    updateLocationMedia,
+    deleteLocationMedia,
+  };
+});
+
+import {
+  cancelLocationMediaUploadAction,
+  confirmLocationMediaUploadAction,
+  deleteLocationMediaAction,
+  startLocationMediaUploadAction,
+  updateLocationMediaAction,
+} from "./actions";
+
+const LOCATION_ID = "11111111-1111-4111-8111-111111111111";
+const MEDIA_ID = "22222222-2222-4222-8222-222222222222";
+const ADMIN_ID = "33333333-3333-4333-8333-333333333333";
+
+const VALID_START = {
+  locationId: LOCATION_ID,
+  fileName: "cover.jpg",
+  mimeType: "image/jpeg" as const,
+  byteSize: 1024,
+  width: 1600,
+  height: 900,
+  role: "cover" as const,
+  altText: "Казанский кремль",
+  caption: "Вид с реки",
+  source: "Куратор",
+};
+
+function asAdmin() {
+  requireAdminSession.mockResolvedValue({ adminId: ADMIN_ID, adminClient: {} });
+}
+
+function asNonAdmin() {
+  requireAdminSession.mockRejectedValue(new Error("Доступ только для администраторов."));
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  getPresignedUploadUrl.mockResolvedValue({
+    path: `${ADMIN_ID}/cover.jpg`,
+    token: "t",
+    signedUrl: "https://storage.test/upload",
+  });
+  beginLocationMediaUpload.mockResolvedValue(MEDIA_ID);
+});
+
+describe("location media authorization boundary", () => {
+  it("refuses every write for a non-admin", async () => {
+    asNonAdmin();
+
+    const results = await Promise.all([
+      startLocationMediaUploadAction(VALID_START),
+      confirmLocationMediaUploadAction(LOCATION_ID, MEDIA_ID),
+      cancelLocationMediaUploadAction(LOCATION_ID, MEDIA_ID),
+      updateLocationMediaAction(LOCATION_ID, MEDIA_ID, { status: "published" }),
+      deleteLocationMediaAction(LOCATION_ID, MEDIA_ID),
+    ]);
+
+    expect(results.every((r) => r.ok === false)).toBe(true);
+    expect(getPresignedUploadUrl).not.toHaveBeenCalled();
+    expect(beginLocationMediaUpload).not.toHaveBeenCalled();
+    expect(confirmLocationMediaUpload).not.toHaveBeenCalled();
+    expect(cancelLocationMediaUpload).not.toHaveBeenCalled();
+    expect(updateLocationMedia).not.toHaveBeenCalled();
+    expect(deleteLocationMedia).not.toHaveBeenCalled();
+  });
+});
+
+describe("startLocationMediaUploadAction", () => {
+  beforeEach(asAdmin);
+
+  it("reserves the row with its editorial metadata before returning an upload URL", async () => {
+    const result = await startLocationMediaUploadAction(VALID_START);
+
+    expect(result).toEqual({
+      ok: true,
+      mediaId: MEDIA_ID,
+      signedUrl: "https://storage.test/upload",
+    });
+    expect(beginLocationMediaUpload).toHaveBeenCalledWith(
+      {},
+      expect.objectContaining({
+        objectPath: `${ADMIN_ID}/cover.jpg`,
+        altText: "Казанский кремль",
+        caption: "Вид с реки",
+        source: "Куратор",
+        width: 1600,
+        height: 900,
+        mimeType: "image/jpeg",
+        byteSize: 1024,
+        createdBy: ADMIN_ID,
+      }),
+    );
+  });
+
+  it("never leaks the raw object path to the browser", async () => {
+    const result = await startLocationMediaUploadAction(VALID_START);
+
+    expect(result).not.toHaveProperty("path");
+  });
+
+  it("rejects a disallowed mime type before signing anything", async () => {
+    const result = await startLocationMediaUploadAction({
+      ...VALID_START,
+      mimeType: "application/pdf" as never,
+    });
+
+    expect(result).toEqual({ ok: false, error: "Разрешены только JPG, PNG или WEBP." });
+    expect(getPresignedUploadUrl).not.toHaveBeenCalled();
+    expect(beginLocationMediaUpload).not.toHaveBeenCalled();
+  });
+
+  it("rejects a file over the bucket limit server-side", async () => {
+    const result = await startLocationMediaUploadAction({
+      ...VALID_START,
+      byteSize: 5 * 1024 * 1024 + 1,
+    });
+
+    expect(result).toEqual({ ok: false, error: "Файл превышает лимит 5 МБ." });
+    expect(beginLocationMediaUpload).not.toHaveBeenCalled();
+  });
+
+  it("rejects non-positive pixel dimensions", async () => {
+    const result = await startLocationMediaUploadAction({ ...VALID_START, width: 0 });
+
+    expect(result.ok).toBe(false);
+    expect(beginLocationMediaUpload).not.toHaveBeenCalled();
+  });
+});
+
+describe("confirmLocationMediaUploadAction", () => {
+  beforeEach(asAdmin);
+
+  it("confirms the reservation for a valid id", async () => {
+    confirmLocationMediaUpload.mockResolvedValue(undefined);
+
+    expect(await confirmLocationMediaUploadAction(LOCATION_ID, MEDIA_ID)).toEqual({
+      ok: true,
+    });
+    expect(confirmLocationMediaUpload).toHaveBeenCalledWith({}, MEDIA_ID);
+  });
+
+  it("rejects a malformed media id before touching the data layer", async () => {
+    const result = await confirmLocationMediaUploadAction(LOCATION_ID, "not-a-uuid");
+
+    expect(result.ok).toBe(false);
+    expect(confirmLocationMediaUpload).not.toHaveBeenCalled();
+  });
+});
+
+describe("cancelLocationMediaUploadAction", () => {
+  beforeEach(asAdmin);
+
+  it("cancels the reservation so no unmanaged object survives", async () => {
+    cancelLocationMediaUpload.mockResolvedValue(undefined);
+
+    expect(await cancelLocationMediaUploadAction(LOCATION_ID, MEDIA_ID)).toEqual({ ok: true });
+    expect(cancelLocationMediaUpload).toHaveBeenCalledWith({}, MEDIA_ID);
+  });
+
+  it("surfaces a cancellation failure rather than pretending it worked", async () => {
+    cancelLocationMediaUpload.mockRejectedValue(new Error("boom"));
+
+    expect(await cancelLocationMediaUploadAction(LOCATION_ID, MEDIA_ID)).toEqual({
+      ok: false,
+      error: "boom",
+    });
+  });
+});
+
+describe("updateLocationMediaAction", () => {
+  beforeEach(asAdmin);
+
+  it("publishes as a cover when a row is promoted to primary", async () => {
+    updateLocationMedia.mockResolvedValue(undefined);
+
+    await updateLocationMediaAction(LOCATION_ID, MEDIA_ID, { isPrimary: true });
+
+    expect(updateLocationMedia).toHaveBeenCalledWith({}, MEDIA_ID, {
+      isPrimary: true,
+      status: "published",
+      role: "cover",
+    });
+  });
+
+  it("clears the primary flag when unpublishing — a hidden row cannot stay primary", async () => {
+    updateLocationMedia.mockResolvedValue(undefined);
+
+    await updateLocationMediaAction(LOCATION_ID, MEDIA_ID, { status: "draft" });
+
+    expect(updateLocationMedia).toHaveBeenCalledWith({}, MEDIA_ID, {
+      status: "draft",
+      isPrimary: false,
+    });
+  });
+
+  it("clears the primary flag when a cover is demoted to gallery", async () => {
+    updateLocationMedia.mockResolvedValue(undefined);
+
+    await updateLocationMediaAction(LOCATION_ID, MEDIA_ID, { role: "gallery" });
+
+    expect(updateLocationMedia).toHaveBeenCalledWith({}, MEDIA_ID, {
+      role: "gallery",
+      isPrimary: false,
+    });
+  });
+
+  it("refuses to set the internal uploading status through the generic patch", async () => {
+    const result = await updateLocationMediaAction(LOCATION_ID, MEDIA_ID, {
+      status: "uploading" as never,
+    });
+
+    expect(result.ok).toBe(false);
+    expect(updateLocationMedia).not.toHaveBeenCalled();
+  });
+
+  it("rejects a malformed media id before touching the data layer", async () => {
+    const result = await updateLocationMediaAction(LOCATION_ID, "not-a-uuid", {
+      status: "published",
+    });
+
+    expect(result.ok).toBe(false);
+    expect(updateLocationMedia).not.toHaveBeenCalled();
+  });
+});
+
+describe("deleteLocationMediaAction", () => {
+  beforeEach(asAdmin);
+
+  it("reports a storage failure instead of silently dropping the record", async () => {
+    deleteLocationMedia.mockRejectedValue(
+      new Error("Файл не удалён из хранилища: network"),
+    );
+
+    expect(await deleteLocationMediaAction(LOCATION_ID, MEDIA_ID)).toEqual({
+      ok: false,
+      error: "Файл не удалён из хранилища: network",
+    });
+  });
+});

--- a/src/app/(protected)/admin/locations/[locationId]/actions.ts
+++ b/src/app/(protected)/admin/locations/[locationId]/actions.ts
@@ -1,0 +1,166 @@
+"use server";
+
+import { revalidatePath } from "next/cache";
+import { z } from "zod";
+
+import { getStorageBucketConfig } from "@/lib/storage/buckets";
+import { getPresignedUploadUrl } from "@/lib/storage/upload";
+import {
+  LOCATION_MEDIA_BUCKET,
+  beginLocationMediaUpload,
+  cancelLocationMediaUpload,
+  confirmLocationMediaUpload,
+  deleteLocationMedia,
+  updateLocationMedia,
+} from "@/lib/supabase/location-media";
+import { requireAdminSession } from "@/lib/supabase/moderation";
+
+export type LocationMediaActionResult = { ok: true } | { ok: false; error: string };
+export type LocationMediaUploadStartResult =
+  | { ok: true; mediaId: string; signedUrl: string }
+  | { ok: false; error: string };
+
+const bucketConfig = getStorageBucketConfig(LOCATION_MEDIA_BUCKET);
+
+const mimeSchema = z.enum(bucketConfig.allowedMimeTypes, {
+  message: "Разрешены только JPG, PNG или WEBP.",
+});
+
+const textSchema = z.string().trim().max(300).nullable();
+
+const startSchema = z.object({
+  locationId: z.string().uuid(),
+  fileName: z.string().trim().min(1).max(255),
+  mimeType: mimeSchema,
+  byteSize: z
+    .number()
+    .int()
+    .positive()
+    .max(bucketConfig.maxBytes, "Файл превышает лимит 5 МБ."),
+  width: z.number().int().positive().nullable(),
+  height: z.number().int().positive().nullable(),
+  role: z.enum(["cover", "gallery"]),
+  altText: textSchema,
+  caption: textSchema,
+  source: textSchema,
+});
+
+const patchSchema = z.object({
+  altText: textSchema.optional(),
+  caption: textSchema.optional(),
+  source: textSchema.optional(),
+  role: z.enum(["cover", "gallery"]).optional(),
+  status: z.enum(["draft", "published"]).optional(),
+  isPrimary: z.boolean().optional(),
+});
+
+function actionError(e: unknown, fallback: string): { ok: false; error: string } {
+  if (e instanceof z.ZodError) {
+    return { ok: false, error: e.issues[0]?.message ?? fallback };
+  }
+  return { ok: false, error: e instanceof Error ? e.message : fallback };
+}
+
+function revalidate(locationId: string) {
+  revalidatePath(`/admin/locations/${locationId}`);
+  // Public surfaces resolve covers per render; drop their cached HTML too.
+  revalidatePath("/requests");
+}
+
+/**
+ * Reserves the media row, then hands back the signed upload URL.
+ *
+ * The row is created as `uploading` *before* the browser can write a byte, so a failed or
+ * abandoned upload is always represented by a record an admin can cancel — never by an
+ * orphaned object in a bucket nothing indexes.
+ */
+export async function startLocationMediaUploadAction(
+  input: z.input<typeof startSchema>,
+): Promise<LocationMediaUploadStartResult> {
+  try {
+    const { adminClient, adminId } = await requireAdminSession();
+    const { fileName, ...parsed } = startSchema.parse(input);
+    const { path, signedUrl } = await getPresignedUploadUrl(
+      LOCATION_MEDIA_BUCKET,
+      fileName,
+      parsed.mimeType,
+      adminId,
+    );
+    const mediaId = await beginLocationMediaUpload(adminClient, {
+      ...parsed,
+      objectPath: path,
+      createdBy: adminId,
+    });
+    revalidate(parsed.locationId);
+    return { ok: true, mediaId, signedUrl };
+  } catch (e) {
+    return actionError(e, "Не удалось подготовить загрузку.");
+  }
+}
+
+export async function confirmLocationMediaUploadAction(
+  locationId: string,
+  mediaId: string,
+): Promise<LocationMediaActionResult> {
+  try {
+    const { adminClient } = await requireAdminSession();
+    await confirmLocationMediaUpload(adminClient, z.string().uuid().parse(mediaId));
+    revalidate(z.string().uuid().parse(locationId));
+    return { ok: true };
+  } catch (e) {
+    return actionError(e, "Не удалось сохранить медиа.");
+  }
+}
+
+export async function cancelLocationMediaUploadAction(
+  locationId: string,
+  mediaId: string,
+): Promise<LocationMediaActionResult> {
+  try {
+    const { adminClient } = await requireAdminSession();
+    await cancelLocationMediaUpload(adminClient, z.string().uuid().parse(mediaId));
+    revalidate(z.string().uuid().parse(locationId));
+    return { ok: true };
+  } catch (e) {
+    return actionError(e, "Не удалось отменить загрузку.");
+  }
+}
+
+export async function updateLocationMediaAction(
+  locationId: string,
+  mediaId: string,
+  patch: z.input<typeof patchSchema>,
+): Promise<LocationMediaActionResult> {
+  try {
+    const { adminClient } = await requireAdminSession();
+    const parsed = patchSchema.parse(patch);
+    // A primary cover must be publicly resolvable, and the schema enforces it. Promoting
+    // therefore implies publishing as a cover; the reverse — unpublishing, or demoting to
+    // gallery — has to clear the flag in the same write, or the update just fails.
+    if (parsed.isPrimary === true) {
+      parsed.status = "published";
+      parsed.role = "cover";
+    } else if (parsed.status === "draft" || parsed.role === "gallery") {
+      parsed.isPrimary = false;
+    }
+    await updateLocationMedia(adminClient, z.string().uuid().parse(mediaId), parsed);
+    revalidate(z.string().uuid().parse(locationId));
+    return { ok: true };
+  } catch (e) {
+    return actionError(e, "Не удалось обновить медиа.");
+  }
+}
+
+export async function deleteLocationMediaAction(
+  locationId: string,
+  mediaId: string,
+): Promise<LocationMediaActionResult> {
+  try {
+    const { adminClient } = await requireAdminSession();
+    await deleteLocationMedia(adminClient, z.string().uuid().parse(mediaId));
+    revalidate(z.string().uuid().parse(locationId));
+    return { ok: true };
+  } catch (e) {
+    return actionError(e, "Не удалось удалить медиа.");
+  }
+}

--- a/src/app/(protected)/admin/locations/[locationId]/page.tsx
+++ b/src/app/(protected)/admin/locations/[locationId]/page.tsx
@@ -1,0 +1,48 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+import { notFound } from "next/navigation";
+import { ArrowLeft } from "lucide-react";
+
+import { Button } from "@/components/ui/button";
+import { PageHeader } from "@/components/shared/page-header";
+import { getLocation, listLocationMedia } from "@/lib/supabase/location-media";
+import { requireAdminSession } from "@/lib/supabase/moderation";
+import { LocationMediaConsole } from "./_components/location-media-console";
+
+export const metadata: Metadata = { title: "Медиа локации" };
+
+/**
+ * Editorial media for one canonical location. The published primary cover replaces the
+ * branded gradient on public request cards and request heroes; drafts stay admin-only.
+ */
+export default async function AdminLocationMediaPage({
+  params,
+}: {
+  params: Promise<{ locationId: string }>;
+}) {
+  const { locationId } = await params;
+  const { adminClient } = await requireAdminSession();
+  const location = await getLocation(adminClient, locationId);
+  if (!location) notFound();
+
+  const media = await listLocationMedia(adminClient, location.id);
+
+  return (
+    <div className="flex flex-col gap-8">
+      <div>
+        <Button asChild variant="ghost" size="sm">
+          <Link href="/admin/locations">
+            <ArrowLeft size={16} />
+            Все локации
+          </Link>
+        </Button>
+      </div>
+      <PageHeader
+        eyebrow="Администрирование"
+        title={location.name}
+        subtitle="Медиа локации. Опубликованная главная обложка показывается на карточках и в шапке запросов для этой локации. Без опубликованной обложки остаётся фирменный градиент."
+      />
+      <LocationMediaConsole locationId={location.id} locationName={location.name} media={media} />
+    </div>
+  );
+}

--- a/src/app/(protected)/admin/locations/_components/locations-console.tsx
+++ b/src/app/(protected)/admin/locations/_components/locations-console.tsx
@@ -92,7 +92,9 @@ export function LocationsConsole({ locations }: { locations: LocationCatalogEntr
           {locations.map((location) => (
             <ListRow
               key={location.id}
+              href={`/admin/locations/${location.id}`}
               title={location.name}
+              subtitle="Медиа локации"
               badge={
                 <Badge variant={location.status === "active" ? "default" : "secondary"}>
                   {location.status === "active" ? "Активна" : "В архиве"}

--- a/src/app/(site)/requests/[requestId]/page.tsx
+++ b/src/app/(site)/requests/[requestId]/page.tsx
@@ -17,6 +17,10 @@ import {
 import { canSeeRequestNotes } from "@/features/requests/request-notes-visibility";
 import { getRequestViewerContext, viewerRoleForRequest } from "@/lib/auth/viewer-role-for-request";
 import { cityImage } from "@/lib/city-image";
+import {
+  getPublishedLocationCoversSafe,
+  resolveLocationCover,
+} from "@/lib/supabase/location-media";
 import { friendlyError } from "@/lib/errors";
 import { maskPii } from "@/lib/pii/mask";
 import { createSupabaseServerClient } from "@/lib/supabase/server";
@@ -116,6 +120,7 @@ function buildViewModel({
   isMember,
   ownerId,
   includeNotes,
+  coverUrl = null,
 }: {
   request: RequestRecord;
   currentUserId: string | null;
@@ -125,6 +130,8 @@ function buildViewModel({
   // viewers get it in the model; everyone else gets an empty string so no render
   // path (hero intro, member brief) can surface it. See canSeeRequestNotes.
   includeNotes: boolean;
+  /** Published primary location cover, or null to keep the branded gradient. */
+  coverUrl?: string | null;
 }): PublicRequestDetailViewModel {
   const organizerFallback = request.requesterName || "Путешественник";
   const members =
@@ -142,7 +149,7 @@ function buildViewModel({
   return {
     title: request.title,
     regionLabel: request.destinationRegion,
-    cityImageUrl: cityImage(request.destination),
+    cityImageUrl: coverUrl ?? cityImage(request.destination),
     dateLabel: request.dateLabel,
     timeLabel: getTimeLabel(request),
     datesFlexible: request.dateFlexibility === "few_days",
@@ -426,6 +433,20 @@ export default async function RequestDetailPage({
   currentUserId = viewerContext.userId;
   ownerId = result.data.travelerId ?? null;
 
+  // Published primary cover for this destination; null keeps the branded gradient.
+  let coverUrl: string | null = null;
+  if (hasSupabaseEnv()) {
+    try {
+      const coverClient = await createSupabaseServerClient();
+      coverUrl = resolveLocationCover(
+        await getPublishedLocationCoversSafe(coverClient),
+        result.data.destination,
+      );
+    } catch {
+      // Cover lookup is decorative — never block the request page on it.
+    }
+  }
+
   if (
     result.data.mode !== "assembly" &&
     viewerRole !== "owner" &&
@@ -466,6 +487,7 @@ export default async function RequestDetailPage({
       isMember,
       ownerId,
       includeNotes: true,
+      coverUrl,
     });
 
     const ownerGroupThread = await getRequestGroupThread(requestId as Uuid);
@@ -505,6 +527,7 @@ export default async function RequestDetailPage({
       <RequestDetailScreen
         viewerRole="guide"
         request={guideRequestForView}
+        cityImageUrl={coverUrl ?? undefined}
         isApproved={guideData.isApproved}
         existingOfferId={guideData.existingOfferId}
         offerMeta={guideData.offerMeta}
@@ -525,6 +548,7 @@ export default async function RequestDetailPage({
     includeNotes: canSeeRequestNotes({
       viewerRole: viewerRole === "admin" ? "admin" : "public",
     }),
+    coverUrl,
   });
 
   let biddingGuides: BiddingGuide[] = [];

--- a/src/app/(site)/requests/page.tsx
+++ b/src/app/(site)/requests/page.tsx
@@ -8,6 +8,10 @@ import type { OpenRequestRecord } from "@/data/open-requests/types";
 import { getOpenRequests, type RequestRecord } from "@/data/supabase/queries";
 import { PublicRequestsMarketplaceScreen } from "@/features/requests/components/public-requests-marketplace-screen";
 import { cityImage } from "@/lib/city-image";
+import {
+  getPublishedLocationCoversSafe,
+  resolveLocationCover,
+} from "@/lib/supabase/location-media";
 import { createSupabaseServerClient } from "@/lib/supabase/server";
 
 // In-page skeleton replaces the removed (site)/loading.tsx boundary for this
@@ -38,6 +42,7 @@ function mapToOpenRequestRecord(
   request: RequestRecord,
   viewerId: string | null,
   joinedRequestIds: Set<string>,
+  covers: Map<string, string>,
 ): OpenRequestRecord {
   const isOwner = request.travelerId != null && request.travelerId === viewerId;
   // The free-text «Пожелания» is private (health/PII). The public marketplace is a
@@ -60,7 +65,8 @@ function mapToOpenRequestRecord(
     },
     destinationLabel: request.destination,
     imageUrl: request.imageUrl,
-    cityImageUrl: cityImage(request.destination),
+    cityImageUrl:
+      resolveLocationCover(covers, request.destination) ?? cityImage(request.destination),
     regionLabel: request.destinationRegion,
     dateRangeLabel: request.dateLabel,
     datesFlexible: request.dateFlexibility === "few_days",
@@ -116,8 +122,10 @@ export async function RequestsContent() {
           if (membership.request_id) joinedRequestIds.add(membership.request_id as string);
         }
       }
+      // Anon/user client: RLS plus the explicit status filter keep drafts out of public HTML.
+      const covers = await getPublishedLocationCoversSafe(supabase);
       initialData = assemblyRequests.map((request) =>
-        mapToOpenRequestRecord(request, viewerId, joinedRequestIds),
+        mapToOpenRequestRecord(request, viewerId, joinedRequestIds, covers),
       );
     }
   } catch {

--- a/src/features/requests/components/request-detail-screen.tsx
+++ b/src/features/requests/components/request-detail-screen.tsx
@@ -142,6 +142,8 @@ type RequestDetailScreenProps =
   | {
       viewerRole: "guide";
       request: RequestRecord;
+      /** Published primary location cover; omitted keeps the branded gradient. */
+      cityImageUrl?: string;
       isApproved: boolean;
       existingOfferId: string | null;
       offerMeta?: OfferMeta | null;
@@ -874,6 +876,7 @@ function formatCompetingOffersLabel(count: number, hasOwnOffer: boolean): string
 
 function GuideDetailBranch({
   request,
+  cityImageUrl,
   isApproved,
   existingOfferId,
   offerMeta,
@@ -903,7 +906,7 @@ function GuideDetailBranch({
       <ImmersiveHero
         navBleed
         variant="compact"
-        imageUrl={cityImage(request.destination)}
+        imageUrl={cityImageUrl ?? cityImage(request.destination)}
         breadcrumb={buildRequestDetailBreadcrumb(request.destination, request.destination)}
         title={request.destination}
         intro={request.description || undefined}

--- a/src/lib/storage/__tests__/buckets.test.ts
+++ b/src/lib/storage/__tests__/buckets.test.ts
@@ -15,6 +15,7 @@ describe('storage bucket configuration', () => {
       'traveler-avatars',
       'guide-documents',
       'listing-media',
+      'location-media',
       'dispute-evidence',
     ])
   })
@@ -22,6 +23,9 @@ describe('storage bucket configuration', () => {
   it('exposes the expected public/private bucket flags', () => {
     expect(isPublicStorageBucket('guide-avatars')).toBe(true)
     expect(isPublicStorageBucket('listing-media')).toBe(true)
+    // Private on purpose: a public bucket serves objects without consulting RLS, which
+    // would expose draft/uploading destination media to anyone holding a path.
+    expect(isPublicStorageBucket('location-media')).toBe(false)
     expect(isPublicStorageBucket('guide-documents')).toBe(false)
     expect(isPublicStorageBucket('dispute-evidence')).toBe(false)
   })
@@ -29,6 +33,7 @@ describe('storage bucket configuration', () => {
   it('enforces the documented file size limits', () => {
     expect(getStorageBucketConfig('guide-avatars').maxBytes).toBe(2 * 1024 * 1024)
     expect(getStorageBucketConfig('listing-media').maxBytes).toBe(5 * 1024 * 1024)
+    expect(getStorageBucketConfig('location-media').maxBytes).toBe(5 * 1024 * 1024)
     expect(getStorageBucketConfig('guide-documents').maxBytes).toBe(10 * 1024 * 1024)
     expect(getStorageBucketConfig('dispute-evidence').maxBytes).toBe(10 * 1024 * 1024)
   })
@@ -44,8 +49,14 @@ describe('storage bucket configuration', () => {
       'image/png',
       'image/webp',
     ])
+    expect(storageBucketConfig['location-media'].allowedMimeTypes).toEqual([
+      'image/jpeg',
+      'image/png',
+      'image/webp',
+    ])
     expect(storageBucketConfig['guide-avatars'].allowedMimeTypes).not.toContain('application/pdf')
     expect(storageBucketConfig['listing-media'].allowedMimeTypes).not.toContain('application/pdf')
+    expect(storageBucketConfig['location-media'].allowedMimeTypes).not.toContain('application/pdf')
   })
 
   it('allows PDFs only in private document/evidence buckets', () => {

--- a/src/lib/storage/buckets.ts
+++ b/src/lib/storage/buckets.ts
@@ -26,6 +26,13 @@ export const storageBucketConfig = {
     maxBytes: 5 * 1024 * 1024,
     allowedMimeTypes: ["image/jpeg", "image/png", "image/webp"] as const,
   },
+  // Private: object RLS is the publication boundary, and a public bucket bypasses it.
+  // Images are served as signed URLs — see src/lib/supabase/location-media.ts.
+  "location-media": {
+    isPublic: false,
+    maxBytes: 5 * 1024 * 1024,
+    allowedMimeTypes: ["image/jpeg", "image/png", "image/webp"] as const,
+  },
   "dispute-evidence": {
     isPublic: false,
     maxBytes: 10 * 1024 * 1024,

--- a/src/lib/storage/upload.ts
+++ b/src/lib/storage/upload.ts
@@ -42,6 +42,9 @@ const bucketAssetKinds: Record<StorageBucketId, readonly StorageAssetKindDb[]> =
   "traveler-avatars": [],
   "guide-documents": ["guide-document"],
   "listing-media": ["listing-cover", "listing-gallery"],
+  // Location media keeps its editorial metadata on `location_media`, not `storage_assets`,
+  // so no asset kind routes here.
+  "location-media": [],
   "dispute-evidence": ["dispute-evidence"],
 };
 

--- a/src/lib/supabase/database.types.ts
+++ b/src/lib/supabase/database.types.ts
@@ -2659,6 +2659,77 @@ export type Database = {
           },
         ]
       }
+      location_media: {
+        Row: {
+          alt_text: string | null
+          bucket_id: string
+          byte_size: number
+          caption: string | null
+          created_at: string
+          created_by: string | null
+          height: number | null
+          id: string
+          is_primary: boolean
+          location_id: string
+          mime_type: string
+          object_path: string
+          role: string
+          sort_order: number
+          source: string | null
+          status: string
+          updated_at: string
+          width: number | null
+        }
+        Insert: {
+          alt_text?: string | null
+          bucket_id?: string
+          byte_size: number
+          caption?: string | null
+          created_at?: string
+          created_by?: string | null
+          height?: number | null
+          id?: string
+          is_primary?: boolean
+          location_id: string
+          mime_type: string
+          object_path: string
+          role?: string
+          sort_order?: number
+          source?: string | null
+          status?: string
+          updated_at?: string
+          width?: number | null
+        }
+        Update: {
+          alt_text?: string | null
+          bucket_id?: string
+          byte_size?: number
+          caption?: string | null
+          created_at?: string
+          created_by?: string | null
+          height?: number | null
+          id?: string
+          is_primary?: boolean
+          location_id?: string
+          mime_type?: string
+          object_path?: string
+          role?: string
+          sort_order?: number
+          source?: string | null
+          status?: string
+          updated_at?: string
+          width?: number | null
+        }
+        Relationships: [
+          {
+            foreignKeyName: "location_media_location_id_fkey"
+            columns: ["location_id"]
+            isOneToOne: false
+            referencedRelation: "guide_location_catalog"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
       moderation_actions: {
         Row: {
           admin_id: string

--- a/src/lib/supabase/location-media.test.ts
+++ b/src/lib/supabase/location-media.test.ts
@@ -1,0 +1,377 @@
+import { describe, expect, it, vi } from "vitest";
+import type { SupabaseClient } from "@supabase/supabase-js";
+
+import {
+  beginLocationMediaUpload,
+  cancelLocationMediaUpload,
+  confirmLocationMediaUpload,
+  deleteLocationMedia,
+  getPublishedLocationCovers,
+  getPublishedLocationCoversSafe,
+  listLocationMedia,
+  resolveLocationCover,
+  updateLocationMedia,
+} from "./location-media";
+
+type Row = Record<string, unknown>;
+
+function stubClient({
+  rows = [] as Row[],
+  error = null as { message: string } | null,
+  /** Paths the bucket refuses to sign — i.e. objects that are not readable or not there. */
+  unsignable = [] as string[],
+  removeError = null as { message: string } | null,
+} = {}) {
+  const filters: Record<string, unknown> = {};
+  const excluded: Record<string, unknown> = {};
+  const updates: Row[] = [];
+  const inserts: Row[] = [];
+  const deleted: string[][] = [];
+  const signRequests: string[][] = [];
+
+  let rowDeletes = 0;
+  const query: Record<string, unknown> = {};
+  for (const method of ["select", "order"]) {
+    query[method] = () => query;
+  }
+  query.delete = () => {
+    rowDeletes += 1;
+    return query;
+  };
+  query.insert = (row: Row) => {
+    inserts.push(row);
+    return query;
+  };
+  query.eq = (column: string, value: unknown) => {
+    filters[column] = value;
+    return query;
+  };
+  query.neq = (column: string, value: unknown) => {
+    excluded[column] = value;
+    return query;
+  };
+  query.update = (patch: Row) => {
+    updates.push(patch);
+    return query;
+  };
+  query.maybeSingle = () => Promise.resolve({ data: rows[0] ?? null, error });
+  query.single = () => Promise.resolve({ data: rows[0] ?? null, error });
+  query.then = (resolve: (v: unknown) => void) => resolve({ data: rows, error });
+
+  const client = {
+    from: vi.fn(() => query),
+    storage: {
+      from: (bucket: string) => ({
+        createSignedUrls: (paths: string[]) => {
+          signRequests.push(paths);
+          return Promise.resolve({
+            data: paths.map((path) =>
+              unsignable.includes(path)
+                ? { path, signedUrl: null, error: "Object not found" }
+                : { path, signedUrl: `https://signed.test/${bucket}/${path}`, error: null },
+            ),
+            error: null,
+          });
+        },
+        remove: (paths: string[]) => {
+          deleted.push(paths);
+          return Promise.resolve({ data: null, error: removeError });
+        },
+      }),
+    },
+  } as unknown as SupabaseClient;
+
+  return {
+    client,
+    filters,
+    excluded,
+    updates,
+    inserts,
+    deleted,
+    signRequests,
+    rowDeletes: () => rowDeletes,
+  };
+}
+
+const PUBLISHED_COVER: Row = {
+  bucket_id: "location-media",
+  object_path: "admin-1/cover.jpg",
+  guide_location_catalog: { name: " Казань " },
+};
+
+describe("getPublishedLocationCovers", () => {
+  it("only ever asks for published primary covers — drafts must not reach public pages", async () => {
+    const { client, filters } = stubClient({ rows: [PUBLISHED_COVER] });
+
+    await getPublishedLocationCovers(client);
+
+    expect(filters).toEqual({ status: "published", role: "cover", is_primary: true });
+  });
+
+  it("keys covers by normalised location name and signs the object", async () => {
+    const { client } = stubClient({ rows: [PUBLISHED_COVER] });
+
+    const covers = await getPublishedLocationCovers(client);
+
+    expect(covers.get("казань")).toBe(
+      "https://signed.test/location-media/admin-1/cover.jpg",
+    );
+  });
+
+  it("never emits an unsigned public URL", async () => {
+    const { client } = stubClient({ rows: [PUBLISHED_COVER] });
+
+    const covers = await getPublishedLocationCovers(client);
+
+    expect([...covers.values()].every((url) => url.includes("/signed.test/"))).toBe(true);
+  });
+
+  it("drops a cover the bucket refuses to sign rather than guessing a URL", async () => {
+    const { client } = stubClient({
+      rows: [PUBLISHED_COVER],
+      unsignable: ["admin-1/cover.jpg"],
+    });
+
+    expect((await getPublishedLocationCovers(client)).size).toBe(0);
+  });
+
+  it("tolerates the embed arriving as an array", async () => {
+    const { client } = stubClient({
+      rows: [{ ...PUBLISHED_COVER, guide_location_catalog: [{ name: "Сочи" }] }],
+    });
+
+    const covers = await getPublishedLocationCovers(client);
+
+    expect(covers.has("сочи")).toBe(true);
+  });
+
+  it("skips rows whose location relation is missing", async () => {
+    const { client } = stubClient({
+      rows: [{ ...PUBLISHED_COVER, guide_location_catalog: null }],
+    });
+
+    expect((await getPublishedLocationCovers(client)).size).toBe(0);
+  });
+
+  it("throws on a query error so callers decide the fallback", async () => {
+    const { client } = stubClient({ error: { message: "boom" } });
+
+    await expect(getPublishedLocationCovers(client)).rejects.toThrow("boom");
+  });
+
+  it("degrades to an empty map in the safe wrapper — media must not break /requests", async () => {
+    const { client } = stubClient({ error: { message: "boom" } });
+
+    expect((await getPublishedLocationCoversSafe(client)).size).toBe(0);
+  });
+});
+
+describe("resolveLocationCover", () => {
+  const covers = new Map([["казань", "https://signed.test/kazan.jpg"]]);
+
+  it("matches case- and whitespace-insensitively", () => {
+    expect(resolveLocationCover(covers, "  КАЗАНЬ ")).toBe("https://signed.test/kazan.jpg");
+  });
+
+  it("returns null for an uncovered destination so the branded gradient stays", () => {
+    expect(resolveLocationCover(covers, "Элиста")).toBeNull();
+  });
+
+  it("returns null for an empty destination", () => {
+    expect(resolveLocationCover(covers, "")).toBeNull();
+    expect(resolveLocationCover(covers, null)).toBeNull();
+  });
+});
+
+const DRAFT_ROW: Row = {
+  id: "m-1",
+  location_id: "loc-1",
+  bucket_id: "location-media",
+  object_path: "admin-1/cover.webp",
+  role: "cover",
+  status: "draft",
+  is_primary: false,
+  alt_text: "Казанский кремль",
+  caption: "Вид с реки",
+  source: "Куратор",
+  mime_type: "image/webp",
+  byte_size: 204800,
+  width: 1600,
+  height: 900,
+  sort_order: 0,
+  created_at: "2026-07-20T00:00:00Z",
+};
+
+describe("listLocationMedia", () => {
+  it("maps a row to a record with metadata and a signed URL", async () => {
+    const { client } = stubClient({ rows: [DRAFT_ROW] });
+
+    const [record] = await listLocationMedia(client, "loc-1");
+
+    expect(record).toMatchObject({
+      id: "m-1",
+      status: "draft",
+      isPrimary: false,
+      altText: "Казанский кремль",
+      caption: "Вид с реки",
+      source: "Куратор",
+      mimeType: "image/webp",
+      byteSize: 204800,
+      width: 1600,
+      height: 900,
+      signedUrl: "https://signed.test/location-media/admin-1/cover.webp",
+    });
+  });
+
+  it("leaves signedUrl null when the object never landed", async () => {
+    const { client } = stubClient({
+      rows: [{ ...DRAFT_ROW, status: "uploading" }],
+      unsignable: ["admin-1/cover.webp"],
+    });
+
+    const [record] = await listLocationMedia(client, "loc-1");
+
+    expect(record.signedUrl).toBeNull();
+  });
+});
+
+describe("beginLocationMediaUpload", () => {
+  it("reserves the row as uploading so a failed upload is never unmanaged", async () => {
+    const { client, inserts } = stubClient({ rows: [{ id: "m-1" }] });
+
+    const id = await beginLocationMediaUpload(client, {
+      locationId: "loc-1",
+      objectPath: "admin-1/cover.jpg",
+      role: "cover",
+      mimeType: "image/jpeg",
+      byteSize: 1024,
+      width: 1600,
+      height: 900,
+      altText: null,
+      caption: null,
+      source: null,
+      createdBy: "admin-1",
+    });
+
+    expect(id).toBe("m-1");
+    expect(inserts[0]).toMatchObject({ status: "uploading", object_path: "admin-1/cover.jpg" });
+  });
+});
+
+describe("confirmLocationMediaUpload", () => {
+  it("moves the reservation to draft, and only from uploading", async () => {
+    const { client, updates, filters } = stubClient({ rows: [{ id: "m-1" }] });
+
+    await confirmLocationMediaUpload(client, "m-1");
+
+    expect(updates).toEqual([{ status: "draft" }]);
+    expect(filters).toEqual({ id: "m-1", status: "uploading" });
+  });
+
+  it("throws when there is no reservation to confirm", async () => {
+    const { client } = stubClient({ rows: [] });
+
+    await expect(confirmLocationMediaUpload(client, "m-1")).rejects.toThrow(
+      "Загрузка не найдена или уже подтверждена.",
+    );
+  });
+});
+
+describe("cancelLocationMediaUpload", () => {
+  it("removes the object and the reservation", async () => {
+    const { client, deleted, filters } = stubClient({
+      rows: [{ bucket_id: "location-media", object_path: "admin-1/cover.jpg" }],
+    });
+
+    await cancelLocationMediaUpload(client, "m-1");
+
+    expect(deleted).toEqual([["admin-1/cover.jpg"]]);
+    expect(filters.status).toBe("uploading");
+  });
+
+  it("keeps the row when storage removal fails, so the object stays recoverable", async () => {
+    const { client, rowDeletes } = stubClient({
+      rows: [{ bucket_id: "location-media", object_path: "admin-1/cover.jpg" }],
+      removeError: { message: "network" },
+    });
+
+    await expect(cancelLocationMediaUpload(client, "m-1")).rejects.toThrow(
+      "Файл не удалён из хранилища: network",
+    );
+    expect(rowDeletes()).toBe(0);
+  });
+
+  it("is a no-op when the row is already gone", async () => {
+    const { client, deleted } = stubClient({ rows: [] });
+
+    await cancelLocationMediaUpload(client, "m-1");
+
+    expect(deleted).toEqual([]);
+  });
+});
+
+describe("updateLocationMedia", () => {
+  it("sends only the supplied columns", async () => {
+    const { client, updates } = stubClient();
+
+    await updateLocationMedia(client, "m-1", { status: "published", isPrimary: true });
+
+    expect(updates).toEqual([{ status: "published", is_primary: true }]);
+  });
+
+  it("refuses to touch a row that is still uploading", async () => {
+    const { client, excluded } = stubClient();
+
+    await updateLocationMedia(client, "m-1", { status: "published" });
+
+    expect(excluded).toEqual({ status: "uploading" });
+  });
+
+  it("writes an explicit null when metadata is cleared", async () => {
+    const { client, updates } = stubClient();
+
+    await updateLocationMedia(client, "m-1", { caption: null });
+
+    expect(updates).toEqual([{ caption: null }]);
+  });
+
+  it("does not issue an update for an empty patch", async () => {
+    const { client, updates } = stubClient();
+
+    await updateLocationMedia(client, "m-1", {});
+
+    expect(updates).toEqual([]);
+  });
+});
+
+describe("deleteLocationMedia", () => {
+  it("removes the storage object too — a dangling file is invisible waste", async () => {
+    const { client, deleted } = stubClient({
+      rows: [{ bucket_id: "location-media", object_path: "admin-1/cover.jpg" }],
+    });
+
+    await deleteLocationMedia(client, "m-1");
+
+    expect(deleted).toEqual([["admin-1/cover.jpg"]]);
+  });
+
+  it("keeps the row when storage removal fails, so the object stays recoverable", async () => {
+    const { client, rowDeletes } = stubClient({
+      rows: [{ bucket_id: "location-media", object_path: "admin-1/cover.jpg" }],
+      removeError: { message: "network" },
+    });
+
+    await expect(deleteLocationMedia(client, "m-1")).rejects.toThrow(
+      "Файл не удалён из хранилища: network",
+    );
+    expect(rowDeletes()).toBe(0);
+  });
+
+  it("is a no-op when the row is already gone", async () => {
+    const { client, deleted } = stubClient({ rows: [] });
+
+    await deleteLocationMedia(client, "m-1");
+
+    expect(deleted).toEqual([]);
+  });
+});

--- a/src/lib/supabase/location-media.ts
+++ b/src/lib/supabase/location-media.ts
@@ -1,0 +1,371 @@
+import type { SupabaseClient } from "@supabase/supabase-js";
+
+import type { Uuid } from "@/lib/supabase/types";
+
+export const LOCATION_MEDIA_BUCKET = "location-media" as const;
+
+/** Long enough for an admin to work through a page of media, short enough to expire. */
+const LOCATION_MEDIA_URL_TTL_SECONDS = 60 * 60;
+
+export type LocationMediaRole = "cover" | "gallery";
+/** `uploading` = row reserved before the signed upload URL was issued; never public. */
+export type LocationMediaStatus = "uploading" | "draft" | "published";
+
+export type LocationMediaRecord = {
+  id: Uuid;
+  locationId: Uuid;
+  bucketId: string;
+  objectPath: string;
+  /** Short-lived signed URL; null when the object is missing (upload never completed). */
+  signedUrl: string | null;
+  role: LocationMediaRole;
+  status: LocationMediaStatus;
+  isPrimary: boolean;
+  altText: string | null;
+  caption: string | null;
+  source: string | null;
+  mimeType: string;
+  byteSize: number;
+  width: number | null;
+  height: number | null;
+  sortOrder: number;
+  createdAt: string;
+};
+
+type LocationMediaRow = {
+  id: string;
+  location_id: string;
+  bucket_id: string;
+  object_path: string;
+  role: LocationMediaRole;
+  status: LocationMediaStatus;
+  is_primary: boolean;
+  alt_text: string | null;
+  caption: string | null;
+  source: string | null;
+  mime_type: string;
+  byte_size: number;
+  width: number | null;
+  height: number | null;
+  sort_order: number;
+  created_at: string;
+};
+
+const MEDIA_COLUMNS =
+  "id, location_id, bucket_id, object_path, role, status, is_primary, alt_text, caption, source, mime_type, byte_size, width, height, sort_order, created_at";
+
+/**
+ * The bucket is private, so a URL has to be signed by a caller the object policy admits:
+ * an admin for anything, or any client for a published primary cover. Signing is best
+ * effort per path — a row whose upload never landed simply has no URL.
+ */
+async function signLocationMediaUrls(
+  client: SupabaseClient,
+  objects: readonly { bucketId: string; objectPath: string }[],
+): Promise<Map<string, string>> {
+  const signed = new Map<string, string>();
+  const byBucket = new Map<string, string[]>();
+  for (const { bucketId, objectPath } of objects) {
+    const paths = byBucket.get(bucketId) ?? [];
+    paths.push(objectPath);
+    byBucket.set(bucketId, paths);
+  }
+
+  for (const [bucketId, paths] of byBucket) {
+    const { data } = await client.storage
+      .from(bucketId)
+      .createSignedUrls(paths, LOCATION_MEDIA_URL_TTL_SECONDS);
+    for (const entry of data ?? []) {
+      if (entry.path && entry.signedUrl) signed.set(signedKey(bucketId, entry.path), entry.signedUrl);
+    }
+  }
+  return signed;
+}
+
+function signedKey(bucketId: string, objectPath: string) {
+  return `${bucketId}\n${objectPath}`;
+}
+
+function toRecord(row: LocationMediaRow, signed: Map<string, string>): LocationMediaRecord {
+  return {
+    id: row.id,
+    locationId: row.location_id,
+    bucketId: row.bucket_id,
+    objectPath: row.object_path,
+    signedUrl: signed.get(signedKey(row.bucket_id, row.object_path)) ?? null,
+    role: row.role,
+    status: row.status,
+    isPrimary: row.is_primary,
+    altText: row.alt_text,
+    caption: row.caption,
+    source: row.source,
+    mimeType: row.mime_type,
+    byteSize: row.byte_size,
+    width: row.width,
+    height: row.height,
+    sortOrder: row.sort_order,
+    createdAt: row.created_at,
+  };
+}
+
+/** Every asset for one location, drafts included. Admin (service-role) client only. */
+export async function listLocationMedia(
+  adminClient: SupabaseClient,
+  locationId: string,
+): Promise<LocationMediaRecord[]> {
+  const { data, error } = await adminClient
+    .from("location_media")
+    .select(MEDIA_COLUMNS)
+    .eq("location_id", locationId)
+    .order("sort_order", { ascending: true })
+    .order("created_at", { ascending: true });
+  if (error) throw new Error(error.message);
+
+  const rows = (data ?? []) as LocationMediaRow[];
+  const signed = await signLocationMediaUrls(
+    adminClient,
+    rows.map((row) => ({ bucketId: row.bucket_id, objectPath: row.object_path })),
+  );
+  return rows.map((row) => toRecord(row, signed));
+}
+
+export async function getLocation(
+  adminClient: SupabaseClient,
+  locationId: string,
+): Promise<{ id: Uuid; name: string; status: "active" | "retired" } | null> {
+  const { data, error } = await adminClient
+    .from("guide_location_catalog")
+    .select("id, name, status")
+    .eq("id", locationId)
+    .maybeSingle();
+  if (error) throw new Error(error.message);
+  return (data as { id: Uuid; name: string; status: "active" | "retired" } | null) ?? null;
+}
+
+/**
+ * Reserves the row *before* the signed upload URL is issued, as `uploading`.
+ *
+ * The order matters: if the browser dies between the signed URL and confirmation, the
+ * storage object is still owned by a row an admin can see and cancel. Reserving after the
+ * upload instead would leave unmanaged objects nobody can enumerate.
+ */
+export async function beginLocationMediaUpload(
+  adminClient: SupabaseClient,
+  input: {
+    locationId: string;
+    objectPath: string;
+    role: LocationMediaRole;
+    mimeType: string;
+    byteSize: number;
+    width: number | null;
+    height: number | null;
+    altText: string | null;
+    caption: string | null;
+    source: string | null;
+    createdBy: string;
+  },
+): Promise<Uuid> {
+  const { data, error } = await adminClient
+    .from("location_media")
+    .insert({
+      location_id: input.locationId,
+      bucket_id: LOCATION_MEDIA_BUCKET,
+      object_path: input.objectPath,
+      role: input.role,
+      status: "uploading",
+      mime_type: input.mimeType,
+      byte_size: input.byteSize,
+      width: input.width,
+      height: input.height,
+      alt_text: input.altText,
+      caption: input.caption,
+      source: input.source,
+      created_by: input.createdBy,
+    })
+    .select("id")
+    .single();
+  if (error || !data) throw new Error(error?.message ?? "Не удалось сохранить медиа.");
+  return (data as { id: Uuid }).id;
+}
+
+/** Promotes a reserved row to `draft` once its bytes are in storage. */
+export async function confirmLocationMediaUpload(
+  adminClient: SupabaseClient,
+  id: string,
+): Promise<void> {
+  const { data, error } = await adminClient
+    .from("location_media")
+    .update({ status: "draft" })
+    .eq("id", id)
+    .eq("status", "uploading")
+    .select("id")
+    .maybeSingle();
+  if (error) throw new Error(error.message);
+  if (!data) throw new Error("Загрузка не найдена или уже подтверждена.");
+}
+
+async function getMediaObject(
+  adminClient: SupabaseClient,
+  id: string,
+): Promise<{ bucket_id: string; object_path: string } | null> {
+  const { data, error } = await adminClient
+    .from("location_media")
+    .select("bucket_id, object_path")
+    .eq("id", id)
+    .maybeSingle();
+  if (error) throw new Error(error.message);
+  return (data as { bucket_id: string; object_path: string } | null) ?? null;
+}
+
+/**
+ * Removes the backing object, failing loudly. Supabase does not report removing a path
+ * that holds no bytes as an error, so the "file never left the browser" case still
+ * cleans up; anything that *is* an error must keep the row, and with it the path.
+ */
+async function removeMediaObject(
+  adminClient: SupabaseClient,
+  object: { bucket_id: string; object_path: string },
+): Promise<void> {
+  const { error } = await adminClient.storage
+    .from(object.bucket_id)
+    .remove([object.object_path]);
+  if (error) throw new Error(`Файл не удалён из хранилища: ${error.message}`);
+}
+
+/**
+ * Cancels a reserved upload. As strict as a normal delete: an abandoned upload is the
+ * common case and cleans up silently, but a real storage failure must not drop the only
+ * row that knows the object exists.
+ */
+export async function cancelLocationMediaUpload(
+  adminClient: SupabaseClient,
+  id: string,
+): Promise<void> {
+  const object = await getMediaObject(adminClient, id);
+  if (!object) return;
+
+  await removeMediaObject(adminClient, object);
+
+  const { error } = await adminClient
+    .from("location_media")
+    .delete()
+    .eq("id", id)
+    .eq("status", "uploading");
+  if (error) throw new Error(error.message);
+}
+
+export async function updateLocationMedia(
+  adminClient: SupabaseClient,
+  id: string,
+  patch: {
+    altText?: string | null;
+    caption?: string | null;
+    source?: string | null;
+    role?: LocationMediaRole;
+    status?: LocationMediaStatus;
+    isPrimary?: boolean;
+  },
+): Promise<void> {
+  const row: Record<string, unknown> = {};
+  if ("altText" in patch) row.alt_text = patch.altText;
+  if ("caption" in patch) row.caption = patch.caption;
+  if ("source" in patch) row.source = patch.source;
+  if (patch.role !== undefined) row.role = patch.role;
+  if (patch.status !== undefined) row.status = patch.status;
+  if (patch.isPrimary !== undefined) row.is_primary = patch.isPrimary;
+  // ponytail: no reorder writer yet — `sort_order` only gives list reads a stable
+  // order. Add one here when the console grows drag-to-reorder.
+  if (Object.keys(row).length === 0) return;
+
+  // An `uploading` row has no confirmed bytes behind it, so no edit — least of all
+  // publishing it — may apply until confirmLocationMediaUpload has moved it to draft.
+  const { error } = await adminClient
+    .from("location_media")
+    .update(row)
+    .eq("id", id)
+    .neq("status", "uploading");
+  if (error) throw new Error(error.message);
+}
+
+/**
+ * Deletes the storage object first, then its row.
+ *
+ * Order and strictness are both deliberate: dropping the row first and then failing to
+ * remove the object leaves a file no query can find. Failing loudly instead keeps the
+ * record — and therefore the object path — recoverable, so the admin can retry.
+ */
+export async function deleteLocationMedia(
+  adminClient: SupabaseClient,
+  id: string,
+): Promise<void> {
+  const object = await getMediaObject(adminClient, id);
+  if (!object) return;
+
+  await removeMediaObject(adminClient, object);
+
+  const { error } = await adminClient.from("location_media").delete().eq("id", id);
+  if (error) throw new Error(error.message);
+}
+
+/**
+ * Published primary covers keyed by lower-cased location name — the public request
+ * surfaces match on the free-text destination label, not a foreign key.
+ *
+ * ponytail: reads every published primary cover (one row per canonical location, tens
+ * of rows today). Filter by the requested destinations if the catalogue passes ~500.
+ */
+export async function getPublishedLocationCovers(
+  client: SupabaseClient,
+): Promise<Map<string, string>> {
+  const { data, error } = await client
+    .from("location_media")
+    .select("bucket_id, object_path, guide_location_catalog!inner(name)")
+    .eq("status", "published")
+    .eq("role", "cover")
+    .eq("is_primary", true);
+  if (error) throw new Error(error.message);
+
+  const rows = (data ?? []) as unknown as {
+    bucket_id: string;
+    object_path: string;
+    guide_location_catalog: { name: string } | { name: string }[] | null;
+  }[];
+  // Signing is what the object SELECT policy gates, so an unpublished or demoted row can
+  // never yield a URL even if it somehow reached this list.
+  const signed = await signLocationMediaUrls(
+    client,
+    rows.map((row) => ({ bucketId: row.bucket_id, objectPath: row.object_path })),
+  );
+
+  const covers = new Map<string, string>();
+  for (const row of rows) {
+    const relation = Array.isArray(row.guide_location_catalog)
+      ? row.guide_location_catalog[0]
+      : row.guide_location_catalog;
+    if (!relation?.name) continue;
+    const url = signed.get(signedKey(row.bucket_id, row.object_path));
+    if (!url) continue;
+    covers.set(relation.name.trim().toLocaleLowerCase("ru-RU"), url);
+  }
+  return covers;
+}
+
+/** Published cover for a destination label, or null so callers keep the branded fallback. */
+export function resolveLocationCover(
+  covers: Map<string, string>,
+  destination: string | null | undefined,
+): string | null {
+  if (!destination) return null;
+  return covers.get(destination.trim().toLocaleLowerCase("ru-RU")) ?? null;
+}
+
+/** Never throws: a media outage must not take the public marketplace down. */
+export async function getPublishedLocationCoversSafe(
+  client: SupabaseClient,
+): Promise<Map<string, string>> {
+  try {
+    return await getPublishedLocationCovers(client);
+  } catch {
+    return new Map();
+  }
+}

--- a/supabase/migrations/20260720000000_location_media.sql
+++ b/supabase/migrations/20260720000000_location_media.sql
@@ -1,0 +1,138 @@
+-- Destination media — one admin-curated, reusable cover per canonical location.
+--
+-- Public request cards and request heroes currently render `cityImage()`, a branded
+-- blue gradient, for every destination. That is the correct *fallback* but a poor
+-- default once a curator has a real city photo. Rather than attaching photography to
+-- each request (duplicated uploads, no review), media hangs off the canonical
+-- `guide_location_catalog` row and is resolved by destination name.
+--
+-- Boundary: admins are the only writers. Public readers see PUBLISHED rows only, so an
+-- unpublished/draft object path never reaches a public page. The bucket is PRIVATE — a
+-- public bucket bypasses object RLS entirely, so a guessed draft path would be readable.
+-- Every image URL is therefore a short-lived signed URL. Guide-owned Photobank
+-- (`guide_location_photos`) is untouched — this is editorial, curator-owned media.
+CREATE TABLE IF NOT EXISTS public.location_media (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  location_id uuid NOT NULL REFERENCES public.guide_location_catalog(id) ON DELETE CASCADE,
+  bucket_id text NOT NULL DEFAULT 'location-media',
+  object_path text NOT NULL,
+  role text NOT NULL DEFAULT 'cover',
+  status text NOT NULL DEFAULT 'draft',
+  is_primary boolean NOT NULL DEFAULT false,
+  alt_text text,
+  caption text,
+  source text,
+  mime_type text NOT NULL,
+  byte_size integer NOT NULL,
+  width integer,
+  height integer,
+  sort_order integer NOT NULL DEFAULT 0,
+  created_by uuid REFERENCES auth.users(id) ON DELETE SET NULL,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  updated_at timestamptz NOT NULL DEFAULT now(),
+  CONSTRAINT location_media_role_check CHECK (role IN ('cover', 'gallery')),
+  -- `uploading` is reserved for a record created *before* its signed upload URL is
+  -- issued, so a browser that dies mid-upload still leaves a row an admin can cancel
+  -- instead of an unmanaged storage object nobody knows about.
+  CONSTRAINT location_media_status_check CHECK (status IN ('uploading', 'draft', 'published')),
+  CONSTRAINT location_media_mime_check
+    CHECK (mime_type IN ('image/jpeg', 'image/png', 'image/webp')),
+  CONSTRAINT location_media_byte_size_check CHECK (byte_size > 0 AND byte_size <= 5242880),
+  CONSTRAINT location_media_dimensions_check
+    CHECK ((width IS NULL OR width > 0) AND (height IS NULL OR height > 0)),
+  -- The primary flag means "this is the asset the public resolver serves", so it can only
+  -- sit on a row the public can actually reach. Without this, unpublishing or demoting a
+  -- primary to gallery leaves `is_primary = true` on an invisible row, and the location
+  -- then has a primary that resolves to nothing while the unique index blocks a
+  -- replacement.
+  CONSTRAINT location_media_primary_is_published_cover
+    CHECK (NOT is_primary OR (role = 'cover' AND status = 'published'))
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS location_media_object_path_key
+  ON public.location_media (bucket_id, object_path);
+
+-- At most one primary per location: the resolver picks a cover without tie-breaking.
+CREATE UNIQUE INDEX IF NOT EXISTS location_media_one_primary_per_location
+  ON public.location_media (location_id) WHERE is_primary;
+
+CREATE INDEX IF NOT EXISTS location_media_location_idx
+  ON public.location_media (location_id, sort_order);
+
+-- Promoting a row to primary demotes its siblings atomically, so the admin console
+-- never has to run a two-statement swap that could trip the unique index mid-flight.
+CREATE OR REPLACE FUNCTION public.location_media_demote_siblings()
+RETURNS trigger
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+BEGIN
+  IF NEW.is_primary THEN
+    UPDATE public.location_media
+       SET is_primary = false, updated_at = now()
+     WHERE location_id = NEW.location_id
+       AND id <> NEW.id
+       AND is_primary;
+  END IF;
+  NEW.updated_at := now();
+  RETURN NEW;
+END;
+$$;
+
+DROP TRIGGER IF EXISTS location_media_primary_guard ON public.location_media;
+CREATE TRIGGER location_media_primary_guard
+  BEFORE INSERT OR UPDATE ON public.location_media
+  FOR EACH ROW EXECUTE FUNCTION public.location_media_demote_siblings();
+
+ALTER TABLE public.location_media ENABLE ROW LEVEL SECURITY;
+
+-- Public read is limited to published media. Admins additionally see drafts.
+DROP POLICY IF EXISTS location_media_published_read ON public.location_media;
+CREATE POLICY location_media_published_read ON public.location_media
+  FOR SELECT USING (status = 'published' OR public.is_admin());
+
+DROP POLICY IF EXISTS location_media_admin_write ON public.location_media;
+CREATE POLICY location_media_admin_write ON public.location_media
+  USING (public.is_admin()) WITH CHECK (public.is_admin());
+
+GRANT SELECT ON TABLE public.location_media TO anon, authenticated;
+GRANT ALL ON TABLE public.location_media TO service_role;
+
+-- Dedicated PRIVATE bucket (mirrors src/lib/storage/buckets.ts). Private is load-bearing:
+-- a public bucket serves every object by path with no policy check, which would expose
+-- `uploading`/`draft` files to anyone who guesses or once saw a path.
+INSERT INTO storage.buckets (id, name, public, file_size_limit, allowed_mime_types)
+VALUES ('location-media', 'location-media', false, 5242880,
+        array['image/jpeg', 'image/png', 'image/webp'])
+ON CONFLICT (id) DO UPDATE SET public = excluded.public;
+
+-- Object-level boundary. Uploads run through a service-role signed URL (which bypasses
+-- RLS), so these policies exist to stop a signed-in non-admin writing to the bucket
+-- directly with their own token.
+--
+-- SELECT is what gates *minting a signed URL*, so it is deliberately narrow: an object is
+-- readable only when a published, primary `cover` row points at it. Drafts, uploading
+-- records, gallery assets and demoted covers stay admin-only.
+DROP POLICY IF EXISTS location_media_objects_public_read ON storage.objects;
+CREATE POLICY location_media_objects_public_read ON storage.objects
+  FOR SELECT USING (
+    bucket_id = 'location-media'
+    AND (
+      public.is_admin()
+      OR EXISTS (
+        SELECT 1
+          FROM public.location_media m
+         WHERE m.bucket_id = storage.objects.bucket_id
+           AND m.object_path = storage.objects.name
+           AND m.status = 'published'
+           AND m.role = 'cover'
+           AND m.is_primary
+      )
+    )
+  );
+
+DROP POLICY IF EXISTS location_media_objects_admin_write ON storage.objects;
+CREATE POLICY location_media_objects_admin_write ON storage.objects
+  USING (bucket_id = 'location-media' AND public.is_admin())
+  WITH CHECK (bucket_id = 'location-media' AND public.is_admin());

--- a/supabase/tests/location_media_rls_test.sql
+++ b/supabase/tests/location_media_rls_test.sql
@@ -1,0 +1,261 @@
+-- Destination media boundary: only admins write location media, and the public
+-- may read PUBLISHED rows only (an unpublished object path must never leak).
+begin;
+
+create extension if not exists pgtap with schema extensions;
+set search_path = public, extensions;
+
+select plan(18);
+
+insert into auth.users (
+  id, instance_id, aud, role, email, encrypted_password, email_confirmed_at,
+  raw_app_meta_data, raw_user_meta_data, created_at, updated_at, is_sso_user,
+  confirmation_token, email_change, email_change_token_new, recovery_token
+)
+values
+  (
+    '7b000000-0000-4000-8000-000000000001',
+    '00000000-0000-0000-0000-000000000000',
+    'authenticated', 'authenticated', 'media-admin@example.test',
+    extensions.crypt('MediaAdmin123!', extensions.gen_salt('bf')),
+    timezone('utc', now()),
+    '{"provider":"email","providers":["email"]}'::jsonb, '{}'::jsonb,
+    timezone('utc', now()), timezone('utc', now()), false, '', '', '', ''
+  ),
+  (
+    '7b000000-0000-4000-8000-000000000002',
+    '00000000-0000-0000-0000-000000000000',
+    'authenticated', 'authenticated', 'media-outsider@example.test',
+    extensions.crypt('MediaOutsider123!', extensions.gen_salt('bf')),
+    timezone('utc', now()),
+    '{"provider":"email","providers":["email"]}'::jsonb, '{}'::jsonb,
+    timezone('utc', now()), timezone('utc', now()), false, '', '', '', ''
+  )
+on conflict (id) do update set email = excluded.email;
+
+update public.profiles
+   set role = 'admin'::public.app_role,
+       account_status = 'active'::public.account_status
+ where id = '7b000000-0000-4000-8000-000000000001';
+
+update public.profiles
+   set role = 'traveler'::public.app_role,
+       account_status = 'active'::public.account_status
+ where id = '7b000000-0000-4000-8000-000000000002';
+
+insert into public.guide_location_catalog (id, name, status)
+values ('7c000000-0000-4000-8000-000000000001', 'Тестоград', 'active')
+on conflict (id) do nothing;
+
+insert into public.location_media
+  (id, location_id, object_path, role, status, is_primary, mime_type, byte_size)
+values
+  ('7d000000-0000-4000-8000-000000000001',
+   '7c000000-0000-4000-8000-000000000001',
+   'curator/published-cover.jpg', 'cover', 'published', true, 'image/jpeg', 100000),
+  ('7d000000-0000-4000-8000-000000000002',
+   '7c000000-0000-4000-8000-000000000001',
+   'curator/draft-cover.jpg', 'cover', 'draft', false, 'image/jpeg', 100000),
+  -- A published cover that is NOT primary, and a row reserved before its upload: both
+  -- must be as unreadable at the object level as an outright draft.
+  ('7d000000-0000-4000-8000-000000000003',
+   '7c000000-0000-4000-8000-000000000001',
+   'curator/published-secondary.jpg', 'cover', 'published', false, 'image/jpeg', 100000),
+  ('7d000000-0000-4000-8000-000000000004',
+   '7c000000-0000-4000-8000-000000000001',
+   'curator/uploading.jpg', 'cover', 'uploading', false, 'image/jpeg', 100000);
+
+-- Storage objects backing those rows. The bucket is private, so `storage.objects` SELECT
+-- is what decides whether a caller may mint a signed URL for a path.
+select is(
+  (select public from storage.buckets where id = 'location-media'),
+  false,
+  'the location-media bucket is private — a public bucket would bypass object RLS'
+);
+
+insert into storage.objects (bucket_id, name, metadata)
+values
+  ('location-media', 'curator/published-cover.jpg', '{}'::jsonb),
+  ('location-media', 'curator/draft-cover.jpg', '{}'::jsonb),
+  ('location-media', 'curator/published-secondary.jpg', '{}'::jsonb),
+  ('location-media', 'curator/uploading.jpg', '{}'::jsonb)
+on conflict (bucket_id, name) do update set metadata = excluded.metadata;
+
+-- Anonymous public reader ------------------------------------------------------
+set local role anon;
+select set_config('request.jwt.claim.role', 'anon', true);
+select set_config('request.jwt.claim.sub', '', true);
+
+select results_eq(
+  $$ select object_path from public.location_media order by object_path $$,
+  $$ values ('curator/published-cover.jpg'::text),
+            ('curator/published-secondary.jpg'::text) $$,
+  'anonymous readers see published location media only — no draft or uploading path leaks'
+);
+
+-- Direct object reads: only the published PRIMARY cover may be signed by the public.
+select results_eq(
+  $$
+    select name from storage.objects
+     where bucket_id = 'location-media'
+     order by name
+  $$,
+  $$ values ('curator/published-cover.jpg'::text) $$,
+  'anonymous callers can read only the object behind the published primary cover'
+);
+
+select is(
+  (
+    select count(*)::integer from storage.objects
+     where bucket_id = 'location-media'
+       and name = 'curator/draft-cover.jpg'
+  ),
+  0,
+  'a draft object cannot be read directly even when its path is known'
+);
+
+select is(
+  (
+    select count(*)::integer from storage.objects
+     where bucket_id = 'location-media'
+       and name = 'curator/uploading.jpg'
+  ),
+  0,
+  'an object reserved by an uploading record cannot be read directly'
+);
+
+select is(
+  (
+    select count(*)::integer from storage.objects
+     where bucket_id = 'location-media'
+       and name = 'curator/published-secondary.jpg'
+  ),
+  0,
+  'a published but non-primary object cannot be read directly'
+);
+
+select throws_ok(
+  $$
+    insert into public.location_media (location_id, object_path, mime_type, byte_size)
+    values ('7c000000-0000-4000-8000-000000000001', 'anon/hack.jpg', 'image/jpeg', 10)
+  $$,
+  '42501',
+  NULL,
+  'anonymous users cannot insert location media'
+);
+
+-- Signed-in non-admin ----------------------------------------------------------
+set local role authenticated;
+select set_config('request.jwt.claim.role', 'authenticated', true);
+select set_config('request.jwt.claim.sub', '7b000000-0000-4000-8000-000000000002', true);
+
+select is(
+  (select count(*)::integer from public.location_media where status = 'draft'),
+  0,
+  'a signed-in non-admin cannot read draft location media'
+);
+
+select is(
+  (
+    select count(*)::integer from storage.objects
+     where bucket_id = 'location-media'
+       and name in ('curator/draft-cover.jpg', 'curator/uploading.jpg')
+  ),
+  0,
+  'a signed-in non-admin cannot read draft or uploading objects directly'
+);
+
+select throws_ok(
+  $$
+    insert into public.location_media (location_id, object_path, mime_type, byte_size)
+    values ('7c000000-0000-4000-8000-000000000001', 'traveler/hack.jpg', 'image/jpeg', 10)
+  $$,
+  '42501',
+  NULL,
+  'a signed-in non-admin cannot insert location media'
+);
+
+-- RLS makes this a silent no-op rather than an error; the assertion below (run as an
+-- admin, who can actually see the row) proves the draft was never published.
+update public.location_media
+   set status = 'published'
+ where id = '7d000000-0000-4000-8000-000000000002';
+
+-- Admin ------------------------------------------------------------------------
+select set_config('request.jwt.claim.sub', '7b000000-0000-4000-8000-000000000001', true);
+
+select is(
+  (select status from public.location_media where id = '7d000000-0000-4000-8000-000000000002'),
+  'draft',
+  'a signed-in non-admin cannot publish location media'
+);
+
+select is(
+  (select count(*)::integer from public.location_media),
+  4,
+  'an admin sees drafts and uploading records alongside published media'
+);
+
+select is(
+  (select count(*)::integer from storage.objects where bucket_id = 'location-media'),
+  4,
+  'an admin can read every object in the bucket, drafts included'
+);
+
+-- The primary flag may only sit on a row the public resolver can actually serve.
+select throws_ok(
+  $$
+    update public.location_media
+       set is_primary = true
+     where id = '7d000000-0000-4000-8000-000000000002'
+  $$,
+  '23514',
+  NULL,
+  'a draft cannot be made primary — a primary that resolves to nothing is not a cover'
+);
+
+select lives_ok(
+  $$
+    update public.location_media
+       set is_primary = true, status = 'published'
+     where id = '7d000000-0000-4000-8000-000000000002'
+  $$,
+  'an admin can promote another asset to primary by publishing it as a cover'
+);
+
+select is(
+  (
+    select count(*)::integer
+      from public.location_media
+     where location_id = '7c000000-0000-4000-8000-000000000001'
+       and is_primary
+  ),
+  1,
+  'promoting a new primary demotes the previous one — never two covers per location'
+);
+
+select throws_ok(
+  $$
+    update public.location_media
+       set status = 'draft'
+     where id = '7d000000-0000-4000-8000-000000000002'
+  $$,
+  '23514',
+  NULL,
+  'unpublishing a primary must clear the flag, not leave a primary nobody can read'
+);
+
+select throws_ok(
+  $$
+    update public.location_media
+       set role = 'gallery'
+     where id = '7d000000-0000-4000-8000-000000000002'
+  $$,
+  '23514',
+  NULL,
+  'demoting a primary to gallery must clear the flag too'
+);
+
+select * from finish();
+
+rollback;


### PR DESCRIPTION
## Scope
- Admin → Locations media console with metadata, role, publishing, primary cover and deletion
- Private media storage with signed public-cover delivery only
- Published primary covers replace request-card and request-hero fallbacks

## Verification
- bun run check
- bun run test:run (1,453 tests)
- bun run build
- git diff --check

## CI gate
The local Docker/Supabase image is corrupted, so the fresh database gate must pass in GitHub CI before merge.