### PR TITLE
fix(admin): revoke destination cover access at storage level

### DIFF
--- a/docs/plans/2026-07-20-destination-media.md
+++ b/docs/plans/2026-07-20-destination-media.md
@@ -37,3 +37,36 @@
 - Update generated/local database types consistently with migration strategy.
 - Run focused checks before the full suite.
 - Commit all implementation and plan changes using a conventional human commit message; do not push.
+
+## Task 5 — Security repair: revocable delivery copies and a cancel/confirm CAS
+
+Two gaps found by review after the feature merged.
+
+**Signed URLs survived unpublishing.** The public resolver signed the *original* private
+object and leaned on the object SELECT policy to gate who could mint that URL. A Supabase
+signed URL is a self-contained JWT, so an issued 3600s token kept serving the object after
+the row was demoted, unpublished or deleted — the policy gates minting, not the minted
+token, and a shorter TTL only narrows the window rather than closing it.
+
+- A published primary cover is now served from a **separate delivery object**, copied from
+  the original and tracked in `location_media.delivery_object_path`. The original is never
+  signed for a public caller and never leaves the admin-only side of the object policy.
+- Every demotion, unpublish and delete **deletes the delivery object first**. Removing the
+  bytes is the revocation: outstanding signed URLs for that path die with it. A revocation
+  failure throws before any row write, so publish state is left unchanged.
+- Promotion **rotates**: the row's own previous copy and the outgoing primary's are revoked
+  before the new copy is created, so no URL minted for an earlier cover survives a swap.
+- `CHECK ((delivery_object_path IS NOT NULL) = is_primary)` makes "is primary" and "has a
+  live copy" one fact, so the database cannot hold a primary with nothing to serve, nor a
+  copy no row will ever revoke. The sibling-demote trigger fails closed against it.
+- Existing primaries are demoted by the migration rather than backfilled — fabricating a
+  copy there would publish bytes the migration cannot verify. Curators re-promote.
+
+**Cancel raced confirmation.** Cancel read the object path, removed the bytes, then deleted
+`WHERE status = 'uploading'`. A confirm interleaving between the read and the remove left a
+`draft` row pointing at an object that had just been deleted.
+
+- Cancel now claims the row by compare-and-swap `uploading -> cancelling` *before* touching
+  storage; confirmation still only ever transitions `uploading`, so exactly one wins.
+- Losing the CAS is a silent no-op. Bytes are removed, then the `cancelling` row is deleted;
+  a removal failure leaves that row in place, keeping the object recoverable.

--- a/src/app/(protected)/admin/locations/[locationId]/_components/location-media-console.tsx
+++ b/src/app/(protected)/admin/locations/[locationId]/_components/location-media-console.tsx
@@ -276,7 +276,9 @@ function MediaCard({
     source: item.source ?? "",
     role: item.role,
   });
-  const uploading = item.status === "uploading";
+  // `cancelling` is an in-flight cancel that outlived its storage removal, so it locks the
+  // same controls as `uploading`: no bytes are settled behind either.
+  const uploading = item.status === "uploading" || item.status === "cancelling";
   const dirty =
     (item.altText ?? "") !== fields.altText ||
     (item.caption ?? "") !== fields.caption ||
@@ -302,9 +304,11 @@ function MediaCard({
           <Badge variant={item.status === "published" ? "default" : "secondary"}>
             {item.status === "published"
               ? "Опубликовано"
-              : uploading
-                ? "Загружается"
-                : "Черновик"}
+              : item.status === "cancelling"
+                ? "Отменяется"
+                : uploading
+                  ? "Загружается"
+                  : "Черновик"}
           </Badge>
           <Badge variant="secondary">{item.role === "cover" ? "Обложка" : "Галерея"}</Badge>
           {item.isPrimary ? <Badge>Главная</Badge> : null}

--- a/src/lib/supabase/database.types.ts
+++ b/src/lib/supabase/database.types.ts
@@ -2667,6 +2667,7 @@ export type Database = {
           caption: string | null
           created_at: string
           created_by: string | null
+          delivery_object_path: string | null
           height: number | null
           id: string
           is_primary: boolean
@@ -2687,6 +2688,7 @@ export type Database = {
           caption?: string | null
           created_at?: string
           created_by?: string | null
+          delivery_object_path?: string | null
           height?: number | null
           id?: string
           is_primary?: boolean
@@ -2707,6 +2709,7 @@ export type Database = {
           caption?: string | null
           created_at?: string
           created_by?: string | null
+          delivery_object_path?: string | null
           height?: number | null
           id?: string
           is_primary?: boolean

--- a/src/lib/supabase/location-media.test.ts
+++ b/src/lib/supabase/location-media.test.ts
@@ -15,51 +15,87 @@ import {
 
 type Row = Record<string, unknown>;
 
+/** One recorded `from("location_media")` chain: what it did and to which rows. */
+type Op = {
+  kind: "select" | "insert" | "update" | "delete";
+  patch?: Row;
+  filters: Record<string, unknown>;
+  excluded: Record<string, unknown>;
+  in: Record<string, unknown>;
+  notNull: string[];
+};
+
 function stubClient({
   rows = [] as Row[],
   error = null as { message: string } | null,
+  /**
+   * Answers for `maybeSingle`/`single`, consumed in call order — the delivery flow issues
+   * several distinct single-row reads and writes per operation.
+   */
+  singles = null as (Row | null)[] | null,
   /** Paths the bucket refuses to sign — i.e. objects that are not readable or not there. */
   unsignable = [] as string[],
   removeError = null as { message: string } | null,
+  copyError = null as { message: string } | null,
+  /** Errors keyed by 1-based chain index, so one statement in a flow can fail. */
+  opErrors = {} as Record<number, { message: string }>,
 } = {}) {
-  const filters: Record<string, unknown> = {};
-  const excluded: Record<string, unknown> = {};
-  const updates: Row[] = [];
-  const inserts: Row[] = [];
-  const deleted: string[][] = [];
+  const ops: Op[] = [];
+  const removed: string[][] = [];
+  const copies: { from: string; to: string }[] = [];
   const signRequests: string[][] = [];
+  let singleIndex = 0;
 
-  let rowDeletes = 0;
-  const query: Record<string, unknown> = {};
-  for (const method of ["select", "order"]) {
-    query[method] = () => query;
+  function chain(): Record<string, unknown> {
+    const op: Op = { kind: "select", filters: {}, excluded: {}, in: {}, notNull: [] };
+    ops.push(op);
+    const opError = () => opErrors[ops.length] ?? error;
+
+    const q: Record<string, unknown> = {};
+    q.select = () => q;
+    q.order = () => q;
+    q.delete = () => {
+      op.kind = "delete";
+      return q;
+    };
+    q.insert = (patch: Row) => {
+      op.kind = "insert";
+      op.patch = patch;
+      return q;
+    };
+    q.update = (patch: Row) => {
+      op.kind = "update";
+      op.patch = patch;
+      return q;
+    };
+    q.eq = (column: string, value: unknown) => {
+      op.filters[column] = value;
+      return q;
+    };
+    q.neq = (column: string, value: unknown) => {
+      op.excluded[column] = value;
+      return q;
+    };
+    q.in = (column: string, value: unknown) => {
+      op.in[column] = value;
+      return q;
+    };
+    q.not = (column: string, operator: string) => {
+      if (operator === "is") op.notNull.push(column);
+      return q;
+    };
+    const single = () => {
+      const data = singles ? (singles[singleIndex++] ?? null) : (rows[0] ?? null);
+      return Promise.resolve({ data, error: opError() });
+    };
+    q.maybeSingle = single;
+    q.single = single;
+    q.then = (resolve: (v: unknown) => void) => resolve({ data: rows, error: opError() });
+    return q;
   }
-  query.delete = () => {
-    rowDeletes += 1;
-    return query;
-  };
-  query.insert = (row: Row) => {
-    inserts.push(row);
-    return query;
-  };
-  query.eq = (column: string, value: unknown) => {
-    filters[column] = value;
-    return query;
-  };
-  query.neq = (column: string, value: unknown) => {
-    excluded[column] = value;
-    return query;
-  };
-  query.update = (patch: Row) => {
-    updates.push(patch);
-    return query;
-  };
-  query.maybeSingle = () => Promise.resolve({ data: rows[0] ?? null, error });
-  query.single = () => Promise.resolve({ data: rows[0] ?? null, error });
-  query.then = (resolve: (v: unknown) => void) => resolve({ data: rows, error });
 
   const client = {
-    from: vi.fn(() => query),
+    from: vi.fn(() => chain()),
     storage: {
       from: (bucket: string) => ({
         createSignedUrls: (paths: string[]) => {
@@ -74,8 +110,12 @@ function stubClient({
           });
         },
         remove: (paths: string[]) => {
-          deleted.push(paths);
+          removed.push(paths);
           return Promise.resolve({ data: null, error: removeError });
+        },
+        copy: (from: string, to: string) => {
+          copies.push({ from, to });
+          return Promise.resolve({ data: copyError ? null : { path: to }, error: copyError });
         },
       }),
     },
@@ -83,38 +123,43 @@ function stubClient({
 
   return {
     client,
-    filters,
-    excluded,
-    updates,
-    inserts,
-    deleted,
+    ops,
+    removed,
+    copies,
     signRequests,
-    rowDeletes: () => rowDeletes,
+    updates: () => ops.filter((op) => op.kind === "update").map((op) => op.patch),
+    inserts: () => ops.filter((op) => op.kind === "insert").map((op) => op.patch),
+    rowDeletes: () => ops.filter((op) => op.kind === "delete").length,
+    last: () => ops[ops.length - 1],
   };
 }
 
 const PUBLISHED_COVER: Row = {
   bucket_id: "location-media",
   object_path: "admin-1/cover.jpg",
+  delivery_object_path: "delivery/live-cover.jpg",
   guide_location_catalog: { name: " Казань " },
 };
 
 describe("getPublishedLocationCovers", () => {
-  it("only ever asks for published primary covers — drafts must not reach public pages", async () => {
-    const { client, filters } = stubClient({ rows: [PUBLISHED_COVER] });
+  it("only ever asks for published primary covers with a live delivery copy", async () => {
+    const { client, last } = stubClient({ rows: [PUBLISHED_COVER] });
 
     await getPublishedLocationCovers(client);
 
-    expect(filters).toEqual({ status: "published", role: "cover", is_primary: true });
+    expect(last().filters).toEqual({ status: "published", role: "cover", is_primary: true });
+    expect(last().notNull).toEqual(["delivery_object_path"]);
   });
 
-  it("keys covers by normalised location name and signs the object", async () => {
-    const { client } = stubClient({ rows: [PUBLISHED_COVER] });
+  it("signs the delivery copy, never the original — the original is not revocable", async () => {
+    const { client, signRequests } = stubClient({ rows: [PUBLISHED_COVER] });
 
     const covers = await getPublishedLocationCovers(client);
 
+    expect(signRequests).toEqual([["delivery/live-cover.jpg"]]);
+    expect(signRequests.flat()).not.toContain("admin-1/cover.jpg");
     expect(covers.get("казань")).toBe(
-      "https://signed.test/location-media/admin-1/cover.jpg",
+      "https://signed.test/location-media/delivery/live-cover.jpg",
     );
   });
 
@@ -129,10 +174,19 @@ describe("getPublishedLocationCovers", () => {
   it("drops a cover the bucket refuses to sign rather than guessing a URL", async () => {
     const { client } = stubClient({
       rows: [PUBLISHED_COVER],
-      unsignable: ["admin-1/cover.jpg"],
+      unsignable: ["delivery/live-cover.jpg"],
     });
 
     expect((await getPublishedLocationCovers(client)).size).toBe(0);
+  });
+
+  it("skips a row whose delivery copy was already revoked", async () => {
+    const { client, signRequests } = stubClient({
+      rows: [{ ...PUBLISHED_COVER, delivery_object_path: null }],
+    });
+
+    expect((await getPublishedLocationCovers(client)).size).toBe(0);
+    expect(signRequests.flat()).toEqual([]);
   });
 
   it("tolerates the embed arriving as an array", async () => {
@@ -188,6 +242,7 @@ const DRAFT_ROW: Row = {
   location_id: "loc-1",
   bucket_id: "location-media",
   object_path: "admin-1/cover.webp",
+  delivery_object_path: null,
   role: "cover",
   status: "draft",
   is_primary: false,
@@ -254,18 +309,18 @@ describe("beginLocationMediaUpload", () => {
     });
 
     expect(id).toBe("m-1");
-    expect(inserts[0]).toMatchObject({ status: "uploading", object_path: "admin-1/cover.jpg" });
+    expect(inserts()[0]).toMatchObject({ status: "uploading", object_path: "admin-1/cover.jpg" });
   });
 });
 
 describe("confirmLocationMediaUpload", () => {
   it("moves the reservation to draft, and only from uploading", async () => {
-    const { client, updates, filters } = stubClient({ rows: [{ id: "m-1" }] });
+    const { client, updates, last } = stubClient({ rows: [{ id: "m-1" }] });
 
     await confirmLocationMediaUpload(client, "m-1");
 
-    expect(updates).toEqual([{ status: "draft" }]);
-    expect(filters).toEqual({ id: "m-1", status: "uploading" });
+    expect(updates()).toEqual([{ status: "draft" }]);
+    expect(last().filters).toEqual({ id: "m-1", status: "uploading" });
   });
 
   it("throws when there is no reservation to confirm", async () => {
@@ -275,23 +330,60 @@ describe("confirmLocationMediaUpload", () => {
       "Загрузка не найдена или уже подтверждена.",
     );
   });
+
+  it("cannot confirm a row a cancel already claimed — the CAS filter excludes it", async () => {
+    // The stub answers the CAS `... eq(status, 'uploading')` with no row, which is exactly
+    // what Postgres returns once cancel has moved the row to `cancelling`.
+    const { client } = stubClient({ singles: [null] });
+
+    await expect(confirmLocationMediaUpload(client, "m-1")).rejects.toThrow(
+      "Загрузка не найдена или уже подтверждена.",
+    );
+  });
 });
 
+const RESERVED = { bucket_id: "location-media", object_path: "admin-1/cover.jpg" };
+
 describe("cancelLocationMediaUpload", () => {
-  it("removes the object and the reservation", async () => {
-    const { client, deleted, filters } = stubClient({
-      rows: [{ bucket_id: "location-media", object_path: "admin-1/cover.jpg" }],
-    });
+  it("claims the row by CAS out of uploading before removing a single byte", async () => {
+    const { client, ops, removed } = stubClient({ singles: [RESERVED] });
 
     await cancelLocationMediaUpload(client, "m-1");
 
-    expect(deleted).toEqual([["admin-1/cover.jpg"]]);
-    expect(filters.status).toBe("uploading");
+    // Statement 1 is the CAS, and it is the only thing gating the storage removal.
+    expect(ops[0]).toMatchObject({
+      kind: "update",
+      patch: { status: "cancelling" },
+      filters: { id: "m-1", status: "uploading" },
+    });
+    expect(removed).toEqual([["admin-1/cover.jpg"]]);
   });
 
-  it("keeps the row when storage removal fails, so the object stays recoverable", async () => {
+  it("deletes the cancelling row, not the uploading one — confirm cannot resurrect it", async () => {
+    const { client, ops } = stubClient({ singles: [RESERVED] });
+
+    await cancelLocationMediaUpload(client, "m-1");
+
+    expect(ops[ops.length - 1]).toMatchObject({
+      kind: "delete",
+      filters: { id: "m-1", status: "cancelling" },
+    });
+  });
+
+  it("is a silent no-op when a concurrent confirm won the CAS", async () => {
+    const { client, removed, rowDeletes } = stubClient({ singles: [null] });
+
+    await cancelLocationMediaUpload(client, "m-1");
+
+    // The decisive assertion: a lost race must not delete the bytes of a row that is now
+    // a confirmed draft.
+    expect(removed).toEqual([]);
+    expect(rowDeletes()).toBe(0);
+  });
+
+  it("leaves a recoverable cancelling row when storage removal fails", async () => {
     const { client, rowDeletes } = stubClient({
-      rows: [{ bucket_id: "location-media", object_path: "admin-1/cover.jpg" }],
+      singles: [RESERVED],
       removeError: { message: "network" },
     });
 
@@ -301,63 +393,202 @@ describe("cancelLocationMediaUpload", () => {
     expect(rowDeletes()).toBe(0);
   });
 
-  it("is a no-op when the row is already gone", async () => {
-    const { client, deleted } = stubClient({ rows: [] });
+  it("surfaces a CAS error rather than assuming the row was already confirmed", async () => {
+    const { client, removed } = stubClient({ singles: [RESERVED], opErrors: { 1: { message: "boom" } } });
 
-    await cancelLocationMediaUpload(client, "m-1");
-
-    expect(deleted).toEqual([]);
+    await expect(cancelLocationMediaUpload(client, "m-1")).rejects.toThrow("boom");
+    expect(removed).toEqual([]);
   });
 });
 
+const DRAFT_STATE: Row = {
+  id: "m-1",
+  location_id: "loc-1",
+  bucket_id: "location-media",
+  object_path: "admin-1/cover.jpg",
+  delivery_object_path: null,
+  status: "draft",
+};
+const PRIMARY_STATE: Row = {
+  ...DRAFT_STATE,
+  delivery_object_path: "delivery/old.jpg",
+  status: "published",
+};
+
 describe("updateLocationMedia", () => {
   it("sends only the supplied columns", async () => {
-    const { client, updates } = stubClient();
+    const { client, updates } = stubClient({ singles: [DRAFT_STATE] });
 
-    await updateLocationMedia(client, "m-1", { status: "published", isPrimary: true });
+    await updateLocationMedia(client, "m-1", { caption: "Вид" });
 
-    expect(updates).toEqual([{ status: "published", is_primary: true }]);
+    expect(updates()).toEqual([{ caption: "Вид" }]);
   });
 
   it("refuses to touch a row that is still uploading", async () => {
-    const { client, excluded } = stubClient();
+    const { client, updates } = stubClient({ singles: [{ ...DRAFT_STATE, status: "uploading" }] });
 
     await updateLocationMedia(client, "m-1", { status: "published" });
 
-    expect(excluded).toEqual({ status: "uploading" });
+    expect(updates()).toEqual([]);
+  });
+
+  it("refuses to touch a row a cancel is tearing down", async () => {
+    const { client, updates } = stubClient({ singles: [{ ...DRAFT_STATE, status: "cancelling" }] });
+
+    await updateLocationMedia(client, "m-1", { status: "published" });
+
+    expect(updates()).toEqual([]);
   });
 
   it("writes an explicit null when metadata is cleared", async () => {
-    const { client, updates } = stubClient();
+    const { client, updates } = stubClient({ singles: [DRAFT_STATE] });
 
     await updateLocationMedia(client, "m-1", { caption: null });
 
-    expect(updates).toEqual([{ caption: null }]);
+    expect(updates()).toEqual([{ caption: null }]);
   });
 
-  it("does not issue an update for an empty patch", async () => {
-    const { client, updates } = stubClient();
+  it("does not issue an update — or even a read — for an empty patch", async () => {
+    const { client, ops } = stubClient();
 
     await updateLocationMedia(client, "m-1", {});
 
-    expect(updates).toEqual([]);
+    expect(ops).toEqual([]);
+  });
+
+  it("copies the original into a fresh delivery object when promoting to primary", async () => {
+    const { client, copies, updates } = stubClient({ singles: [DRAFT_STATE, null] });
+
+    await updateLocationMedia(client, "m-1", {
+      status: "published",
+      role: "cover",
+      isPrimary: true,
+    });
+
+    expect(copies).toHaveLength(1);
+    expect(copies[0].from).toBe("admin-1/cover.jpg");
+    expect(copies[0].to).toMatch(/^delivery\/[0-9a-f-]{36}\.jpg$/);
+    expect(updates()[updates().length - 1]).toMatchObject({
+      status: "published",
+      is_primary: true,
+      delivery_object_path: copies[0].to,
+    });
+  });
+
+  it("revokes the outgoing primary's copy before serving the new one", async () => {
+    const sibling = {
+      id: "m-2",
+      bucket_id: "location-media",
+      delivery_object_path: "delivery/sibling.jpg",
+    };
+    const { client, removed, copies } = stubClient({ singles: [DRAFT_STATE, sibling] });
+
+    await updateLocationMedia(client, "m-1", { isPrimary: true });
+
+    // Without this, the trigger demotes the sibling row while its bytes keep serving.
+    expect(removed).toEqual([["delivery/sibling.jpg"]]);
+    expect(copies).toHaveLength(1);
+  });
+
+  it("rotates its own copy on re-promotion so old signed URLs die", async () => {
+    const { client, removed, copies } = stubClient({ singles: [PRIMARY_STATE, null] });
+
+    await updateLocationMedia(client, "m-1", { isPrimary: true });
+
+    expect(removed).toEqual([["delivery/old.jpg"]]);
+    expect(copies[0].to).not.toBe("delivery/old.jpg");
+  });
+
+  it("deletes the delivery bytes before unpublishing, and clears the column", async () => {
+    const { client, removed, updates } = stubClient({ singles: [PRIMARY_STATE] });
+
+    await updateLocationMedia(client, "m-1", { status: "draft", isPrimary: false });
+
+    expect(removed).toEqual([["delivery/old.jpg"]]);
+    expect(updates()[updates().length - 1]).toMatchObject({
+      status: "draft",
+      is_primary: false,
+      delivery_object_path: null,
+    });
+  });
+
+  it("revokes when demoting a primary to gallery", async () => {
+    const { client, removed } = stubClient({ singles: [PRIMARY_STATE] });
+
+    await updateLocationMedia(client, "m-1", { role: "gallery" });
+
+    expect(removed).toEqual([["delivery/old.jpg"]]);
+  });
+
+  it("leaves the publish state untouched when revocation fails", async () => {
+    const { client, updates } = stubClient({
+      singles: [PRIMARY_STATE],
+      removeError: { message: "network" },
+    });
+
+    await expect(
+      updateLocationMedia(client, "m-1", { status: "draft", isPrimary: false }),
+    ).rejects.toThrow("Публичная копия не отозвана: network");
+    // Nothing was written, so the row is still published — a caller sees the failure and
+    // the cover keeps serving from an object that is still tracked and still revocable.
+    expect(updates()).toEqual([]);
+  });
+
+  it("does not publish when the delivery copy cannot be created", async () => {
+    const { client, updates } = stubClient({
+      singles: [DRAFT_STATE, null],
+      copyError: { message: "quota" },
+    });
+
+    await expect(updateLocationMedia(client, "m-1", { isPrimary: true })).rejects.toThrow(
+      "Публичная копия не создана: quota",
+    );
+    expect(updates()).toEqual([]);
+  });
+
+  it("removes the orphaned copy when the promoting write fails", async () => {
+    // Chain 1 = state read, 2 = sibling read, 3 = the final update.
+    const { client, removed, copies } = stubClient({
+      singles: [DRAFT_STATE, null],
+      opErrors: { 3: { message: "conflict" } },
+    });
+
+    await expect(updateLocationMedia(client, "m-1", { isPrimary: true })).rejects.toThrow(
+      "conflict",
+    );
+    expect(removed).toEqual([[copies[0].to]]);
+  });
+
+  it("leaves a published cover's copy alone for a metadata-only edit", async () => {
+    const { client, removed, copies } = stubClient({ singles: [PRIMARY_STATE] });
+
+    await updateLocationMedia(client, "m-1", { caption: "Новая подпись" });
+
+    expect(removed).toEqual([]);
+    expect(copies).toEqual([]);
   });
 });
 
 describe("deleteLocationMedia", () => {
-  it("removes the storage object too — a dangling file is invisible waste", async () => {
-    const { client, deleted } = stubClient({
-      rows: [{ bucket_id: "location-media", object_path: "admin-1/cover.jpg" }],
-    });
+  it("revokes the delivery copy first, then removes the original", async () => {
+    const { client, removed } = stubClient({ singles: [PRIMARY_STATE] });
 
     await deleteLocationMedia(client, "m-1");
 
-    expect(deleted).toEqual([["admin-1/cover.jpg"]]);
+    expect(removed).toEqual([["delivery/old.jpg"], ["admin-1/cover.jpg"]]);
+  });
+
+  it("removes the storage object too — a dangling file is invisible waste", async () => {
+    const { client, removed } = stubClient({ singles: [DRAFT_STATE] });
+
+    await deleteLocationMedia(client, "m-1");
+
+    expect(removed).toEqual([["admin-1/cover.jpg"]]);
   });
 
   it("keeps the row when storage removal fails, so the object stays recoverable", async () => {
     const { client, rowDeletes } = stubClient({
-      rows: [{ bucket_id: "location-media", object_path: "admin-1/cover.jpg" }],
+      singles: [DRAFT_STATE],
       removeError: { message: "network" },
     });
 
@@ -367,11 +598,25 @@ describe("deleteLocationMedia", () => {
     expect(rowDeletes()).toBe(0);
   });
 
+  it("keeps the row when the delivery copy cannot be revoked", async () => {
+    const { client, rowDeletes, removed } = stubClient({
+      singles: [PRIMARY_STATE],
+      removeError: { message: "network" },
+    });
+
+    await expect(deleteLocationMedia(client, "m-1")).rejects.toThrow(
+      "Публичная копия не отозвана: network",
+    );
+    // The original was never touched — deletion aborts before it can orphan anything.
+    expect(removed).toEqual([["delivery/old.jpg"]]);
+    expect(rowDeletes()).toBe(0);
+  });
+
   it("is a no-op when the row is already gone", async () => {
-    const { client, deleted } = stubClient({ rows: [] });
+    const { client, removed } = stubClient({ singles: [null] });
 
     await deleteLocationMedia(client, "m-1");
 
-    expect(deleted).toEqual([]);
+    expect(removed).toEqual([]);
   });
 });

--- a/src/lib/supabase/location-media.ts
+++ b/src/lib/supabase/location-media.ts
@@ -1,3 +1,5 @@
+import { randomUUID } from "node:crypto";
+
 import type { SupabaseClient } from "@supabase/supabase-js";
 
 import type { Uuid } from "@/lib/supabase/types";
@@ -7,9 +9,19 @@ export const LOCATION_MEDIA_BUCKET = "location-media" as const;
 /** Long enough for an admin to work through a page of media, short enough to expire. */
 const LOCATION_MEDIA_URL_TTL_SECONDS = 60 * 60;
 
+/**
+ * Where public delivery copies live. Kept on its own prefix so the originals — which no
+ * public caller may ever read — are trivially distinguishable when auditing the bucket.
+ */
+const DELIVERY_PREFIX = "delivery";
+
 export type LocationMediaRole = "cover" | "gallery";
-/** `uploading` = row reserved before the signed upload URL was issued; never public. */
-export type LocationMediaStatus = "uploading" | "draft" | "published";
+/**
+ * `uploading` = row reserved before the signed upload URL was issued; never public.
+ * `cancelling` = the row a cancel has claimed by CAS out of `uploading`; its bytes are
+ * being removed, and it survives a removal failure so the object stays recoverable.
+ */
+export type LocationMediaStatus = "uploading" | "cancelling" | "draft" | "published";
 
 export type LocationMediaRecord = {
   id: Uuid;
@@ -204,19 +216,6 @@ export async function confirmLocationMediaUpload(
   if (!data) throw new Error("Загрузка не найдена или уже подтверждена.");
 }
 
-async function getMediaObject(
-  adminClient: SupabaseClient,
-  id: string,
-): Promise<{ bucket_id: string; object_path: string } | null> {
-  const { data, error } = await adminClient
-    .from("location_media")
-    .select("bucket_id, object_path")
-    .eq("id", id)
-    .maybeSingle();
-  if (error) throw new Error(error.message);
-  return (data as { bucket_id: string; object_path: string } | null) ?? null;
-}
-
 /**
  * Removes the backing object, failing loudly. Supabase does not report removing a path
  * that holds no bytes as an error, so the "file never left the browser" case still
@@ -233,25 +232,139 @@ async function removeMediaObject(
 }
 
 /**
- * Cancels a reserved upload. As strict as a normal delete: an abandoned upload is the
- * common case and cleans up silently, but a real storage failure must not drop the only
- * row that knows the object exists.
+ * Cancels a reserved upload.
+ *
+ * The first statement is a compare-and-swap: `uploading -> cancelling` claims the row
+ * before a single byte is touched. Confirmation only ever transitions `uploading`, so
+ * exactly one of the two wins — previously cancel read the path, then removed the bytes,
+ * then deleted `WHERE status = 'uploading'`, and a confirm landing in that gap left a
+ * `draft` row pointing at an object cancel had already deleted.
+ *
+ * Losing the CAS is a no-op, not an error: the upload was confirmed (or already gone),
+ * and deleting a confirmed asset is what deleteLocationMedia is for. If removal fails the
+ * `cancelling` row stays, keeping the object path recoverable for a retry.
  */
 export async function cancelLocationMediaUpload(
   adminClient: SupabaseClient,
   id: string,
 ): Promise<void> {
-  const object = await getMediaObject(adminClient, id);
-  if (!object) return;
+  const { data, error } = await adminClient
+    .from("location_media")
+    .update({ status: "cancelling" })
+    .eq("id", id)
+    .eq("status", "uploading")
+    .select("bucket_id, object_path")
+    .maybeSingle();
+  if (error) throw new Error(error.message);
+  if (!data) return;
 
-  await removeMediaObject(adminClient, object);
+  await removeMediaObject(adminClient, data as { bucket_id: string; object_path: string });
 
-  const { error } = await adminClient
+  const { error: rowError } = await adminClient
     .from("location_media")
     .delete()
     .eq("id", id)
-    .eq("status", "uploading");
+    .eq("status", "cancelling");
+  if (rowError) throw new Error(rowError.message);
+}
+
+type LocationMediaState = {
+  id: string;
+  location_id: string;
+  bucket_id: string;
+  object_path: string;
+  delivery_object_path: string | null;
+  status: LocationMediaStatus;
+};
+
+async function getMediaState(
+  adminClient: SupabaseClient,
+  id: string,
+): Promise<LocationMediaState | null> {
+  const { data, error } = await adminClient
+    .from("location_media")
+    .select("id, location_id, bucket_id, object_path, delivery_object_path, status")
+    .eq("id", id)
+    .maybeSingle();
   if (error) throw new Error(error.message);
+  return (data as LocationMediaState | null) ?? null;
+}
+
+function deliveryPathFor(objectPath: string): string {
+  const dot = objectPath.lastIndexOf(".");
+  const extension = dot === -1 ? "" : objectPath.slice(dot).toLowerCase();
+  return `${DELIVERY_PREFIX}/${randomUUID()}${extension}`;
+}
+
+/**
+ * Copies the original into a fresh delivery object — the only thing a public caller is
+ * ever entitled to sign. The copy is what makes publication revocable: deleting it kills
+ * every signed URL issued for it, while the original never leaves the admin-only side.
+ */
+async function createDeliveryObject(
+  adminClient: SupabaseClient,
+  row: Pick<LocationMediaState, "bucket_id" | "object_path">,
+): Promise<string> {
+  const deliveryPath = deliveryPathFor(row.object_path);
+  const { error } = await adminClient.storage
+    .from(row.bucket_id)
+    .copy(row.object_path, deliveryPath);
+  if (error) throw new Error(`Публичная копия не создана: ${error.message}`);
+  return deliveryPath;
+}
+
+/**
+ * Revokes a delivery copy: bytes first, then the row that claims them.
+ *
+ * A signed URL is a self-contained token — no policy edit and no TTL expiry recalls one
+ * already in a browser. Deleting the bytes it addresses is the revocation. Doing it
+ * before the row transition is what makes the guarantee hold: the copy is gone by the
+ * time the media stops being published, and a failure here throws, so the caller aborts
+ * with the publish state untouched.
+ */
+async function revokeDeliveryObject(
+  adminClient: SupabaseClient,
+  row: { id: string; bucket_id: string; delivery_object_path: string | null },
+): Promise<void> {
+  if (!row.delivery_object_path) return;
+
+  const { error } = await adminClient.storage
+    .from(row.bucket_id)
+    .remove([row.delivery_object_path]);
+  if (error) throw new Error(`Публичная копия не отозвана: ${error.message}`);
+
+  const { error: rowError } = await adminClient
+    .from("location_media")
+    .update({ delivery_object_path: null, is_primary: false })
+    .eq("id", row.id);
+  if (rowError) throw new Error(rowError.message);
+}
+
+/**
+ * Revokes the outgoing primary's copy before a new one takes its place.
+ *
+ * The database demotes siblings by trigger, which would otherwise strand a live delivery
+ * object on a row no longer flagged primary — a published cover that the console shows as
+ * demoted but the bucket still serves.
+ */
+async function revokePrimarySibling(
+  adminClient: SupabaseClient,
+  row: Pick<LocationMediaState, "id" | "location_id">,
+): Promise<void> {
+  const { data, error } = await adminClient
+    .from("location_media")
+    .select("id, bucket_id, delivery_object_path")
+    .eq("location_id", row.location_id)
+    .eq("is_primary", true)
+    .neq("id", row.id)
+    .maybeSingle();
+  if (error) throw new Error(error.message);
+  if (data) {
+    await revokeDeliveryObject(
+      adminClient,
+      data as { id: string; bucket_id: string; delivery_object_path: string | null },
+    );
+  }
 }
 
 export async function updateLocationMedia(
@@ -277,31 +390,60 @@ export async function updateLocationMedia(
   // order. Add one here when the console grows drag-to-reorder.
   if (Object.keys(row).length === 0) return;
 
-  // An `uploading` row has no confirmed bytes behind it, so no edit — least of all
-  // publishing it — may apply until confirmLocationMediaUpload has moved it to draft.
+  // An `uploading`/`cancelling` row has no settled bytes behind it, so no edit — least of
+  // all publishing it — may apply until confirmLocationMediaUpload has moved it to draft.
+  const current = await getMediaState(adminClient, id);
+  if (!current || current.status === "uploading" || current.status === "cancelling") return;
+
+  const becomesPrimary = patch.isPrimary === true;
+  // The action layer normalises these into each other, but the storage side must not
+  // depend on that: any of the three ends public delivery and has to revoke first.
+  const losesPrimary =
+    patch.isPrimary === false || patch.status === "draft" || patch.role === "gallery";
+
+  if (becomesPrimary) {
+    // Rotate rather than reuse. The row's own previous copy and the outgoing primary's
+    // both die before the new one exists, so no URL minted for an earlier cover survives
+    // the swap. Either revoke throwing aborts the promotion untouched.
+    await revokeDeliveryObject(adminClient, { ...current, id });
+    await revokePrimarySibling(adminClient, current);
+    row.delivery_object_path = await createDeliveryObject(adminClient, current);
+  } else if (losesPrimary) {
+    await revokeDeliveryObject(adminClient, { ...current, id });
+    row.delivery_object_path = null;
+  }
+
   const { error } = await adminClient
     .from("location_media")
     .update(row)
     .eq("id", id)
-    .neq("status", "uploading");
-  if (error) throw new Error(error.message);
+    .in("status", ["draft", "published"]);
+  if (error) {
+    if (typeof row.delivery_object_path === "string") {
+      // The copy exists but no row claims it — an object nothing can later revoke.
+      await adminClient.storage.from(current.bucket_id).remove([row.delivery_object_path]);
+    }
+    throw new Error(error.message);
+  }
 }
 
 /**
- * Deletes the storage object first, then its row.
+ * Revokes the public delivery copy, deletes the original object, then the row.
  *
- * Order and strictness are both deliberate: dropping the row first and then failing to
- * remove the object leaves a file no query can find. Failing loudly instead keeps the
- * record — and therefore the object path — recoverable, so the admin can retry.
+ * Order and strictness are both deliberate. The delivery copy goes first so deletion can
+ * never leave a published cover the bucket still serves. Dropping the row before removing
+ * objects would leave files no query can find; failing loudly instead keeps the record —
+ * and therefore both paths — recoverable, so the admin can retry.
  */
 export async function deleteLocationMedia(
   adminClient: SupabaseClient,
   id: string,
 ): Promise<void> {
-  const object = await getMediaObject(adminClient, id);
-  if (!object) return;
+  const current = await getMediaState(adminClient, id);
+  if (!current) return;
 
-  await removeMediaObject(adminClient, object);
+  await revokeDeliveryObject(adminClient, current);
+  await removeMediaObject(adminClient, current);
 
   const { error } = await adminClient.from("location_media").delete().eq("id", id);
   if (error) throw new Error(error.message);
@@ -319,22 +461,28 @@ export async function getPublishedLocationCovers(
 ): Promise<Map<string, string>> {
   const { data, error } = await client
     .from("location_media")
-    .select("bucket_id, object_path, guide_location_catalog!inner(name)")
+    .select("bucket_id, delivery_object_path, guide_location_catalog!inner(name)")
     .eq("status", "published")
     .eq("role", "cover")
-    .eq("is_primary", true);
+    .eq("is_primary", true)
+    .not("delivery_object_path", "is", null);
   if (error) throw new Error(error.message);
 
   const rows = (data ?? []) as unknown as {
     bucket_id: string;
-    object_path: string;
+    delivery_object_path: string | null;
     guide_location_catalog: { name: string } | { name: string }[] | null;
   }[];
-  // Signing is what the object SELECT policy gates, so an unpublished or demoted row can
-  // never yield a URL even if it somehow reached this list.
+  // Only ever the delivery copy. Signing the original would hand out a token that
+  // outlives demotion — the copy is deleted as part of every unpublish, so its URLs die
+  // with it. The object SELECT policy admits the delivery path and nothing else.
   const signed = await signLocationMediaUrls(
     client,
-    rows.map((row) => ({ bucketId: row.bucket_id, objectPath: row.object_path })),
+    rows.flatMap((row) =>
+      row.delivery_object_path
+        ? [{ bucketId: row.bucket_id, objectPath: row.delivery_object_path }]
+        : [],
+    ),
   );
 
   const covers = new Map<string, string>();
@@ -342,8 +490,8 @@ export async function getPublishedLocationCovers(
     const relation = Array.isArray(row.guide_location_catalog)
       ? row.guide_location_catalog[0]
       : row.guide_location_catalog;
-    if (!relation?.name) continue;
-    const url = signed.get(signedKey(row.bucket_id, row.object_path));
+    if (!relation?.name || !row.delivery_object_path) continue;
+    const url = signed.get(signedKey(row.bucket_id, row.delivery_object_path));
     if (!url) continue;
     covers.set(relation.name.trim().toLocaleLowerCase("ru-RU"), url);
   }

--- a/supabase/migrations/20260720120000_location_media_delivery_revocation.sql
+++ b/supabase/migrations/20260720120000_location_media_delivery_revocation.sql
@@ -1,0 +1,77 @@
+-- Destination media, security repair: revocable delivery copies + a cancel/confirm CAS.
+--
+-- (1) REVOCATION. The previous design signed the *original* private object and relied on
+-- the object SELECT policy to gate who could mint that URL. That gates minting, not the
+-- minted token: a Supabase signed URL is a self-contained JWT, so an already-issued
+-- 3600s URL keeps serving the object after the row is demoted, unpublished or deleted.
+-- No policy change and no shorter TTL closes that window — only removing the bytes does.
+--
+-- So a published primary cover is now served from a SEPARATE delivery object, copied from
+-- the original and tracked in `delivery_object_path`. The original is never public and
+-- never signed for a public caller. Demote/unpublish/delete deletes the delivery object
+-- first; any outstanding signed URL for it is dead the moment those bytes are gone, and
+-- the original was never reachable in the first place.
+--
+-- The check constraint makes "is primary" and "has a delivery copy" the same fact, so the
+-- database cannot hold a primary with no live copy, nor a copy no row will ever revoke.
+--
+-- (2) CANCEL/CONFIRM RACE. `cancelling` is a new terminal-ish state so cancel can take the
+-- row out of `uploading` by compare-and-swap *before* touching storage. Previously cancel
+-- read the object path, then removed bytes, then deleted `WHERE status = 'uploading'` — a
+-- confirm interleaving between the read and the remove produced a `draft` row whose bytes
+-- had been deleted underneath it. Now confirm and cancel contend for the same single
+-- `uploading -> x` transition and exactly one wins.
+
+ALTER TABLE public.location_media
+  ADD COLUMN IF NOT EXISTS delivery_object_path text;
+
+-- Existing primaries predate delivery copies, so none of them has one. Demote rather than
+-- backfill: fabricating a copy here would publish bytes this migration cannot verify.
+-- Curators re-promote from the console, which creates the copy through the normal path.
+UPDATE public.location_media SET is_primary = false WHERE is_primary;
+
+ALTER TABLE public.location_media
+  DROP CONSTRAINT IF EXISTS location_media_status_check;
+ALTER TABLE public.location_media
+  ADD CONSTRAINT location_media_status_check
+  CHECK (status IN ('uploading', 'cancelling', 'draft', 'published'));
+
+-- A primary has a delivery copy and a delivery copy belongs to a primary — one biconditional
+-- so neither half can drift. Combined with the existing published-cover check, a delivery
+-- object exists exactly while the public is entitled to read it.
+ALTER TABLE public.location_media
+  DROP CONSTRAINT IF EXISTS location_media_delivery_matches_primary;
+ALTER TABLE public.location_media
+  ADD CONSTRAINT location_media_delivery_matches_primary
+  CHECK ((delivery_object_path IS NOT NULL) = is_primary);
+
+-- A delivery copy is a distinct object, never an alias for the original.
+ALTER TABLE public.location_media
+  DROP CONSTRAINT IF EXISTS location_media_delivery_is_distinct;
+ALTER TABLE public.location_media
+  ADD CONSTRAINT location_media_delivery_is_distinct
+  CHECK (delivery_object_path IS NULL OR delivery_object_path <> object_path);
+
+CREATE UNIQUE INDEX IF NOT EXISTS location_media_delivery_object_path_key
+  ON public.location_media (bucket_id, delivery_object_path)
+  WHERE delivery_object_path IS NOT NULL;
+
+-- Public object reads now point at the delivery copy only. The original stays admin-only
+-- forever, so no public caller can ever hold a signed URL to it — revoked or not.
+DROP POLICY IF EXISTS location_media_objects_public_read ON storage.objects;
+CREATE POLICY location_media_objects_public_read ON storage.objects
+  FOR SELECT USING (
+    bucket_id = 'location-media'
+    AND (
+      public.is_admin()
+      OR EXISTS (
+        SELECT 1
+          FROM public.location_media m
+         WHERE m.bucket_id = storage.objects.bucket_id
+           AND m.delivery_object_path = storage.objects.name
+           AND m.status = 'published'
+           AND m.role = 'cover'
+           AND m.is_primary
+      )
+    )
+  );

--- a/supabase/tests/location_media_rls_test.sql
+++ b/supabase/tests/location_media_rls_test.sql
@@ -1,11 +1,12 @@
--- Destination media boundary: only admins write location media, and the public
--- may read PUBLISHED rows only (an unpublished object path must never leak).
+-- Destination media boundary: only admins write location media, the public may read
+-- PUBLISHED rows only, and — the point of the delivery split — the only object any public
+-- caller can sign is the revocable delivery copy, never the original asset.
 begin;
 
 create extension if not exists pgtap with schema extensions;
 set search_path = public, extensions;
 
-select plan(18);
+select plan(24);
 
 insert into auth.users (
   id, instance_id, aud, role, email, encrypted_password, email_confirmed_at,
@@ -48,22 +49,27 @@ values ('7c000000-0000-4000-8000-000000000001', 'Тестоград', 'active')
 on conflict (id) do nothing;
 
 insert into public.location_media
-  (id, location_id, object_path, role, status, is_primary, mime_type, byte_size)
+  (id, location_id, object_path, delivery_object_path, role, status, is_primary,
+   mime_type, byte_size)
 values
   ('7d000000-0000-4000-8000-000000000001',
    '7c000000-0000-4000-8000-000000000001',
-   'curator/published-cover.jpg', 'cover', 'published', true, 'image/jpeg', 100000),
+   'curator/published-cover.jpg', 'delivery/published-cover.jpg',
+   'cover', 'published', true, 'image/jpeg', 100000),
   ('7d000000-0000-4000-8000-000000000002',
    '7c000000-0000-4000-8000-000000000001',
-   'curator/draft-cover.jpg', 'cover', 'draft', false, 'image/jpeg', 100000),
-  -- A published cover that is NOT primary, and a row reserved before its upload: both
-  -- must be as unreadable at the object level as an outright draft.
+   'curator/draft-cover.jpg', NULL, 'cover', 'draft', false, 'image/jpeg', 100000),
+  -- A published cover that is NOT primary, a row reserved before its upload, and a row a
+  -- cancel has claimed: all three must be as unreadable as an outright draft.
   ('7d000000-0000-4000-8000-000000000003',
    '7c000000-0000-4000-8000-000000000001',
-   'curator/published-secondary.jpg', 'cover', 'published', false, 'image/jpeg', 100000),
+   'curator/published-secondary.jpg', NULL, 'cover', 'published', false, 'image/jpeg', 100000),
   ('7d000000-0000-4000-8000-000000000004',
    '7c000000-0000-4000-8000-000000000001',
-   'curator/uploading.jpg', 'cover', 'uploading', false, 'image/jpeg', 100000);
+   'curator/uploading.jpg', NULL, 'cover', 'uploading', false, 'image/jpeg', 100000),
+  ('7d000000-0000-4000-8000-000000000005',
+   '7c000000-0000-4000-8000-000000000001',
+   'curator/cancelling.jpg', NULL, 'cover', 'cancelling', false, 'image/jpeg', 100000);
 
 -- Storage objects backing those rows. The bucket is private, so `storage.objects` SELECT
 -- is what decides whether a caller may mint a signed URL for a path.
@@ -76,9 +82,11 @@ select is(
 insert into storage.objects (bucket_id, name, metadata)
 values
   ('location-media', 'curator/published-cover.jpg', '{}'::jsonb),
+  ('location-media', 'delivery/published-cover.jpg', '{}'::jsonb),
   ('location-media', 'curator/draft-cover.jpg', '{}'::jsonb),
   ('location-media', 'curator/published-secondary.jpg', '{}'::jsonb),
-  ('location-media', 'curator/uploading.jpg', '{}'::jsonb)
+  ('location-media', 'curator/uploading.jpg', '{}'::jsonb),
+  ('location-media', 'curator/cancelling.jpg', '{}'::jsonb)
 on conflict (bucket_id, name) do update set metadata = excluded.metadata;
 
 -- Anonymous public reader ------------------------------------------------------
@@ -90,18 +98,30 @@ select results_eq(
   $$ select object_path from public.location_media order by object_path $$,
   $$ values ('curator/published-cover.jpg'::text),
             ('curator/published-secondary.jpg'::text) $$,
-  'anonymous readers see published location media only — no draft or uploading path leaks'
+  'anonymous readers see published location media only — no draft, uploading or cancelling path leaks'
 );
 
--- Direct object reads: only the published PRIMARY cover may be signed by the public.
+-- The revocation guarantee, stated as a policy fact: the delivery copy is the ONLY object
+-- a public caller can sign. Deleting that copy therefore ends public access outright,
+-- which no signed-URL TTL or policy edit could do on its own.
 select results_eq(
   $$
     select name from storage.objects
      where bucket_id = 'location-media'
      order by name
   $$,
-  $$ values ('curator/published-cover.jpg'::text) $$,
-  'anonymous callers can read only the object behind the published primary cover'
+  $$ values ('delivery/published-cover.jpg'::text) $$,
+  'anonymous callers can read only the delivery copy of the published primary cover'
+);
+
+select is(
+  (
+    select count(*)::integer from storage.objects
+     where bucket_id = 'location-media'
+       and name = 'curator/published-cover.jpg'
+  ),
+  0,
+  'the ORIGINAL behind a live published cover is unreadable — only the delivery copy is served'
 );
 
 select is(
@@ -122,6 +142,16 @@ select is(
   ),
   0,
   'an object reserved by an uploading record cannot be read directly'
+);
+
+select is(
+  (
+    select count(*)::integer from storage.objects
+     where bucket_id = 'location-media'
+       and name = 'curator/cancelling.jpg'
+  ),
+  0,
+  'an object whose row a cancel has claimed cannot be read directly'
 );
 
 select is(
@@ -159,10 +189,11 @@ select is(
   (
     select count(*)::integer from storage.objects
      where bucket_id = 'location-media'
-       and name in ('curator/draft-cover.jpg', 'curator/uploading.jpg')
+       and name in ('curator/draft-cover.jpg', 'curator/uploading.jpg',
+                    'curator/published-cover.jpg')
   ),
   0,
-  'a signed-in non-admin cannot read draft or uploading objects directly'
+  'a signed-in non-admin cannot read draft, uploading or original cover objects directly'
 );
 
 select throws_ok(
@@ -192,14 +223,14 @@ select is(
 
 select is(
   (select count(*)::integer from public.location_media),
-  4,
-  'an admin sees drafts and uploading records alongside published media'
+  5,
+  'an admin sees drafts, uploading and cancelling records alongside published media'
 );
 
 select is(
   (select count(*)::integer from storage.objects where bucket_id = 'location-media'),
-  4,
-  'an admin can read every object in the bucket, drafts included'
+  6,
+  'an admin can read every object in the bucket, originals and drafts included'
 );
 
 -- The primary flag may only sit on a row the public resolver can actually serve.
@@ -214,13 +245,50 @@ select throws_ok(
   'a draft cannot be made primary — a primary that resolves to nothing is not a cover'
 );
 
-select lives_ok(
+select throws_ok(
   $$
     update public.location_media
        set is_primary = true, status = 'published'
      where id = '7d000000-0000-4000-8000-000000000002'
   $$,
-  'an admin can promote another asset to primary by publishing it as a cover'
+  '23514',
+  NULL,
+  'publishing without a delivery copy is rejected — a primary must have something revocable'
+);
+
+-- Fail-closed swap: the demote-siblings trigger would otherwise strand the outgoing
+-- primary's delivery copy, leaving the bucket serving a cover the console shows as demoted.
+select throws_ok(
+  $$
+    update public.location_media
+       set is_primary = true, status = 'published',
+           delivery_object_path = 'delivery/new-cover.jpg'
+     where id = '7d000000-0000-4000-8000-000000000002'
+  $$,
+  '23514',
+  NULL,
+  'promotion is refused while the outgoing primary still holds a live delivery copy'
+);
+
+-- What the application does before any demotion completes: delete the bytes, then drop
+-- the claim on them in the same statement that clears the flag.
+select lives_ok(
+  $$
+    update public.location_media
+       set is_primary = false, delivery_object_path = NULL
+     where id = '7d000000-0000-4000-8000-000000000001'
+  $$,
+  'revoking the delivery copy and demoting in one write is the supported transition'
+);
+
+select lives_ok(
+  $$
+    update public.location_media
+       set is_primary = true, status = 'published',
+           delivery_object_path = 'delivery/new-cover.jpg'
+     where id = '7d000000-0000-4000-8000-000000000002'
+  $$,
+  'once the previous copy is revoked, the replacement can be promoted'
 );
 
 select is(
@@ -254,6 +322,17 @@ select throws_ok(
   '23514',
   NULL,
   'demoting a primary to gallery must clear the flag too'
+);
+
+select throws_ok(
+  $$
+    update public.location_media
+       set delivery_object_path = NULL
+     where id = '7d000000-0000-4000-8000-000000000002'
+  $$,
+  '23514',
+  NULL,
+  'a primary cannot drop its delivery copy and stay primary — the two are one fact'
 );
 
 select * from finish();


### PR DESCRIPTION
Closes signed-URL revocation and upload-cancel race. Delivery copies are deleted before demotion/unpublish; original assets stay private. CI database gate required before merge.