### PR TITLE
perf(guides): overlap auth with catalog load

### DIFF
--- a/src/app/(site)/guides/page.test.tsx
+++ b/src/app/(site)/guides/page.test.tsx
@@ -64,6 +64,50 @@ describe("GuidesPage", () => {
     );
   });
 
+  it("starts catalogue loading before auth context resolves", async () => {
+    let resolveAuth!: (value: { role: string }) => void;
+    const authDeferred = new Promise<{ role: string }>((resolve) => {
+      resolveAuth = resolve;
+    });
+    readAuthContextMock.mockReturnValue(authDeferred);
+
+    let resolveCatalogue!: (value: {
+      data: { id: string }[];
+      error: null;
+      hasMore: boolean;
+    }) => void;
+    const catalogueDeferred = new Promise<{
+      data: { id: string }[];
+      error: null;
+      hasMore: boolean;
+    }>((resolve) => {
+      resolveCatalogue = resolve;
+    });
+    getGuidesPagedMock.mockReturnValue(catalogueDeferred);
+
+    const contentPromise = GuidesContent({ searchParams: Promise.resolve({}) });
+
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(readAuthContextMock).toHaveBeenCalled();
+    expect(getGuidesPagedMock).toHaveBeenCalled();
+
+    resolveCatalogue({ data: [{ id: "g1" }], error: null, hasMore: false });
+    await Promise.resolve();
+
+    resolveAuth({ role: "traveler" });
+
+    render(await contentPromise);
+
+    expect(gridPropsSpy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        guides: [{ id: "g1" }],
+        showGuideCta: true,
+      }),
+    );
+  });
+
   it("hides the guide CTA for guides and shows it for everyone else", async () => {
     getGuidesPagedMock.mockResolvedValue({ data: [], error: null, hasMore: false });
 

--- a/src/app/(site)/guides/page.tsx
+++ b/src/app/(site)/guides/page.tsx
@@ -65,7 +65,7 @@ export async function GuidesContent({
   let hasMore = false;
   let loadError = false;
 
-  const auth = await readAuthContextFromServer();
+  const authPromise = readAuthContextFromServer();
   try {
     const supabase = await createSupabaseServerClient();
     const result = await getGuidesPaged(supabase, {
@@ -82,6 +82,7 @@ export async function GuidesContent({
   } catch {
     loadError = true;
   }
+  const auth = await authPromise;
 
   return (
     <PublicGuidesGrid


### PR DESCRIPTION
## Что меняется

Контекст авторизации и загрузка каталога гидов стартуют одновременно; контекст по-прежнему применяется только к CTA.

## Проверка

- `bun run check`
- `bun run test:run` — 277 файлов, 1678 тестов
- `bun run build`
- Добавлена проверка параллельного старта.