### PR TITLE
fix(request): keep destination input focused

### DIFF
--- a/src/features/homepage-classic/components/homepage-request-form-classic.destination.test.tsx
+++ b/src/features/homepage-classic/components/homepage-request-form-classic.destination.test.tsx
@@ -37,6 +37,14 @@ const DESTINATIONS = [
   { name: "Камчатка", region: "Дальний Восток", guideCount: 2 },
   { name: "Карелия", region: "Северо-Запад", guideCount: 1 },
   { name: "Сочи", region: "Юг", guideCount: 5 },
+  { name: "Элиста", region: "Калмыкия", guideCount: 2 },
+];
+
+const DEFERRED_DESTINATIONS = [
+  { name: "Элиста", region: "Калмыкия", guideCount: 2 },
+  { name: "Эхо", region: "Центр", guideCount: 1 },
+  { name: "Эльбрус", region: "Кавказ", guideCount: 3 },
+  { name: "Элион", region: "Север", guideCount: 1 },
 ];
 
 beforeAll(() => {
@@ -60,13 +68,7 @@ describe("HomepageRequestFormClassic destination typeahead", () => {
     expect(screen.queryByRole("listbox")).toBeNull();
     expect(input).toHaveAttribute("aria-expanded", "false");
 
-    // The component suppresses jsx-a11y/role-has-required-aria-props on the grounds
-    // that cmdk injects `aria-controls` at runtime (it points at cmdk's own generated
-    // list id, which is not knowable in JSX). That justification is only acceptable if
-    // it is TRUE — so assert the finished DOM really carries the attribute the linter
-    // could not see. If a refactor drops `asChild`, this fails instead of silently
-    // shipping a combobox that announces nothing to a screen reader.
-    expect(input).toHaveAttribute("aria-controls");
+    expect(input).toHaveAttribute("aria-controls", "destination-suggestions");
   });
 
   it("filters the suggestions while typing «Кав» and closes on Escape", () => {
@@ -187,6 +189,29 @@ describe("HomepageRequestFormClassic destination typeahead at scale", () => {
 
     expect(input).toHaveValue("Кариж-0007");
     expect(screen.queryByRole("listbox")).toBeNull();
+  });
+
+  it("does not focus out while deferred matches update for «Элиста»", async () => {
+    render(<HomepageRequestFormClassic destinations={DEFERRED_DESTINATIONS} />);
+    const input = screen.getByLabelText("Направление") as HTMLInputElement;
+    const focusout = vi.fn();
+    input.addEventListener("focusout", focusout);
+    input.focus();
+
+    for (const [value, count] of [
+      ["Э", 4],
+      ["Эл", 3],
+      ["Эли", 2],
+      ["Элиста", 1],
+    ] as const) {
+      fireEvent.input(input, { target: { value } });
+      // The decreasing count proves the deferred filtering commit completed.
+      await waitFor(() => expect(screen.getAllByRole("option")).toHaveLength(count));
+      expect(screen.getByRole("option", { name: "Элиста" })).toBeInTheDocument();
+      expect(input).toHaveValue(value);
+      expect(document.activeElement).toBe(input);
+      expect(focusout).not.toHaveBeenCalled();
+    }
   });
 
   it("still accepts free text that matches nothing in a large vocabulary", () => {

--- a/src/features/homepage-classic/components/homepage-request-form-classic.tsx
+++ b/src/features/homepage-classic/components/homepage-request-form-classic.tsx
@@ -196,10 +196,10 @@ const MAX_SUGGESTIONS = 8;
  * from guide-entered free text and is therefore always incomplete, so the field
  * keeps accepting arbitrary input and submits it as typed.
  *
- * `asChild` keeps our own `id` on the input — cmdk hardcodes both `id` and
- * `aria-expanded: true` (true for an always-open command palette, a lie here) —
- * so the visible <Label htmlFor> still owns the field and the expanded state is
- * announced correctly.
+ * The text field is deliberately native rather than `Command.Input`: cmdk moves
+ * focus to its list whenever its selected item changes, including when deferred
+ * suggestions commit. The root still handles arrow navigation and Enter through
+ * bubbling, but it no longer owns focus in the text field.
  */
 function DestinationCombobox({
   destinations,
@@ -219,6 +219,7 @@ function DestinationCombobox({
   describedBy?: string;
 }) {
   const [open, setOpen] = React.useState(false);
+  const [activeOption, setActiveOption] = React.useState<string>();
   // The typed value stays immediate (it drives the input); only the filtering
   // work is deferred, so a keystroke never waits on the list to re-render.
   const deferredValue = React.useDeferredValue(value);
@@ -255,15 +256,26 @@ function DestinationCombobox({
   return (
     // Filtering is ours (same ru-lowercase substring rule as TagMultiSelect), because
     // the match count decides whether the list opens at all.
-    <CommandPrimitive label="Направление" shouldFilter={false} className="relative">
+    <CommandPrimitive
+      label="Направление"
+      shouldFilter={false}
+      onValueChange={setActiveOption}
+      className="relative"
+    >
       <FieldShell>
         <FieldIcon icon={MapPin} className="text-primary" />
         <div className="min-w-0 flex-1">
-          <CommandPrimitive.Input
-            asChild
+          <input
+            id="destination"
+            ref={inputRef}
+            className={cn(FIN, "text-lg")}
+            placeholder="Куда едете?"
+            // Cap input length at the schema's max so a destination label can
+            // never be pasted unbounded (matches the 80-char Zod/DB contract).
+            maxLength={80}
             value={value}
-            onValueChange={(next) => {
-              onChange(next);
+            onChange={(e) => {
+              onChange(e.target.value);
               setOpen(true);
             }}
             onKeyDown={(e) => {
@@ -278,25 +290,14 @@ function DestinationCombobox({
               setOpen(false);
               onBlur();
             }}
-          >
-            <input
-              id="destination"
-              ref={inputRef}
-              className={cn(FIN, "text-lg")}
-              placeholder="Куда едете?"
-              // Cap input length at the schema's max so a destination label can
-              // never be pasted unbounded (matches the 80-char Zod/DB contract).
-              maxLength={80}
-              // Restates the role cmdk applies at runtime — without it jsx-a11y reads a
-              // bare textbox and rejects aria-expanded. The rule then wants aria-controls,
-              // which cmdk injects itself (it points at the cmdk-generated list id).
-              // eslint-disable-next-line jsx-a11y/role-has-required-aria-props
-              role="combobox"
-              aria-expanded={listOpen}
-              aria-invalid={invalid}
-              aria-describedby={describedBy}
-            />
-          </CommandPrimitive.Input>
+            role="combobox"
+            aria-autocomplete="list"
+            aria-controls="destination-suggestions"
+            aria-activedescendant={activeOption ? `destination-option-${activeOption}` : undefined}
+            aria-expanded={listOpen}
+            aria-invalid={invalid}
+            aria-describedby={describedBy}
+          />
         </div>
       </FieldShell>
       {/*
@@ -312,7 +313,7 @@ function DestinationCombobox({
         onMouseDown={(e) => e.preventDefault()}
         className="absolute inset-x-0 top-full z-50 mt-1 rounded-lg bg-popover p-1 text-popover-foreground shadow-md ring-1 ring-foreground/10"
       >
-        <CommandList>
+        <CommandList id="destination-suggestions">
           {visible.map((d) => {
             // Unique cmdk value per (name, region): two places sharing a name in
             // different regions must not collide. Value is not the accessible
@@ -321,7 +322,12 @@ function DestinationCombobox({
             const optionValue = d.region ? `${d.name} · ${d.region}` : d.name;
             const showRegion = Boolean(d.region) && ambiguous.has(d.name.toLocaleLowerCase("ru"));
             return (
-              <CommandItem key={optionValue} value={optionValue} onSelect={() => choose(d.name)}>
+              <CommandItem
+                key={optionValue}
+                id={`destination-option-${optionValue}`}
+                value={optionValue}
+                onSelect={() => choose(d.name)}
+              >
                 {d.name}
                 {showRegion ? (
                   <span className="ml-1.5 text-muted-foreground">· {d.region}</span>


### PR DESCRIPTION
Root cause: cmdk moved focus from the request destination text input to its list after deferred suggestions updated. The native controlled input retains focus; cmdk still handles option navigation and selection.\n\nValidation: production reproduction, deferred focus regression, 1,488 tests via commit hook.