### PR TITLE
fix(listings): preserve template destination links

### DIFF
--- a/src/app/(site)/listings/page.test.tsx
+++ b/src/app/(site)/listings/page.test.tsx
@@ -56,10 +56,11 @@ describe("PublicListingsPage", () => {
     expect(screen.queryByLabelText("discovery")).not.toBeInTheDocument();
   });
 
-  it("passes a ready tour's per-group price scope to the public catalogue", async () => {
+  it("passes a ready tour's per-group price scope and template detail route to the public catalogue", async () => {
     const listing: ListingRecord = {
       id: "listing-1",
       slug: "kazan-kremlin",
+      detailHref: "/guides/adyk",
       title: "Казанский кремль",
       destinationSlug: "kazan",
       destinationName: "Казань",
@@ -89,7 +90,10 @@ describe("PublicListingsPage", () => {
     render(await PublicListingsPage({ searchParams: Promise.resolve({}) }));
 
     expect(discoveryScreenMock.mock.calls[0]?.[0]).toMatchObject({
-      listings: [expect.objectContaining({ priceScope: "per_group" })],
+      listings: [expect.objectContaining({
+        priceScope: "per_group",
+        detailHref: "/guides/adyk",
+      })],
     });
   });
 });

--- a/src/app/(site)/listings/page.tsx
+++ b/src/app/(site)/listings/page.tsx
@@ -19,6 +19,7 @@ export function generateMetadata(): Metadata {
 function mapToPublicListing(listing: ListingRecord): PublicListing {
   return {
     slug: listing.slug,
+    detailHref: listing.detailHref,
     title: listing.title,
     city: listing.destinationName,
     region: listing.destinationRegion,

--- a/src/data/public-listings/types.ts
+++ b/src/data/public-listings/types.ts
@@ -23,6 +23,8 @@ export type PublicListingItineraryItem = {
 
 export type PublicListing = {
   slug: string;
+  /** Optional non-listing detail route for records adapted from guide_templates. */
+  detailHref?: string;
   title: string;
   city: string;
   region: string;

--- a/src/features/listings/components/public/public-listing-discovery-screen.test.tsx
+++ b/src/features/listings/components/public/public-listing-discovery-screen.test.tsx
@@ -54,4 +54,24 @@ describe("PublicListingDiscoveryScreen", () => {
 
     expect(screen.getByText("от 5 000 ₽ за группу до 8 человек")).toBeInTheDocument();
   });
+
+  it("uses template detail routes and keeps listing detail routes", () => {
+    render(
+      <PublicListingDiscoveryScreen
+        listings={[
+          makeListing(0),
+          makeListing(1, { detailHref: "/guides/adyk" }),
+        ]}
+      />,
+    );
+
+    expect(screen.getByRole("link", { name: /Экскурсия 0/ })).toHaveAttribute(
+      "href",
+      "/listings/listing-0",
+    );
+    expect(screen.getByRole("link", { name: /Экскурсия 1/ })).toHaveAttribute(
+      "href",
+      "/guides/adyk",
+    );
+  });
 });

--- a/src/features/listings/components/public/public-listing-discovery-screen.tsx
+++ b/src/features/listings/components/public/public-listing-discovery-screen.tsx
@@ -26,6 +26,7 @@ function mapListing(listing: PublicListing): ListingRecord {
   return {
     id: listing.slug,
     slug: listing.slug,
+    detailHref: listing.detailHref,
     title: listing.title,
     destinationSlug: listing.city.toLowerCase().replaceAll(" ", "-"),
     destinationName: listing.city,


### PR DESCRIPTION
## Summary
- preserve the intended guide destination for published guide templates in the public excursions catalog
- keep normal listing detail links unchanged
- add regression coverage for both route types

## Verification
- bun run test:run -- src/app/(site)/listings/page.test.tsx src/features/listings/components/public/public-listing-discovery-screen.test.tsx src/lib/supabase/guide-template-listings.test.ts
- bun run check