### PR TITLE
fix(excursions): add ready tour detail pages

### DIFF
--- a/src/app/(site)/excursions/[id]/page.test.tsx
+++ b/src/app/(site)/excursions/[id]/page.test.tsx
@@ -1,0 +1,70 @@
+import { render } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { createSupabaseServerClient, getPublishedTemplateDetail, notFound, detailScreen } = vi.hoisted(
+  () => ({
+    createSupabaseServerClient: vi.fn(),
+    getPublishedTemplateDetail: vi.fn(),
+    notFound: vi.fn(() => {
+      throw new Error("NEXT_NOT_FOUND");
+    }),
+    detailScreen: vi.fn((_props: unknown) => null),
+  }),
+);
+
+vi.mock("next/navigation", () => ({ notFound }));
+
+vi.mock("@/lib/supabase/server", () => ({ createSupabaseServerClient }));
+
+vi.mock("@/lib/supabase/guide-template-listings", () => ({
+  getPublishedTemplateDetail: (...args: unknown[]) => getPublishedTemplateDetail(...args),
+}));
+
+vi.mock("@/features/listings/components/public/ready-excursion-detail", () => ({
+  ReadyExcursionDetail: (props: unknown) => detailScreen(props),
+}));
+
+import ReadyExcursionPage from "./page";
+
+const DETAIL = {
+  id: "11111111-1111-1111-1111-111111111111",
+  title: "Адык",
+  description: "Прогулка по степи.",
+  photoUrl: "https://cdn.example/adyk.jpg",
+  priceFromKopecks: 450_000,
+  priceScope: "per_group" as const,
+  durationText: "5 часов",
+  meetingPoint: "Элиста, площадь Ленина",
+  maxParticipants: 8,
+  region: "Калмыкия",
+  category: "Культура",
+  guide: { slug: "adyk", displayName: "Адык" },
+};
+
+describe("ReadyExcursionPage", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("renders the published template's dedicated detail page", async () => {
+    const supabase = {};
+    createSupabaseServerClient.mockResolvedValue(supabase);
+    getPublishedTemplateDetail.mockResolvedValue(DETAIL);
+
+    render(await ReadyExcursionPage({ params: Promise.resolve({ id: DETAIL.id }) }));
+
+    expect(getPublishedTemplateDetail).toHaveBeenCalledWith(supabase, DETAIL.id);
+    expect(detailScreen).toHaveBeenCalledWith({ detail: DETAIL });
+  });
+
+  it("returns not found when the template is absent or not public", async () => {
+    createSupabaseServerClient.mockResolvedValue({});
+    getPublishedTemplateDetail.mockResolvedValue(null);
+
+    await expect(
+      ReadyExcursionPage({ params: Promise.resolve({ id: "missing" }) }),
+    ).rejects.toThrow("NEXT_NOT_FOUND");
+
+    expect(notFound).toHaveBeenCalled();
+  });
+});

--- a/src/app/(site)/excursions/[id]/page.tsx
+++ b/src/app/(site)/excursions/[id]/page.tsx
@@ -1,0 +1,40 @@
+import type { Metadata } from "next";
+import { notFound } from "next/navigation";
+import { cache } from "react";
+
+import { ReadyExcursionDetail } from "@/features/listings/components/public/ready-excursion-detail";
+import { getPublishedTemplateDetail } from "@/lib/supabase/guide-template-listings";
+import { createSupabaseServerClient } from "@/lib/supabase/server";
+
+const getReadyExcursion = cache(async (templateId: string) => {
+  const supabase = await createSupabaseServerClient();
+  return getPublishedTemplateDetail(supabase, templateId);
+});
+
+export async function generateMetadata({
+  params,
+}: {
+  params: Promise<{ id: string }>;
+}): Promise<Metadata> {
+  const { id } = await params;
+  const detail = await getReadyExcursion(id);
+  if (!detail) notFound();
+
+  return {
+    title: detail.title,
+    description: detail.description ?? detail.title,
+    alternates: { canonical: `/excursions/${detail.id}` },
+  };
+}
+
+export default async function ReadyExcursionPage({
+  params,
+}: {
+  params: Promise<{ id: string }>;
+}) {
+  const { id } = await params;
+  const detail = await getReadyExcursion(id);
+  if (!detail) notFound();
+
+  return <ReadyExcursionDetail detail={detail} />;
+}

--- a/src/app/(site)/listings/page.test.tsx
+++ b/src/app/(site)/listings/page.test.tsx
@@ -60,7 +60,7 @@ describe("PublicListingsPage", () => {
     const listing: ListingRecord = {
       id: "listing-1",
       slug: "kazan-kremlin",
-      detailHref: "/guides/adyk",
+      detailHref: "/excursions/template-adyk",
       title: "Казанский кремль",
       destinationSlug: "kazan",
       destinationName: "Казань",
@@ -92,7 +92,7 @@ describe("PublicListingsPage", () => {
     expect(discoveryScreenMock.mock.calls[0]?.[0]).toMatchObject({
       listings: [expect.objectContaining({
         priceScope: "per_group",
-        detailHref: "/guides/adyk",
+        detailHref: "/excursions/template-adyk",
       })],
     });
   });

--- a/src/components/shared/listing-card.tsx
+++ b/src/components/shared/listing-card.tsx
@@ -35,7 +35,7 @@ export function ListingCard({ listing, priority }: ListingCardProps) {
   return (
     <Link
       // Templates adapted from guide_templates have no /listings detail route and
-      // carry their own href (their guide's profile). See ListingRecord.detailHref.
+      // carry their own ready-excursion href. See ListingRecord.detailHref.
       href={listing.detailHref ?? `/listings/${listing.slug}`}
       className="group relative block overflow-hidden rounded-card border border-border bg-card shadow-soft transition-[transform,box-shadow] duration-150 ease-out hover:-translate-y-[3px] hover:shadow-lift focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
     >

--- a/src/features/destinations/components/destination-detail-screen.test.tsx
+++ b/src/features/destinations/components/destination-detail-screen.test.tsx
@@ -1,8 +1,9 @@
-import { render } from "@testing-library/react";
+import { render, screen } from "@testing-library/react";
 import { describe, expect, it } from "vitest";
 
 import { DestinationDetailScreen } from "./destination-detail-screen";
 import type { DestinationSummary } from "@/data/destinations/types";
+import type { ListingRecord } from "@/data/supabase/queries";
 
 function makeDestination(overrides: Partial<DestinationSummary> = {}): DestinationSummary {
   return {
@@ -14,6 +15,37 @@ function makeDestination(overrides: Partial<DestinationSummary> = {}): Destinati
     listingCount: 0,
     openRequestCount: 0,
     ...overrides,
+  };
+}
+
+function makeReadyExcursion(): ListingRecord {
+  return {
+    id: "11111111-1111-1111-1111-111111111111",
+    slug: "11111111-1111-1111-1111-111111111111",
+    detailHref: "/excursions/11111111-1111-1111-1111-111111111111",
+    title: "Степь и хурул",
+    destinationSlug: "kalmykia",
+    destinationName: "Элиста",
+    destinationRegion: "Калмыкия",
+    imageUrl: "/hero-valley.jpg",
+    priceRub: 4500,
+    durationDays: 1,
+    durationLabel: "5 часов",
+    groupSize: 8,
+    difficulty: "",
+    departure: "Элиста",
+    format: "group",
+    priceScope: "per_group",
+    category: "Культура",
+    description: "Золотая обитель и степь",
+    inclusions: [],
+    exclusions: [],
+    guideSlug: "adyk",
+    guideName: "Адык",
+    guideHomeBase: "Элиста",
+    rating: 0,
+    reviewCount: 0,
+    status: "active",
   };
 }
 
@@ -45,5 +77,19 @@ describe("DestinationDetailScreen — requests section", () => {
     );
 
     expect(getByText("Создать запрос").closest("a")).toHaveAttribute("href", "/");
+  });
+
+  it("keeps a ready excursion card on its dedicated detail route", () => {
+    render(
+      <DestinationDetailScreen
+        destination={makeDestination()}
+        listings={[makeReadyExcursion()]}
+      />,
+    );
+
+    expect(screen.getByText("Степь и хурул").closest("a")).toHaveAttribute(
+      "href",
+      "/excursions/11111111-1111-1111-1111-111111111111",
+    );
   });
 });

--- a/src/features/guide/components/public/guide-profile-screen.test.tsx
+++ b/src/features/guide/components/public/guide-profile-screen.test.tsx
@@ -92,10 +92,7 @@ describe("GuideProfileScreen", () => {
     }
   });
 
-  // Every excursion adapted from guide_templates links to this same profile (it has
-  // no /listings detail route), so href is NOT unique within one guide's list. It
-  // was the React key, which made two published templates collide.
-  it("renders several template-backed excursions that share one href", () => {
+  it("renders each template-backed excursion with its own detail route", () => {
     const consoleError = vi.spyOn(console, "error").mockImplementation(() => {});
 
     render(
@@ -104,14 +101,14 @@ describe("GuideProfileScreen", () => {
         listings={[
           {
             slug: "11111111-1111-1111-1111-111111111111",
-            href: "/guides/ivan-petrov",
+            href: "/excursions/11111111-1111-1111-1111-111111111111",
             title: "Тюльпановая степь",
             coverImageUrl: "/hero-valley.jpg",
             price: "от 1 200 ₽ за одного",
           },
           {
             slug: "22222222-2222-2222-2222-222222222222",
-            href: "/guides/ivan-petrov",
+            href: "/excursions/22222222-2222-2222-2222-222222222222",
             title: "Чёрные земли",
             coverImageUrl: "/hero-valley.jpg",
             price: "от 2 500 ₽ за одного",
@@ -122,6 +119,14 @@ describe("GuideProfileScreen", () => {
 
     expect(screen.getByText("Тюльпановая степь")).toBeInTheDocument();
     expect(screen.getByText("Чёрные земли")).toBeInTheDocument();
+    expect(screen.getByText("Тюльпановая степь").closest("a")).toHaveAttribute(
+      "href",
+      "/excursions/11111111-1111-1111-1111-111111111111",
+    );
+    expect(screen.getByText("Чёрные земли").closest("a")).toHaveAttribute(
+      "href",
+      "/excursions/22222222-2222-2222-2222-222222222222",
+    );
     // The price comes from the caller's shared formatter, with its scope intact.
     expect(screen.getByText("от 1 200 ₽ за одного")).toBeInTheDocument();
     expect(consoleError).not.toHaveBeenCalled();

--- a/src/features/guide/components/public/guide-profile-screen.tsx
+++ b/src/features/guide/components/public/guide-profile-screen.tsx
@@ -65,11 +65,9 @@ export function GuideProfileScreen({ guide, listings, reviews, photos = [] }: Pr
   const tourCards =
     listings && listings.length > 0
       ? listings.map((l: GuideListing, index: number) => ({
-          // Not the href: every excursion adapted from guide_templates points at
-          // this same profile, so href is not unique within one guide's list.
           key: l.slug ?? l.id ?? `excursion-${index}`,
           // The caller resolves href and price: an excursion adapted from
-          // guide_templates has no /listings route, and the price scope
+          // guide_templates has a dedicated public route, and the price scope
           // («за одного» / «за группу до N человек») comes from the one shared
           // formatter rather than a second copy of it here.
           href: l.href ?? `/listings/${l.slug ?? l.id ?? ""}`,

--- a/src/features/listings/components/public/public-listing-discovery-screen.test.tsx
+++ b/src/features/listings/components/public/public-listing-discovery-screen.test.tsx
@@ -55,12 +55,12 @@ describe("PublicListingDiscoveryScreen", () => {
     expect(screen.getByText("от 5 000 ₽ за группу до 8 человек")).toBeInTheDocument();
   });
 
-  it("uses template detail routes and keeps listing detail routes", () => {
+  it("uses ready-excursion detail routes and keeps listing detail routes", () => {
     render(
       <PublicListingDiscoveryScreen
         listings={[
           makeListing(0),
-          makeListing(1, { detailHref: "/guides/adyk" }),
+          makeListing(1, { detailHref: "/excursions/template-adyk" }),
         ]}
       />,
     );
@@ -71,7 +71,7 @@ describe("PublicListingDiscoveryScreen", () => {
     );
     expect(screen.getByRole("link", { name: /Экскурсия 1/ })).toHaveAttribute(
       "href",
-      "/guides/adyk",
+      "/excursions/template-adyk",
     );
   });
 });

--- a/src/features/listings/components/public/ready-excursion-detail.test.tsx
+++ b/src/features/listings/components/public/ready-excursion-detail.test.tsx
@@ -1,0 +1,41 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import { ReadyExcursionDetail } from "./ready-excursion-detail";
+
+const DETAIL = {
+  id: "11111111-1111-1111-1111-111111111111",
+  title: "Адык",
+  description: "Прогулка по степи и знакомство с Калмыкией.",
+  photoUrl: "https://cdn.example/adyk.jpg",
+  priceFromKopecks: 450_000,
+  priceScope: "per_group" as const,
+  durationText: "5 часов",
+  meetingPoint: "Элиста, площадь Ленина",
+  maxParticipants: 8,
+  region: "Калмыкия",
+  category: "Культура",
+  guide: { slug: "adyk", displayName: "Адык" },
+};
+
+describe("ReadyExcursionDetail", () => {
+  it("shows the ready excursion's public fields and directs a request to its guide", () => {
+    render(<ReadyExcursionDetail detail={DETAIL} />);
+
+    expect(screen.getByRole("heading", { level: 1, name: "Адык" })).toBeInTheDocument();
+    expect(screen.getByRole("img", { name: "Адык" })).toHaveAttribute(
+      "src",
+      expect.stringContaining("adyk.jpg"),
+    );
+    expect(screen.getByText("от 4 500 ₽ за группу до 8 человек")).toBeInTheDocument();
+    expect(screen.getByText("5 часов")).toBeInTheDocument();
+    expect(screen.getByText("Прогулка по степи и знакомство с Калмыкией.")).toBeInTheDocument();
+    expect(screen.getByText("Элиста, площадь Ленина")).toBeInTheDocument();
+    expect(screen.getByText("до 8 человек")).toBeInTheDocument();
+    expect(screen.getByRole("link", { name: "Адык" })).toHaveAttribute("href", "/guides/adyk");
+    expect(screen.getByRole("link", { name: "Отправить запрос гиду" })).toHaveAttribute(
+      "href",
+      "/?guide=adyk",
+    );
+  });
+});

--- a/src/features/listings/components/public/ready-excursion-detail.tsx
+++ b/src/features/listings/components/public/ready-excursion-detail.tsx
@@ -1,0 +1,139 @@
+import Link from "next/link";
+import { Clock3, MapPin, Users } from "lucide-react";
+
+import { formatExcursionPriceFrom } from "@/components/listing-detail/excursion-price";
+import { ImmersiveHero } from "@/components/shared/immersive-hero";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent } from "@/components/ui/card";
+import { Separator } from "@/components/ui/separator";
+import type { PublicGuideTemplateDetail } from "@/lib/supabase/guide-template-listings";
+
+export function ReadyExcursionDetail({ detail }: { detail: PublicGuideTemplateDetail }) {
+  const priceLabel =
+    detail.priceFromKopecks == null
+      ? "Цена по запросу"
+      : formatExcursionPriceFrom(
+          detail.priceFromKopecks,
+          "group",
+          detail.maxParticipants,
+          detail.priceScope,
+        );
+  const requestHref = `/?guide=${encodeURIComponent(detail.guide.slug)}`;
+
+  return (
+    <div className="pb-28 md:pb-12">
+      <ImmersiveHero
+        imageUrl={detail.photoUrl}
+        imagePosition="center 44%"
+        breadcrumb={[
+          { label: "Экскурсии", href: "/listings" },
+          ...(detail.region ? [{ label: detail.region }] : []),
+          { label: detail.title, current: true },
+        ]}
+        title={detail.title}
+        statusBadge={
+          <span className="inline-flex rounded-full border border-white/30 bg-black/15 px-3 py-1 text-xs font-medium text-white backdrop-blur-sm">
+            Готовая экскурсия
+          </span>
+        }
+        variant="compact"
+      />
+
+      <div className="mx-auto mt-8 grid w-full max-w-page gap-8 px-[clamp(20px,4vw,48px)] lg:grid-cols-[minmax(0,1fr)_20rem] lg:items-start">
+        <div className="flex min-w-0 flex-col gap-8">
+          {detail.description ? (
+            <section className="flex flex-col gap-2">
+              <h2 className="text-xl font-semibold tracking-tight">Об экскурсии</h2>
+              <p className="whitespace-pre-wrap text-sm leading-7 text-muted-foreground">
+                {detail.description}
+              </p>
+            </section>
+          ) : null}
+
+          <section className="flex flex-col gap-3">
+            <h2 className="text-xl font-semibold tracking-tight">Детали</h2>
+            <dl className="grid gap-3 sm:grid-cols-2">
+              {detail.durationText ? (
+                <div className="flex gap-3 rounded-card border border-line bg-surface p-4">
+                  <Clock3 className="mt-0.5 size-5 shrink-0 text-primary" aria-hidden="true" />
+                  <div>
+                    <dt className="text-xs text-muted-foreground">Длительность</dt>
+                    <dd className="mt-0.5 text-sm font-medium">{detail.durationText}</dd>
+                  </div>
+                </div>
+              ) : null}
+              {detail.maxParticipants && detail.maxParticipants > 0 ? (
+                <div className="flex gap-3 rounded-card border border-line bg-surface p-4">
+                  <Users className="mt-0.5 size-5 shrink-0 text-primary" aria-hidden="true" />
+                  <div>
+                    <dt className="text-xs text-muted-foreground">Размер группы</dt>
+                    <dd className="mt-0.5 text-sm font-medium">
+                      до {detail.maxParticipants} человек
+                    </dd>
+                  </div>
+                </div>
+              ) : null}
+              {detail.region ? (
+                <div className="flex gap-3 rounded-card border border-line bg-surface p-4">
+                  <MapPin className="mt-0.5 size-5 shrink-0 text-primary" aria-hidden="true" />
+                  <div>
+                    <dt className="text-xs text-muted-foreground">Регион</dt>
+                    <dd className="mt-0.5 text-sm font-medium">{detail.region}</dd>
+                  </div>
+                </div>
+              ) : null}
+              {detail.meetingPoint ? (
+                <div className="flex gap-3 rounded-card border border-line bg-surface p-4">
+                  <MapPin className="mt-0.5 size-5 shrink-0 text-primary" aria-hidden="true" />
+                  <div>
+                    <dt className="text-xs text-muted-foreground">Место встречи</dt>
+                    <dd className="mt-0.5 text-sm font-medium">{detail.meetingPoint}</dd>
+                  </div>
+                </div>
+              ) : null}
+            </dl>
+          </section>
+
+          <Separator />
+
+          <section className="flex flex-col gap-3">
+            <h2 className="text-xl font-semibold tracking-tight">Гид</h2>
+            <Card className="rounded-card border border-line bg-surface shadow-sm">
+              <CardContent className="flex flex-col gap-1 p-5">
+                <p className="text-sm text-muted-foreground">Экскурсию проводит</p>
+                <Link
+                  href={`/guides/${detail.guide.slug}`}
+                  className="w-fit text-lg font-semibold text-primary underline-offset-4 hover:underline"
+                >
+                  {detail.guide.displayName}
+                </Link>
+                <Link
+                  href={`/guides/${detail.guide.slug}`}
+                  className="mt-1 w-fit text-sm font-medium text-primary underline-offset-4 hover:underline"
+                >
+                  Профиль гида
+                </Link>
+              </CardContent>
+            </Card>
+          </section>
+        </div>
+
+        <aside className="w-full lg:sticky lg:top-24 lg:self-start">
+          <Card className="rounded-card border border-line bg-surface shadow-sm">
+            <CardContent className="flex flex-col gap-4 p-5">
+              <div>
+                <p className="text-3xl font-semibold">{priceLabel}</p>
+                <p className="mt-1 text-sm text-muted-foreground">
+                  Отправьте запрос — гид подтвердит детали и дату.
+                </p>
+              </div>
+              <Button asChild className="w-full">
+                <Link href={requestHref}>Отправить запрос гиду</Link>
+              </Button>
+            </CardContent>
+          </Card>
+        </aside>
+      </div>
+    </div>
+  );
+}

--- a/src/lib/supabase/guide-template-listings.test.ts
+++ b/src/lib/supabase/guide-template-listings.test.ts
@@ -1,6 +1,9 @@
 import { describe, expect, it } from "vitest";
 
-import { getPublishedTemplateListings } from "./guide-template-listings";
+import {
+  getPublishedTemplateDetail,
+  getPublishedTemplateListings,
+} from "./guide-template-listings";
 
 type Row = Record<string, unknown>;
 
@@ -19,6 +22,8 @@ function fakeClient(fixtures: Record<string, Row[]>, errors: Record<string, Erro
           return chain();
         };
       }
+      q.maybeSingle = () =>
+        Promise.resolve({ data: fixtures[table]?.[0] ?? null, error: errors[table] ?? null });
       q.then = (resolve: (v: unknown) => void) =>
         resolve({ data: fixtures[table] ?? [], error: errors[table] ?? null });
       return q;
@@ -84,8 +89,8 @@ describe("getPublishedTemplateListings", () => {
     expect(rec.destinationRegion).toBe("Калмыкия");
     expect(rec.guideName).toBe("Баир Очиров");
     expect(rec.guideSlug).toBe("bair-ochirov");
-    // A template has no row in `listings`, so it has no detail route.
-    expect(rec.detailHref).toBe("/guides/bair-ochirov");
+    // A template has no row in `listings`, but it does have its own public detail route.
+    expect(rec.detailHref).toBe(`/excursions/${TEMPLATE.id}`);
     // Nothing fabricated: no reviews exist for a template.
     expect(rec.rating).toBe(0);
     expect(rec.reviewCount).toBe(0);
@@ -179,5 +184,47 @@ describe("getPublishedTemplateListings", () => {
     expect(rec.priceRub).toBe(0);
     expect(rec.imageUrl).toBeTruthy();
     expect(rec.groupSize).toBe(0);
+  });
+
+  it("resolves a public detail only for a published template from an approved non-QA guide", async () => {
+    const client = fakeClient({
+      guide_templates: [TEMPLATE],
+      guide_profiles: [APPROVED_GUIDE],
+    });
+
+    const detail = await getPublishedTemplateDetail(client, TEMPLATE.id as string);
+
+    expect(detail).toMatchObject({
+      id: TEMPLATE.id,
+      title: "Степь и хурул",
+      photoUrl: "https://cdn.example/photo.jpg",
+      priceFromKopecks: 450_000,
+      durationText: "5 часов",
+      meetingPoint: "Площадь Ленина",
+      maxParticipants: 8,
+      guide: { slug: "bair-ochirov", displayName: "Баир Очиров" },
+    });
+    expect(client.calls).toContain(`guide_templates.eq:id:${TEMPLATE.id}`);
+    expect(client.calls).toContain("guide_templates.eq:status:published");
+    expect(client.calls).toContain("guide_profiles.eq:user_id:guide-1");
+  });
+
+  it("does not resolve unpublished, unapproved, or QA template details", async () => {
+    const unpublished = fakeClient({
+      guide_templates: [{ ...TEMPLATE, status: "draft" }],
+      guide_profiles: [APPROVED_GUIDE],
+    });
+    const unapproved = fakeClient({
+      guide_templates: [TEMPLATE],
+      guide_profiles: [{ ...APPROVED_GUIDE, verification_status: "pending" }],
+    });
+    const qaGuide = fakeClient({
+      guide_templates: [TEMPLATE],
+      guide_profiles: [{ ...APPROVED_GUIDE, slug: "qa-guide" }],
+    });
+
+    await expect(getPublishedTemplateDetail(unpublished, TEMPLATE.id as string)).resolves.toBeNull();
+    await expect(getPublishedTemplateDetail(unapproved, TEMPLATE.id as string)).resolves.toBeNull();
+    await expect(getPublishedTemplateDetail(qaGuide, TEMPLATE.id as string)).resolves.toBeNull();
   });
 });

--- a/src/lib/supabase/guide-template-listings.ts
+++ b/src/lib/supabase/guide-template-listings.ts
@@ -37,14 +37,34 @@ const TEMPLATE_SCAN = 200;
 
 type TemplateGuide = { slug: string; displayName: string };
 
+export type PublicGuideTemplateDetail = {
+  id: string;
+  title: string;
+  description: string | null;
+  photoUrl: string;
+  priceFromKopecks: number | null;
+  priceScope: "per_person" | "per_group";
+  durationText: string | null;
+  meetingPoint: string | null;
+  maxParticipants: number | null;
+  region: string | null;
+  category: string | null;
+  guide: TemplateGuide;
+};
+
+/** Public namespace for ready excursions, which have no `listings` row or slug. */
+export function guideTemplateDetailHref(templateId: string): string {
+  return `/excursions/${templateId}`;
+}
+
 function mapTemplate(row: GuideTemplateRow, guide: TemplateGuide): ListingRecord {
   const region = row.region ?? "";
   return {
     id: row.id,
-    // No `listings` row, so no slug and no /listings/{slug} detail route. The id
-    // keeps React keys stable; detailHref is what the card actually links to.
+    // No `listings` row, so no /listings/{slug} detail route. The id keeps React
+    // keys stable and identifies the public ready-excursion detail route.
     slug: row.id,
-    detailHref: `/guides/${guide.slug}`,
+    detailHref: guideTemplateDetailHref(row.id),
     title: row.title,
     destinationSlug: normalizeSlug(region),
     destinationName: region,
@@ -125,5 +145,63 @@ export async function getPublishedTemplateListings(
     return records;
   } catch {
     return [];
+  }
+}
+
+/**
+ * Public detail data for one ready excursion. The template and its guide both
+ * pass the same visibility gates as the catalog cards, so a copied URL cannot
+ * reveal drafts, unapproved guides, or QA fixtures.
+ */
+export async function getPublishedTemplateDetail(
+  client: SupabaseClient,
+  templateId: string,
+): Promise<PublicGuideTemplateDetail | null> {
+  try {
+    const { data: templateRaw, error: templateError } = await client
+      .from("guide_templates")
+      .select("*")
+      .eq("id", templateId)
+      .eq("status", "published")
+      .maybeSingle();
+    if (templateError) throw templateError;
+    if (!templateRaw) return null;
+
+    const template = templateRaw as GuideTemplateRow;
+    // Keep the application boundary safe even if a mocked/stale client ignores
+    // the PostgREST status predicate.
+    if (template.status !== "published") return null;
+
+    const { data: guideRaw, error: guideError } = await client
+      .from("guide_profiles")
+      .select("user_id, slug, display_name, verification_status")
+      .eq("user_id", template.guide_id)
+      .maybeSingle();
+    if (guideError) throw guideError;
+
+    const slug = guideRaw?.slug as string | null | undefined;
+    if (guideRaw?.verification_status !== "approved" || !slug || isQaGuideSlug(slug)) {
+      return null;
+    }
+
+    return {
+      id: template.id,
+      title: template.title,
+      description: template.description,
+      photoUrl: template.photo_urls?.[0] ?? fallbackHeroImage,
+      priceFromKopecks: template.price_from_kopecks,
+      priceScope: template.price_scope === "per_group" ? "per_group" : "per_person",
+      durationText: template.duration_text,
+      meetingPoint: template.meeting_point,
+      maxParticipants: template.max_participants,
+      region: template.region,
+      category: template.category,
+      guide: {
+        slug,
+        displayName: (guideRaw?.display_name as string | null) ?? "Локальный гид",
+      },
+    };
+  } catch {
+    return null;
   }
 }

--- a/src/lib/supabase/queries-core.ts
+++ b/src/lib/supabase/queries-core.ts
@@ -55,9 +55,8 @@ export type ListingRecord = {
   status: "active" | "draft";
   /**
    * Where the card links. Defaults to `/listings/{slug}` — the `listings` detail
-   * route. Records adapted from `guide_templates` have no row in `listings` and
-   * therefore no detail route, so they point at their guide's public profile
-   * instead of a URL that would 404. See guide-template-listings.ts.
+   * route. Records adapted from `guide_templates` have no row in `listings`, so
+   * they use the ready-excursion public route. See guide-template-listings.ts.
    */
   detailHref?: string;
 };


### PR DESCRIPTION
## Summary
- route published ready-excursion cards to unique excursion detail pages
- show template-backed public detail data and guide-preselected request CTA
- preserve public visibility gates for published, approved non-QA templates

## Verification
- bun run test:run (252 files, 1494 tests)
- bun run typecheck
- bun run lint
- git diff --check