### PR TITLE
fix: request dates, catalog pricing and destination media

### DIFF
--- a/src/app/(protected)/admin/locations/[locationId]/_components/location-media-console.test.tsx
+++ b/src/app/(protected)/admin/locations/[locationId]/_components/location-media-console.test.tsx
@@ -91,6 +91,33 @@ describe("LocationMediaConsole", () => {
     vi.mocked(uploadFileToSignedUrl).mockResolvedValue(undefined);
   });
 
+  it("renders the static cover guide without assertive alert semantics", () => {
+    renderConsole([]);
+
+    const guide = screen.getByText(/не общий баннер и не изображение главной страницы/);
+
+    expect(guide).toBeInTheDocument();
+    expect(guide.closest('[role="alert"]')).toBeNull();
+    expect(screen.getByText(/публичный список запросов и страницы отдельных запросов/)).toBeInTheDocument();
+    expect(screen.getByText(/Выберите «Обложка»\./)).toBeInTheDocument();
+    expect(screen.getByText("Загрузите JPG, PNG или WebP до 5 МБ.")).toBeInTheDocument();
+    expect(screen.getByText(/описание \(alt\) — рекомендуем/)).toBeInTheDocument();
+    expect(screen.getByText("Опубликуйте изображение.")).toBeInTheDocument();
+    expect(screen.getByText(/Нажмите «Сделать главной»\./)).toBeInTheDocument();
+    expect(screen.getByText(/16:9, 1600×900: это рекомендация/)).toBeInTheDocument();
+    expect(screen.getByText(/«Галерея» не заменяет фирменный городской градиент/)).toBeInTheDocument();
+  });
+
+  it("keeps upload failures as assertive alerts", () => {
+    renderConsole([]);
+
+    fireEvent.change(screen.getByLabelText("Файл изображения"), {
+      target: { files: [new File(["not-an-image"], "cover.pdf", { type: "application/pdf" })] },
+    });
+
+    expect(screen.getByText("Разрешены только JPG, PNG или WEBP.").closest('[role="alert"]')).not.toBeNull();
+  });
+
   it("warns that the branded gradient stays while no primary cover is published", () => {
     renderConsole([MEDIA]);
 

--- a/src/app/(protected)/admin/locations/[locationId]/_components/location-media-console.tsx
+++ b/src/app/(protected)/admin/locations/[locationId]/_components/location-media-console.tsx
@@ -151,6 +151,28 @@ export function LocationMediaConsole({
 
   return (
     <div className="flex flex-col gap-6">
+      <section className="rounded-lg border bg-card px-2.5 py-2 text-left">
+        <div className="space-y-2 text-sm text-muted-foreground">
+          <p>
+            Обложка локации — не общий баннер и не изображение главной страницы. Опубликованная
+            главная обложка меняет только публичный список запросов и страницы отдельных запросов
+            для этой локации; остальные поверхности сохраняют текущий вид.
+          </p>
+          <ol className="list-decimal space-y-1 pl-5">
+            <li>Выберите «Обложка».</li>
+            <li>Загрузите JPG, PNG или WebP до 5 МБ.</li>
+            <li>Добавьте понятное описание (alt) — рекомендуем; подпись и источник / права необязательны.</li>
+            <li>Опубликуйте изображение.</li>
+            <li>Нажмите «Сделать главной».</li>
+          </ol>
+          <p>
+            Рекомендуем горизонтальный формат 16:9, 1600×900: это рекомендация, не обязательное
+            требование. «Галерея» не заменяет фирменный городской градиент — это делает только
+            опубликованная главная «Обложка».
+          </p>
+        </div>
+      </section>
+
       <div className="rounded-card border border-border bg-surface-high p-5">
         <h2 className="text-base font-semibold text-foreground">Загрузить изображение</h2>
         <p className="mt-1 text-sm text-muted-foreground">

--- a/src/app/(site)/listings/page.test.tsx
+++ b/src/app/(site)/listings/page.test.tsx
@@ -1,11 +1,13 @@
 import { render, screen } from "@testing-library/react";
 import { describe, expect, it, beforeEach, vi } from "vitest";
+import type { ListingRecord } from "@/data/supabase/queries";
 
-const { redirectMock, flagsMock } = vi.hoisted(() => ({
+const { redirectMock, flagsMock, discoveryScreenMock } = vi.hoisted(() => ({
   redirectMock: vi.fn(() => {
     throw new Error("NEXT_REDIRECT");
   }),
   flagsMock: { FEATURE_PUBLIC_CATALOG: true },
+  discoveryScreenMock: vi.fn((_props: unknown) => null),
 }));
 
 vi.mock("next/navigation", () => ({ redirect: redirectMock }));
@@ -22,9 +24,7 @@ vi.mock("@/data/supabase/queries", () => ({
 }));
 
 vi.mock("@/features/listings/components/public/public-listing-discovery-screen", () => ({
-  PublicListingDiscoveryScreen: () => (
-    <section aria-label="discovery">PublicListingDiscoveryScreen</section>
-  ),
+  PublicListingDiscoveryScreen: discoveryScreenMock,
 }));
 
 import PublicListingsPage from "./page";
@@ -33,6 +33,7 @@ describe("PublicListingsPage", () => {
   beforeEach(() => {
     redirectMock.mockClear();
     getActiveListings.mockReset();
+    discoveryScreenMock.mockClear();
     flagsMock.FEATURE_PUBLIC_CATALOG = true;
   });
 
@@ -53,5 +54,42 @@ describe("PublicListingsPage", () => {
 
     expect(screen.getByText("Не удалось загрузить экскурсии. Попробуйте обновить страницу.")).toBeInTheDocument();
     expect(screen.queryByLabelText("discovery")).not.toBeInTheDocument();
+  });
+
+  it("passes a ready tour's per-group price scope to the public catalogue", async () => {
+    const listing: ListingRecord = {
+      id: "listing-1",
+      slug: "kazan-kremlin",
+      title: "Казанский кремль",
+      destinationSlug: "kazan",
+      destinationName: "Казань",
+      destinationRegion: "Татарстан",
+      imageUrl: "https://example.com/kazan.jpg",
+      priceRub: 5000,
+      durationDays: 1,
+      durationLabel: "1 дн.",
+      groupSize: 8,
+      difficulty: "Средняя",
+      departure: "Казань",
+      format: "group",
+      priceScope: "per_group",
+      category: "history_culture",
+      description: "Кремль",
+      inclusions: ["Работа гида"],
+      exclusions: [],
+      guideSlug: "guide-1",
+      guideName: "Иван",
+      guideHomeBase: "Казань",
+      rating: 4.8,
+      reviewCount: 12,
+      status: "active",
+    };
+    getActiveListings.mockResolvedValueOnce({ data: [listing], error: null });
+
+    render(await PublicListingsPage({ searchParams: Promise.resolve({}) }));
+
+    expect(discoveryScreenMock.mock.calls[0]?.[0]).toMatchObject({
+      listings: [expect.objectContaining({ priceScope: "per_group" })],
+    });
   });
 });

--- a/src/app/(site)/listings/page.tsx
+++ b/src/app/(site)/listings/page.tsx
@@ -29,6 +29,7 @@ function mapToPublicListing(listing: ListingRecord): PublicListing {
     format: (["private", "group", "combo"].includes(listing.format)
       ? listing.format
       : null) as PublicListing["format"],
+    priceScope: listing.priceScope,
     themes: (() => {
       const slug = mapDbCategoryToThemeSlug(listing.category);
       return slug != null ? ([slug] as const) : [];

--- a/src/data/public-listings/types.ts
+++ b/src/data/public-listings/types.ts
@@ -32,6 +32,8 @@ export type PublicListing = {
   groupSizeMax: number;
   /** Real booking format enum (private | group | combo); drives the price unit. */
   format?: "private" | "group" | "combo" | null;
+  /** Ready-tour price scope; overrides the format badge for price wording. */
+  priceScope?: "per_person" | "per_group";
   themes: readonly PublicListingTheme[];
   highlights: readonly string[];
   itinerary: readonly PublicListingItineraryItem[];

--- a/src/features/guide/components/portfolio/guide-portfolio-screen.test.tsx
+++ b/src/features/guide/components/portfolio/guide-portfolio-screen.test.tsx
@@ -1,12 +1,14 @@
-import { render, waitFor } from "@testing-library/react";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { describe, expect, it, vi } from "vitest";
 
 const {
   createSupabaseBrowserClientMock,
   listGuideLocationPhotosMock,
+  uploadPortfolioPhotoMock,
 } = vi.hoisted(() => ({
   createSupabaseBrowserClientMock: vi.fn(),
   listGuideLocationPhotosMock: vi.fn(),
+  uploadPortfolioPhotoMock: vi.fn(),
 }));
 
 vi.mock("@/lib/supabase/client", () => ({
@@ -16,7 +18,7 @@ vi.mock("@/lib/supabase/client", () => ({
 vi.mock("@/lib/supabase/guide-assets", () => ({
   deleteGuideLocationPhoto: vi.fn(),
   listGuideLocationPhotos: listGuideLocationPhotosMock,
-  uploadPortfolioPhoto: vi.fn(),
+  uploadPortfolioPhoto: uploadPortfolioPhotoMock,
 }));
 
 vi.mock("next/image", () => ({
@@ -46,6 +48,54 @@ describe("GuidePortfolioScreen", () => {
 
     await waitFor(() => {
       expect(listGuideLocationPhotosMock).toHaveBeenCalledWith("guide-from-auth");
+    });
+  });
+
+  it("accepts a free-text location and uploads its required metadata", async () => {
+    listGuideLocationPhotosMock.mockResolvedValue([]);
+    uploadPortfolioPhotoMock.mockResolvedValue({
+      id: "photo-id",
+      guide_id: "guide-from-auth",
+      storage_asset_id: "asset-id",
+      location_name: "Смотровая у старого маяка",
+      sort_order: 0,
+      created_at: "2026-07-20T00:00:00.000Z",
+      object_path: "guide-from-auth/photo-id.jpg",
+    });
+    createSupabaseBrowserClientMock.mockReturnValue({
+      auth: {
+        getUser: vi.fn().mockResolvedValue({
+          data: { user: { id: "guide-from-auth" } },
+          error: null,
+        }),
+      },
+      storage: {
+        from: () => ({
+          getPublicUrl: () => ({ data: { publicUrl: "" } }),
+        }),
+      },
+    });
+
+    render(<GuidePortfolioScreen guideId="guide-from-prop" />);
+
+    const location = await screen.findByLabelText("Локация");
+    expect(location).toHaveAttribute("type", "text");
+    expect(screen.queryByRole("combobox", { name: "Локация" })).not.toBeInTheDocument();
+    expect(screen.queryByText("Выберите локацию")).not.toBeInTheDocument();
+
+    fireEvent.change(location, { target: { value: "Смотровая у старого маяка" } });
+    const fileInput = document.querySelector('input[type="file"]') as HTMLInputElement;
+    expect(fileInput).toBeEnabled();
+    const file = new File(["image"], "lighthouse.jpg", { type: "image/jpeg" });
+    fireEvent.change(fileInput, { target: { files: [file] } });
+
+    await waitFor(() => {
+      expect(uploadPortfolioPhotoMock).toHaveBeenCalledWith({
+        guideId: "guide-from-auth",
+        file,
+        locationName: "Смотровая у старого маяка",
+        sortOrder: 0,
+      });
     });
   });
 });

--- a/src/features/guide/components/portfolio/guide-portfolio-screen.tsx
+++ b/src/features/guide/components/portfolio/guide-portfolio-screen.tsx
@@ -9,10 +9,6 @@ import {
   listGuideLocationPhotos,
   uploadPortfolioPhoto,
 } from "@/lib/supabase/guide-assets";
-import {
-  listActiveLocations,
-  type LocationCatalogEntry,
-} from "@/lib/supabase/location-catalog";
 import { CoachCallout } from "@/features/guide/components/excursions/photobank-coach";
 import type { GuideLocationPhotoRow, Uuid } from "@/lib/supabase/types";
 
@@ -44,7 +40,6 @@ export function GuidePortfolioScreen({ guideId: _guideId }: GuidePortfolioScreen
   const [uploading, setUploading] = useState(false);
   const [deletingId, setDeletingId] = useState<string | null>(null);
   const [locationName, setLocationName] = useState("");
-  const [locations, setLocations] = useState<LocationCatalogEntry[]>([]);
   const [uploadError, setUploadError] = useState<string | null>(null);
   const [brokenIds, setBrokenIds] = useState<Set<string>>(new Set());
   const fileInputRef = useRef<HTMLInputElement | null>(null);
@@ -67,13 +62,6 @@ export function GuidePortfolioScreen({ guideId: _guideId }: GuidePortfolioScreen
         setPhotos(
           rows.map((r) => ({ ...r, publicUrl: buildPublicUrl(supabase, r.object_path) })),
         );
-
-        try {
-          const activeLocations = await listActiveLocations(supabase);
-          if (!cancelled) setLocations(activeLocations);
-        } catch {
-          if (!cancelled) setLocations([]);
-        }
       } catch (err) {
         if (cancelled) return;
         console.error("[portfolio] list failed", err);
@@ -190,19 +178,18 @@ export function GuidePortfolioScreen({ guideId: _guideId }: GuidePortfolioScreen
       <div className="mt-6">
         <div className="mb-8 rounded-xl border border-border bg-surface-high p-5">
           <p className="mb-3 text-sm font-medium">Добавить локацию</p>
-          <select
-            aria-label="Локация"
+          <label htmlFor="photo-location" className="mb-1 block text-sm font-medium">
+            Локация
+          </label>
+          <input
+            id="photo-location"
+            type="text"
+            placeholder="Название места"
             value={locationName}
+            maxLength={80}
             onChange={(e) => setLocationName(e.target.value)}
             className="mb-3 w-full rounded-xl border border-border bg-surface px-3.5 py-2.5 text-sm outline-none focus:border-primary"
-          >
-            <option value="">Выберите локацию</option>
-            {locations.map((loc) => (
-              <option key={loc.id} value={loc.name}>
-                {loc.name}
-              </option>
-            ))}
-          </select>
+          />
           <label
             className={`inline-flex items-center gap-2 rounded-xl px-4 py-2.5 text-sm font-medium text-primary-foreground transition-opacity ${
               disabled
@@ -222,9 +209,7 @@ export function GuidePortfolioScreen({ guideId: _guideId }: GuidePortfolioScreen
           </label>
           {!locationName.trim() && !uploading && (
             <p className="mt-2 text-xs text-muted-foreground">
-              {locations.length === 0
-                ? "Список локаций пока пуст — обратитесь к администратору."
-                : "Выберите локацию, чтобы загрузить фото"}
+              Введите локацию, чтобы загрузить фото
             </p>
           )}
           {reachedLimit && !uploading && (

--- a/src/features/guide/components/requests/bid-form-panel.test.tsx
+++ b/src/features/guide/components/requests/bid-form-panel.test.tsx
@@ -138,11 +138,11 @@ describe("BidFormPanel — mode line", () => {
 });
 
 describe("BidFormPanel — date/time locks", () => {
-  it("disables date and time fields when date_locked/time_locked are true", () => {
+  it("disables exact dates even when date_locked=false", () => {
     render(
       <BidFormPanel
         requestId="req-1"
-        request={{ ...baseRequest, date_locked: true, time_locked: true }}
+        request={{ ...baseRequest, dateFlexibility: "exact", date_locked: false, time_locked: true }}
         onClose={() => {}}
       />,
     );
@@ -165,6 +165,7 @@ describe("BidFormPanel — date/time locks", () => {
       screen.queryByText("Путешественник открыт к близким датам — предложите удобную вам дату"),
     ).toBeNull();
     expect(screen.getByText("Гибкие даты")).toBeInTheDocument();
+    expect(screen.getByLabelText(/Дата/)).toBeEnabled();
   });
 });
 

--- a/src/features/guide/components/requests/bid-form-panel.tsx
+++ b/src/features/guide/components/requests/bid-form-panel.tsx
@@ -117,7 +117,7 @@ export function BidFormPanel({
 
   const travelerDate = request.startsOn ? request.startsOn.slice(0, 10) : "";
   const travelerCount = request.groupSize > 0 ? request.groupSize : 1;
-  const dateLocked = request.dateFlexibility === "few_days" ? false : (request.date_locked ?? true);
+  const dateLocked = request.dateFlexibility !== "few_days";
   const timeLocked = request.time_locked ?? true;
 
   const {

--- a/src/features/guide/components/requests/guide-requests-inbox-filter.test.ts
+++ b/src/features/guide/components/requests/guide-requests-inbox-filter.test.ts
@@ -35,6 +35,7 @@ const base = {
   cityFilter: "all",
   filter: "new" as const,
   offeredIds: new Set<string>(),
+  requestTypeFilter: "all" as const,
   sortKey: "newest" as const,
   specializations: ["nature"],
 };
@@ -60,5 +61,28 @@ describe("filterInbox — direct requests (item 9)", () => {
   it("still excludes a general request that fails the city filter", () => {
     const items = [rec({ id: "away", destination: "Сочи", interests: ["nature"] })];
     expect(filterInbox(items, base)).toHaveLength(0);
+  });
+});
+
+describe("filterInbox — request type", () => {
+  const items = [
+    rec({ id: "assembly", destination: "Москва", interests: ["nature"], mode: "assembly" }),
+    rec({ id: "private", destination: "Москва", interests: ["nature"], mode: "private" }),
+    rec({ id: "direct", destination: "Сочи", interests: ["history_culture"], mode: "private", isDirectToViewer: true }),
+  ];
+
+  it.each([
+    ["assembly", ["assembly"]],
+    ["private", ["private"]],
+    ["direct", ["direct"]],
+  ] as const)("selects only %s requests", (requestTypeFilter, expected) => {
+    expect(filterInbox(items, { ...base, requestTypeFilter }).map((item) => item.id)).toEqual(expected);
+  });
+
+  it("composes request type with new and my offers tabs", () => {
+    const options = { ...base, requestTypeFilter: "private" as const, offeredIds: new Set(["private"]) };
+
+    expect(filterInbox(items, { ...options, filter: "new" }).map((item) => item.id)).toEqual([]);
+    expect(filterInbox(items, { ...options, filter: "my-offers" }).map((item) => item.id)).toEqual(["private"]);
   });
 });

--- a/src/features/guide/components/requests/guide-requests-inbox-filter.ts
+++ b/src/features/guide/components/requests/guide-requests-inbox-filter.ts
@@ -2,12 +2,14 @@ import type { RequestRecord } from "@/data/supabase/queries";
 
 export type GuideRequestsFilter = "new" | "my-offers" | "confirmed";
 export type GuideRequestsSortKey = "newest" | "date" | "size";
+export type GuideRequestsTypeFilter = "all" | "assembly" | "private" | "direct";
 
 interface FilterInboxOptions {
   baseCity: string | null;
   cityFilter: string;
   filter: GuideRequestsFilter;
   offeredIds: Set<string>;
+  requestTypeFilter: GuideRequestsTypeFilter;
   sortKey: GuideRequestsSortKey;
   specializations: string[];
 }
@@ -25,6 +27,7 @@ export function filterInbox(
     cityFilter,
     filter,
     offeredIds,
+    requestTypeFilter,
     sortKey,
     specializations,
   }: FilterInboxOptions,
@@ -85,6 +88,15 @@ export function filterInbox(
     filtered = filtered.filter(
       (item: RequestRecord) =>
         item.isDirectToViewer || isMatchedRequest(item, specializations),
+    );
+  }
+
+  // A directed request is its own category, regardless of the underlying mode.
+  if (requestTypeFilter !== "all") {
+    filtered = filtered.filter((item) =>
+      requestTypeFilter === "direct"
+        ? item.isDirectToViewer
+        : !item.isDirectToViewer && item.mode === requestTypeFilter,
     );
   }
 

--- a/src/features/guide/components/requests/guide-requests-inbox-screen.test.tsx
+++ b/src/features/guide/components/requests/guide-requests-inbox-screen.test.tsx
@@ -1,7 +1,7 @@
 import { readFileSync } from "node:fs";
 import { join } from "node:path";
 
-import { render, screen, waitFor } from "@testing-library/react";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import { mapRequestRow, type RequestRecord } from "@/data/supabase/queries";
@@ -68,6 +68,7 @@ describe("filterInbox", () => {
       cityFilter: "all",
       filter: "new",
       offeredIds: new Set(),
+      requestTypeFilter: "all",
       sortKey: "newest",
       specializations: [],
     });
@@ -86,6 +87,7 @@ describe("filterInbox", () => {
       cityFilter: "all",
       filter: "new",
       offeredIds: new Set(),
+      requestTypeFilter: "all",
       sortKey: "newest",
       specializations: [],
     });
@@ -99,6 +101,7 @@ describe("getInboxTabCounts", () => {
     baseCity: "Элиста",
     cityFilter: "all",
     offeredIds: new Set(["elista-b", "karelia-c"]),
+    requestTypeFilter: "all" as const,
     sortKey: "newest" as const,
     specializations: [] as string[],
   };
@@ -188,6 +191,38 @@ describe("GuideRequestsInboxScreen meta layout", () => {
 
     await waitFor(() => {
       expect(loadGuideInboxRequestsMock).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  it("returns to all request types after selecting a type", async () => {
+    HTMLElement.prototype.scrollIntoView = vi.fn();
+    loadGuideInboxRequestsMock.mockResolvedValue({
+      data: [
+        request({ id: "assembly", title: "Сборный запрос", destination: "Элиста, центр" }),
+        request({ id: "private", title: "Приватный запрос", destination: "Элиста, центр", mode: "private" }),
+      ],
+      error: null,
+    });
+    render(<GuideRequestsInboxScreen />);
+
+    const trigger = await screen.findByLabelText("Фильтр по типу запроса");
+    fireEvent.click(trigger);
+    expect(await screen.findByRole("option", { name: "Все типы" })).toBeInTheDocument();
+    expect(await screen.findByRole("option", { name: "Сборная группа" })).toBeInTheDocument();
+    expect(screen.getByRole("option", { name: "Своя группа" })).toBeInTheDocument();
+    expect(screen.getByRole("option", { name: "Запрос на ваше имя" })).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("option", { name: "Сборная группа" }));
+    await waitFor(() => {
+      expect(screen.getAllByText("Сборная группа")).toHaveLength(2);
+      expect(screen.queryByText("Своя группа")).toBeNull();
+    });
+
+    fireEvent.click(trigger);
+    fireEvent.click(await screen.findByRole("option", { name: "Все типы" }));
+    await waitFor(() => {
+      expect(screen.getByText("Сборная группа")).toBeInTheDocument();
+      expect(screen.getByText("Своя группа")).toBeInTheDocument();
     });
   });
 

--- a/src/features/guide/components/requests/guide-requests-inbox-screen.test.tsx
+++ b/src/features/guide/components/requests/guide-requests-inbox-screen.test.tsx
@@ -237,6 +237,30 @@ describe("GuideRequestsInboxScreen meta layout", () => {
     expect(screen.queryByText("Не удалось загрузить запросы. Попробуйте обновить страницу.")).toBeNull();
   });
 
+  it("shows an exact date when guides may suggest alternatives", async () => {
+    loadGuideInboxRequestsMock.mockResolvedValue({
+      data: [request({ dateFlexibility: "exact", date_locked: false })],
+      error: null,
+    });
+
+    render(<GuideRequestsInboxScreen />);
+
+    expect(await screen.findByText("Точная дата")).toBeInTheDocument();
+    expect(screen.queryByText("Гибкие даты")).toBeNull();
+  });
+
+  it("shows flexible dates only for a few_days request", async () => {
+    loadGuideInboxRequestsMock.mockResolvedValue({
+      data: [request({ dateFlexibility: "few_days", date_locked: true })],
+      error: null,
+    });
+
+    render(<GuideRequestsInboxScreen />);
+
+    expect(await screen.findByText("Гибкие даты")).toBeInTheDocument();
+    expect(screen.queryByText("Точная дата")).toBeNull();
+  });
+
   it("keeps the request time inline with the date meta row", () => {
     const source = readFileSync(
       join(

--- a/src/features/guide/components/requests/guide-requests-inbox-screen.tsx
+++ b/src/features/guide/components/requests/guide-requests-inbox-screen.tsx
@@ -35,6 +35,7 @@ import {
   isMatchedRequest,
   type GuideRequestsFilter,
   type GuideRequestsSortKey,
+  type GuideRequestsTypeFilter,
 } from "./guide-requests-inbox-filter";
 import { GuideOfferQaPanel } from "./guide-offer-qa-panel";
 import type { OfferMeta } from "./offer-meta";
@@ -86,6 +87,7 @@ export function GuideRequestsInboxScreen() {
   const [filter, setFilter] = React.useState<GuideRequestsFilter>("new");
   const [didAutoSelect, setDidAutoSelect] = React.useState(false);
   const [cityFilter, setCityFilter] = React.useState<string>("all");
+  const [requestTypeFilter, setRequestTypeFilter] = React.useState<GuideRequestsTypeFilter>("all");
   const [sortKey, setSortKey] = React.useState<GuideRequestsSortKey>(
     "newest",
   );
@@ -176,10 +178,11 @@ export function GuideRequestsInboxScreen() {
         baseCity,
         cityFilter,
         offeredIds,
+        requestTypeFilter,
         sortKey,
         specializations,
       }),
-    [items, offeredIds, baseCity, cityFilter, sortKey, specializations],
+    [items, offeredIds, baseCity, cityFilter, requestTypeFilter, sortKey, specializations],
   );
 
   React.useEffect(() => {
@@ -201,10 +204,11 @@ export function GuideRequestsInboxScreen() {
       cityFilter,
       filter,
       offeredIds,
+      requestTypeFilter,
       sortKey,
       specializations,
     });
-  }, [filter, items, offeredIds, baseCity, cityFilter, sortKey, specializations]);
+  }, [filter, items, offeredIds, baseCity, cityFilter, requestTypeFilter, sortKey, specializations]);
 
   const panelRequest = panelRequestId
     ? items.find((i) => i.id === panelRequestId)
@@ -297,6 +301,20 @@ export function GuideRequestsInboxScreen() {
                         <SelectItem value="newest">Новые сначала</SelectItem>
                         <SelectItem value="date">По дате запроса</SelectItem>
                         <SelectItem value="size">По размеру группы</SelectItem>
+                      </SelectContent>
+                    </Select>
+                    <Select
+                      value={requestTypeFilter}
+                      onValueChange={(next) => setRequestTypeFilter(next as GuideRequestsTypeFilter)}
+                    >
+                      <SelectTrigger className="min-h-11" aria-label="Фильтр по типу запроса">
+                        <SelectValue />
+                      </SelectTrigger>
+                      <SelectContent>
+                        <SelectItem value="all">Все типы</SelectItem>
+                        <SelectItem value="assembly">Сборная группа</SelectItem>
+                        <SelectItem value="private">Своя группа</SelectItem>
+                        <SelectItem value="direct">Запрос на ваше имя</SelectItem>
                       </SelectContent>
                     </Select>
                   </div>

--- a/src/features/guide/components/requests/guide-requests-inbox-screen.tsx
+++ b/src/features/guide/components/requests/guide-requests-inbox-screen.tsx
@@ -317,7 +317,7 @@ export function GuideRequestsInboxScreen() {
                     const offerStatus = offerMeta?.status ?? "pending";
                     const isDeclinedOffer = offerStatus === "declined";
                     const showQaPanel = alreadyOffered && !!offerId && !isDeclinedOffer;
-                    const hasFlexibleDates = item.dateFlexibility === "few_days" || item.date_locked === false;
+                    const hasFlexibleDates = item.dateFlexibility === "few_days";
                     return (
                       <div key={item.id} className="flex flex-col gap-3">
                         <div className="rounded-xl border border-border/70 bg-background/60 p-4 transition hover:border-primary/40">

--- a/src/features/guide/offer-actions.test.ts
+++ b/src/features/guide/offer-actions.test.ts
@@ -27,6 +27,7 @@ import {
 } from "@/features/guide/offer-actions";
 
 const baseRequest = {
+  date_flexibility: "exact",
   date_locked: true,
   time_locked: true,
   starts_on: "2026-09-10",
@@ -64,11 +65,11 @@ describe("checkOfferAgainstLocks", () => {
     }
   });
 
-  it("accepts when both locks are off even if date and time differ", async () => {
+  it("accepts when few_days and time lock are off even if date and time differ", async () => {
     const result = await checkOfferAgainstLocks({
       startsAt: makeIso("2026-09-12", "15:00"),
       endsAt: makeIso("2026-09-12", "18:00"),
-      request: { ...baseRequest, date_locked: false, time_locked: false },
+      request: { ...baseRequest, date_flexibility: "few_days", time_locked: false },
     });
 
     expect("ok" in result && result.ok).toBe(true);
@@ -84,11 +85,21 @@ describe("checkOfferAgainstLocks", () => {
     expect("ok" in result && result.ok).toBe(true);
   });
 
-  it("accepts different date when date_locked=false regardless of date mismatch", async () => {
+  it("rejects a changed date for exact requests even when date_locked=false", async () => {
     const result = await checkOfferAgainstLocks({
       startsAt: makeIso("2026-09-15", "10:00"),
       endsAt: makeIso("2026-09-15", "13:00"),
       request: { ...baseRequest, date_locked: false },
+    });
+
+    expect("error" in result).toBe(true);
+  });
+
+  it("accepts a changed date for few_days requests even when date_locked=true", async () => {
+    const result = await checkOfferAgainstLocks({
+      startsAt: makeIso("2026-09-15", "10:00"),
+      endsAt: makeIso("2026-09-15", "13:00"),
+      request: { ...baseRequest, date_flexibility: "few_days" },
     });
 
     expect("ok" in result && result.ok).toBe(true);
@@ -96,6 +107,45 @@ describe("checkOfferAgainstLocks", () => {
 });
 
 describe("submitOfferAction", () => {
+  it("rejects a changed date for exact requests even when date_locked=false", async () => {
+    const profileSelect = vi.fn().mockReturnValue({
+      eq: vi.fn().mockReturnValue({ maybeSingle: vi.fn().mockResolvedValue({ data: { account_status: "active" } }) }),
+    });
+    const guideSelect = vi.fn().mockReturnValue({
+      eq: vi.fn().mockReturnValue({ maybeSingle: vi.fn().mockResolvedValue({ data: { verification_status: "approved", is_available: true } }) }),
+    });
+    const offerSelect = vi.fn().mockReturnValue({
+      eq: vi.fn().mockReturnValue({
+        eq: vi.fn().mockReturnValue({ limit: vi.fn().mockReturnValue({ maybeSingle: vi.fn().mockResolvedValue({ data: null }) }) }),
+      }),
+    });
+    const requestSelect = vi.fn().mockReturnValue({
+      eq: vi.fn().mockReturnValue({
+        maybeSingle: vi.fn().mockResolvedValue({ data: { ...baseRequest, traveler_id: "trav-1", date_locked: false } }),
+      }),
+    });
+    createSupabaseServerClientMock.mockResolvedValue({
+      auth: { getUser: vi.fn().mockResolvedValue({ data: { user: { id: "guide-1" } } }) },
+      from: vi.fn((table: string) => {
+        if (table === "profiles") return { select: profileSelect };
+        if (table === "guide_profiles") return { select: guideSelect };
+        if (table === "guide_offers") return { select: offerSelect };
+        if (table === "traveler_requests") return { select: requestSelect };
+        throw new Error(`unexpected table ${table}`);
+      }),
+    });
+    const fd = new FormData();
+    fd.set("price_total", "5000");
+    fd.set("message", "предложение достаточной длины для валидации");
+    fd.set("valid_until", "2027-01-01");
+    fd.set("starts_at", makeIso("2026-09-11", "10:00"));
+    fd.set("ends_at", makeIso("2026-09-11", "13:00"));
+
+    await expect(submitOfferAction("11111111-1111-4111-8111-111111111111", fd)).resolves.toEqual({
+      error: "Путешественник просит строго эту дату.",
+    });
+  });
+
   it("rejects unverified guide profiles before submitting an offer", async () => {
     const guideMaybeSingle = vi.fn().mockResolvedValue({
       data: { verification_status: "draft" },
@@ -302,6 +352,41 @@ describe("withdrawOfferAction", () => {
 });
 
 describe("editOfferAction", () => {
+  it("rejects a changed date for exact requests even when date_locked=false", async () => {
+    const profileSelect = vi.fn().mockReturnValue({
+      eq: vi.fn().mockReturnValue({ maybeSingle: vi.fn().mockResolvedValue({ data: { account_status: "active" } }) }),
+    });
+    const offerSelect = vi.fn().mockReturnValue({
+      eq: vi.fn().mockReturnValue({ maybeSingle: vi.fn().mockResolvedValue({
+        data: { id: "offer-1", guide_id: "guide-1", status: "pending", request_id: "req-1" },
+      }) }),
+    });
+    const requestSelect = vi.fn().mockReturnValue({
+      eq: vi.fn().mockReturnValue({
+        maybeSingle: vi.fn().mockResolvedValue({ data: { ...baseRequest, traveler_id: "trav-1", date_locked: false } }),
+      }),
+    });
+    createSupabaseServerClientMock.mockResolvedValue({
+      auth: { getUser: vi.fn().mockResolvedValue({ data: { user: { id: "guide-1" } } }) },
+      from: vi.fn((table: string) => {
+        if (table === "profiles") return { select: profileSelect };
+        if (table === "guide_offers") return { select: offerSelect };
+        if (table === "traveler_requests") return { select: requestSelect };
+        throw new Error(`unexpected table ${table}`);
+      }),
+    });
+    const fd = new FormData();
+    fd.set("price_total", "5000");
+    fd.set("message", "обновлённое предложение достаточной длины");
+    fd.set("valid_until", "2027-01-01");
+    fd.set("starts_at", makeIso("2026-09-11", "10:00"));
+    fd.set("ends_at", makeIso("2026-09-11", "13:00"));
+
+    await expect(editOfferAction("offer-1", "11111111-1111-4111-8111-111111111111", fd)).resolves.toEqual({
+      error: "Путешественник просит строго эту дату.",
+    });
+  });
+
   it("rejects when the offer is not pending", async () => {
     const offerMaybeSingle = vi.fn().mockResolvedValue({
       data: { id: "offer-1", guide_id: "guide-1", status: "accepted", request_id: "req-1" },

--- a/src/features/guide/offer-actions.ts
+++ b/src/features/guide/offer-actions.ts
@@ -18,6 +18,7 @@ import type { SubmitOfferResult } from "@/features/guide/offer-action-types";
 export type { SubmitOfferResult } from "@/features/guide/offer-action-types";
 
 export type LockEnforcementRequest = {
+  date_flexibility?: string | null;
   date_locked?: boolean | null;
   time_locked?: boolean | null;
   starts_on: string;
@@ -68,7 +69,7 @@ export async function checkOfferAgainstLocks(args: {
   const startsAt = toMoscowIsoParts(args.startsAt);
   const endsAt = toMoscowIsoParts(args.endsAt);
 
-  if (args.request.date_locked && startsAt?.date !== args.request.starts_on) {
+  if (args.request.date_flexibility !== "few_days" && startsAt?.date !== args.request.starts_on) {
     return { error: "Путешественник просит строго эту дату." };
   }
 
@@ -205,10 +206,7 @@ export async function submitOfferAction(
     const lockCheck = await checkOfferAgainstLocks({
       startsAt: parsed.data.starts_at ?? undefined,
       endsAt: parsed.data.ends_at ?? undefined,
-      request: {
-        ...requestRow,
-        date_locked: requestRow.date_flexibility === "few_days" ? false : requestRow.date_locked,
-      },
+      request: requestRow,
     });
 
     if ("error" in lockCheck) {
@@ -376,7 +374,7 @@ export async function editOfferAction(
     const lockCheck = await checkOfferAgainstLocks({
       startsAt: parsed.data.starts_at ?? undefined,
       endsAt: parsed.data.ends_at ?? undefined,
-      request: { ...requestRow, date_locked: requestRow.date_flexibility === "few_days" ? false : requestRow.date_locked },
+      request: requestRow,
     });
     if ("error" in lockCheck) return { error: lockCheck.error };
 

--- a/src/features/listings/components/public/public-listing-discovery-screen.test.tsx
+++ b/src/features/listings/components/public/public-listing-discovery-screen.test.tsx
@@ -44,4 +44,14 @@ describe("PublicListingDiscoveryScreen", () => {
     // The tinted DiscoveryFilterBar strip uses bg-surface-low.
     expect(allPill.closest(".bg-surface-low")).not.toBeNull();
   });
+
+  it("renders a per-group ready-tour price", () => {
+    render(
+      <PublicListingDiscoveryScreen
+        listings={[makeListing(0, { priceScope: "per_group" })]}
+      />,
+    );
+
+    expect(screen.getByText("от 5 000 ₽ за группу до 8 человек")).toBeInTheDocument();
+  });
 });

--- a/src/features/listings/components/public/public-listing-discovery-screen.tsx
+++ b/src/features/listings/components/public/public-listing-discovery-screen.tsx
@@ -38,6 +38,7 @@ function mapListing(listing: PublicListing): ListingRecord {
     difficulty: "Средняя",
     departure: listing.city,
     format: listing.format ?? "",
+    priceScope: listing.priceScope,
     category: listing.themes[0] ?? "",
     description: listing.highlights.join(". "),
     inclusions: [...listing.inclusions],

--- a/src/features/requests/components/request-detail-screen.tsx
+++ b/src/features/requests/components/request-detail-screen.tsx
@@ -898,8 +898,7 @@ function GuideDetailBranch({
   }, [existingOfferId]);
 
   const validOfferId = offerId && UUID_RE.test(offerId) ? offerId : null;
-  const hasFlexibleDates =
-    request.dateFlexibility === "few_days" || request.date_locked === false;
+  const hasFlexibleDates = request.dateFlexibility === "few_days";
 
   return (
     <>

--- a/src/features/requests/create-request-actions.test.ts
+++ b/src/features/requests/create-request-actions.test.ts
@@ -180,9 +180,11 @@ describe("createRequestAction — flexibility is not silently locked (#owner609)
 
     expect(createTravelerRequestMock).toHaveBeenCalledTimes(1);
     const payload = createTravelerRequestMock.mock.calls[0][0] as {
+      date_flexibility: "exact" | "few_days";
       date_locked: boolean;
       time_locked: boolean;
     };
+    expect(payload.date_flexibility).toBe("exact");
     expect(payload.date_locked).toBe(false);
     expect(payload.time_locked).toBe(false);
   });

--- a/src/lib/supabase/location-media.test.ts
+++ b/src/lib/supabase/location-media.test.ts
@@ -223,8 +223,18 @@ describe("getPublishedLocationCovers", () => {
 describe("resolveLocationCover", () => {
   const covers = new Map([["казань", "https://signed.test/kazan.jpg"]]);
 
+  it("matches a bare city", () => {
+    expect(resolveLocationCover(covers, "Казань")).toBe("https://signed.test/kazan.jpg");
+  });
+
   it("matches case- and whitespace-insensitively", () => {
     expect(resolveLocationCover(covers, "  КАЗАНЬ ")).toBe("https://signed.test/kazan.jpg");
+  });
+
+  it("matches a city with its comma-separated region label", () => {
+    expect(resolveLocationCover(covers, "Казань, Татарстан")).toBe(
+      "https://signed.test/kazan.jpg",
+    );
   });
 
   it("returns null for an uncovered destination so the branded gradient stays", () => {

--- a/src/lib/supabase/location-media.ts
+++ b/src/lib/supabase/location-media.ts
@@ -504,7 +504,7 @@ export function resolveLocationCover(
   destination: string | null | undefined,
 ): string | null {
   if (!destination) return null;
-  return covers.get(destination.trim().toLocaleLowerCase("ru-RU")) ?? null;
+  return covers.get(destination.split(",", 1)[0].trim().toLocaleLowerCase("ru-RU")) ?? null;
 }
 
 /** Never throws: a media outage must not take the public marketplace down. */

--- a/supabase/migrations/20260720120100_enforce_exact_offer_dates.sql
+++ b/supabase/migrations/20260720120100_enforce_exact_offer_dates.sql
@@ -1,0 +1,31 @@
+-- Exact traveler dates are an invariant, not an action-layer preference: direct
+-- PostgREST writes (including admin writes) must obey the same Moscow-date rule.
+CREATE OR REPLACE FUNCTION public.enforce_exact_offer_start_date()
+RETURNS trigger
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path TO 'public', 'pg_temp'
+AS $$
+BEGIN
+  IF EXISTS (
+    SELECT 1
+    FROM public.traveler_requests request
+    WHERE request.id = NEW.request_id
+      AND request.date_flexibility = 'exact'
+      AND (
+        NEW.starts_at IS NULL
+        OR (NEW.starts_at AT TIME ZONE 'Europe/Moscow')::date <> request.starts_on
+      )
+  ) THEN
+    RAISE EXCEPTION 'offer_start_date_must_match_exact_request'
+      USING ERRCODE = '23514';
+  END IF;
+
+  RETURN NEW;
+END;
+$$;
+
+DROP TRIGGER IF EXISTS enforce_exact_offer_start_date ON public.guide_offers;
+CREATE TRIGGER enforce_exact_offer_start_date
+  BEFORE INSERT OR UPDATE OF starts_at, ends_at, request_id ON public.guide_offers
+  FOR EACH ROW EXECUTE FUNCTION public.enforce_exact_offer_start_date();

--- a/supabase/tests/accept_offer_authority_test.sql
+++ b/supabase/tests/accept_offer_authority_test.sql
@@ -36,10 +36,10 @@ values ('63000000-0000-4000-8000-000000000002','ao-guide-a','approved'),
 on conflict (user_id) do nothing;
 
 insert into public.traveler_requests (id, traveler_id, destination, region, status,
-        participants_count, starts_on, ends_on)
+        participants_count, starts_on, ends_on, date_flexibility)
 values ('63000000-0000-4000-8000-0000000000a1',
         '63000000-0000-4000-8000-000000000001','Элиста','Калмыкия','open',2,
-        (now() + interval '14 days')::date, (now() + interval '16 days')::date);
+        (now() + interval '14 days')::date, (now() + interval '16 days')::date, 'few_days');
 
 -- Two pending offers on the request: guide A @ 500000, guide B @ 900000.
 insert into public.guide_offers (id, request_id, guide_id, price_minor, currency, status)

--- a/supabase/tests/exact_offer_date_guard_test.sql
+++ b/supabase/tests/exact_offer_date_guard_test.sql
@@ -21,7 +21,8 @@ values
 insert into public.profiles (id, role, email, full_name, account_status)
 values
   ('71000000-0000-4000-8000-000000000001', 'traveler', 'offer-date-traveler@example.test', 'Traveler', 'active'),
-  ('71000000-0000-4000-8000-000000000002', 'guide', 'offer-date-guide@example.test', 'Guide', 'active');
+  ('71000000-0000-4000-8000-000000000002', 'guide', 'offer-date-guide@example.test', 'Guide', 'active')
+on conflict (id) do update set role = excluded.role, account_status = excluded.account_status;
 
 insert into public.guide_profiles (user_id, slug, verification_status, is_available)
 values ('71000000-0000-4000-8000-000000000002', 'offer-date-guide', 'approved', true);

--- a/supabase/tests/exact_offer_date_guard_test.sql
+++ b/supabase/tests/exact_offer_date_guard_test.sql
@@ -1,0 +1,90 @@
+begin;
+
+create extension if not exists pgtap with schema extensions;
+set search_path = public, extensions;
+
+select plan(4);
+
+insert into auth.users (id, instance_id, aud, role, email, encrypted_password,
+  email_confirmed_at, raw_app_meta_data, raw_user_meta_data, created_at, updated_at,
+  is_sso_user, confirmation_token, email_change, email_change_token_new, recovery_token)
+values
+  ('71000000-0000-4000-8000-000000000001', '00000000-0000-0000-0000-000000000000',
+   'authenticated', 'authenticated', 'offer-date-traveler@example.test',
+   extensions.crypt('x', extensions.gen_salt('bf')), now(), '{"provider":"email"}', '{}',
+   now(), now(), false, '', '', '', ''),
+  ('71000000-0000-4000-8000-000000000002', '00000000-0000-0000-0000-000000000000',
+   'authenticated', 'authenticated', 'offer-date-guide@example.test',
+   extensions.crypt('x', extensions.gen_salt('bf')), now(), '{"provider":"email"}', '{}',
+   now(), now(), false, '', '', '', '');
+
+insert into public.profiles (id, role, email, full_name, account_status)
+values
+  ('71000000-0000-4000-8000-000000000001', 'traveler', 'offer-date-traveler@example.test', 'Traveler', 'active'),
+  ('71000000-0000-4000-8000-000000000002', 'guide', 'offer-date-guide@example.test', 'Guide', 'active');
+
+insert into public.guide_profiles (user_id, slug, verification_status, is_available)
+values ('71000000-0000-4000-8000-000000000002', 'offer-date-guide', 'approved', true);
+
+insert into public.traveler_requests (
+  id, traveler_id, destination, interests, starts_on, ends_on, budget_minor,
+  participants_count, status, date_flexibility
+)
+values
+  ('72000000-0000-4000-8000-000000000001', '71000000-0000-4000-8000-000000000001',
+   'Exact', array['culture'], date '2026-11-10', date '2026-11-11', 100000, 1, 'open', 'exact'),
+  ('72000000-0000-4000-8000-000000000002', '71000000-0000-4000-8000-000000000001',
+   'Flexible', array['culture'], date '2026-11-10', date '2026-11-11', 100000, 1, 'open', 'few_days');
+
+set local role authenticated;
+select set_config('request.jwt.claim.role', 'authenticated', true);
+select set_config('request.jwt.claim.sub', '71000000-0000-4000-8000-000000000002', true);
+
+select throws_ok(
+  $$
+    insert into public.guide_offers (id, request_id, guide_id, price_minor, starts_at, ends_at)
+    values ('73000000-0000-4000-8000-000000000001',
+      '72000000-0000-4000-8000-000000000001',
+      '71000000-0000-4000-8000-000000000002', 100000,
+      '2026-11-11 09:00+03', '2026-11-11 12:00+03')
+  $$,
+  '23514',
+  'offer_start_date_must_match_exact_request',
+  'direct guide insert cannot move an exact request date'
+);
+
+select lives_ok(
+  $$
+    insert into public.guide_offers (id, request_id, guide_id, price_minor, starts_at, ends_at)
+    values ('73000000-0000-4000-8000-000000000002',
+      '72000000-0000-4000-8000-000000000001',
+      '71000000-0000-4000-8000-000000000002', 100000,
+      '2026-11-10 09:00+03', '2026-11-10 12:00+03')
+  $$,
+  'direct guide insert accepts the exact Moscow date'
+);
+
+select throws_ok(
+  $$
+    update public.guide_offers
+       set starts_at = '2026-11-11 09:00+03'
+     where id = '73000000-0000-4000-8000-000000000002'
+  $$,
+  '23514',
+  'offer_start_date_must_match_exact_request',
+  'direct guide update cannot move an exact request date'
+);
+
+select lives_ok(
+  $$
+    insert into public.guide_offers (id, request_id, guide_id, price_minor, starts_at, ends_at)
+    values ('73000000-0000-4000-8000-000000000003',
+      '72000000-0000-4000-8000-000000000002',
+      '71000000-0000-4000-8000-000000000002', 100000,
+      '2026-11-11 09:00+03', '2026-11-11 12:00+03')
+  $$,
+  'direct guide insert preserves few_days date variance'
+);
+
+select * from finish();
+rollback;


### PR DESCRIPTION
## Что исправлено
- точные даты запроса обязательны в UI, server actions и базе данных
- цена экскурсии «за группу» сохраняется в публичном каталоге
- обложки локаций корректно разрешаются для «Город, Регион»
- Фотобанк использует свободный текст локации, без каталожного фильтра городов
- фильтры входящих запросов гида: сборная / своя / на ваше имя / все

## Проверки
- bun run test:run — 250 files, 1486 tests
- bun run check
- bun run build
- git diff --check

## База
Добавлена узкая миграция exact-date guard. Общий db push не используется из-за существующего исторического рассинхрона миграций; после merge миграция будет применена и проверена отдельно.