### PR TITLE
test(db): align public catalog fixtures

### DIFF
--- a/supabase/tests/directed_request_write_authority_test.sql
+++ b/supabase/tests/directed_request_write_authority_test.sql
@@ -139,10 +139,12 @@ select throws_ok(
 -- 2. Ordinary open requests are untouched.
 select lives_ok(
   $$insert into public.traveler_requests
-      (id, traveler_id, destination, starts_on, ends_on, participants_count)
+      (id, traveler_id, destination, starts_on, ends_on, participants_count,
+       format_preference, open_to_join)
     values ('6f000000-0000-4000-8000-000000000001',
             '6d000000-0000-4000-8000-000000000001',
-            'Ordinary Open Request', date '2026-09-01', date '2026-09-02', 2)$$,
+            'Ordinary Open Request', date '2026-09-01', date '2026-09-02', 2,
+            'group', true)$$,
   'traveler can still directly insert an undirected open request'
 );
 

--- a/supabase/tests/guide_template_moderation_test.sql
+++ b/supabase/tests/guide_template_moderation_test.sql
@@ -109,10 +109,10 @@ select set_config('request.jwt.claim.role','anon', true);
 select set_config('request.jwt.claim.sub','', true);
 
 select is(
-  (select count(*)::int from public.guide_templates
-      where id='72000000-0000-4000-8000-0000000000aa' and status='published'),
+  (select count(*)::int from public.v_public_published_guide_templates
+      where id='72000000-0000-4000-8000-0000000000aa'),
   1,
-  'anon can see published templates');
+  'anon can see published templates through the public projection');
 
 -- 8. Guide cannot persist a new tour as draft even with an explicit draft status.
 set local role authenticated;

--- a/supabase/tests/preferred_guide_slug_discovery_guard_test.sql
+++ b/supabase/tests/preferred_guide_slug_discovery_guard_test.sql
@@ -114,10 +114,12 @@ select set_config('request.jwt.claim.sub', '6d200000-0000-4000-8000-000000000001
 
 select lives_ok(
   $$insert into public.traveler_requests
-      (id, traveler_id, destination, starts_on, ends_on, participants_count)
+      (id, traveler_id, destination, starts_on, ends_on, participants_count,
+       format_preference, open_to_join)
     values ('6f200000-0000-4000-8000-000000000001',
             '6d200000-0000-4000-8000-000000000001',
-            'Discovery Ordinary Open Request', date '2026-09-01', date '2026-09-02', 2)$$,
+            'Discovery Ordinary Open Request', date '2026-09-01', date '2026-09-02', 2,
+            'group', true)$$,
   'traveler can still directly insert an undirected open request'
 );
 


### PR DESCRIPTION
## Summary
- align public-request fixtures with the joinable group catalog
- verify published templates through the public projection

## Verification
- bun run test:db
- bun run test:run
- bun run typecheck
- bun run lint
- bun run build