### PR TITLE
fix(guide): keep matching requests visible

### DIFF
--- a/src/features/guide/components/requests/guide-requests-inbox-filter.test.ts
+++ b/src/features/guide/components/requests/guide-requests-inbox-filter.test.ts
@@ -60,7 +60,7 @@ describe("filterInbox — direct requests (item 9)", () => {
 
   it("still excludes a general request that fails the city filter", () => {
     const items = [rec({ id: "away", destination: "Сочи", interests: ["nature"] })];
-    expect(filterInbox(items, base)).toHaveLength(0);
+    expect(filterInbox(items, { ...base, cityFilter: "Москва" })).toHaveLength(0);
   });
 });
 

--- a/src/features/guide/components/requests/guide-requests-inbox-filter.ts
+++ b/src/features/guide/components/requests/guide-requests-inbox-filter.ts
@@ -23,7 +23,6 @@ export function isMatchedRequest(req: { interests: string[] }, specs: string[]):
 export function filterInbox(
   items: RequestRecord[],
   {
-    baseCity,
     cityFilter,
     filter,
     offeredIds,
@@ -47,22 +46,10 @@ export function filterInbox(
     return [];
   }
 
-  // form-epic #8: baseCity filter (Phase A). If guide's base_city is set,
-  // restrict inbox to requests whose first destination segment matches
-  // (case-insensitive). If base_city is null, leave items untouched —
-  // empty-state with profile-fill hint is rendered downstream.
-  // A request addressed directly to this guide (item 9) always belongs in their inbox,
-  // regardless of city or specialization scoping below.
-  if (baseCity) {
-    const norm = baseCity.trim().toLowerCase();
-    filtered = filtered.filter(
-      (item) =>
-        item.isDirectToViewer ||
-        item.destination.split(",")[0].trim().toLowerCase() === norm,
-    );
-  }
+  // Guide base_city is not an inbox gate (RLS and specialization handle eligibility).
+  // User-driven city filter below.
 
-  // City filter (user-driven dropdown, separate from baseCity Phase A scope)
+  // City filter (user-driven dropdown)
   if (cityFilter !== "all") {
     filtered = filtered.filter(
       (item) =>

--- a/src/features/guide/components/requests/guide-requests-inbox-screen.test.tsx
+++ b/src/features/guide/components/requests/guide-requests-inbox-screen.test.tsx
@@ -57,10 +57,10 @@ function request(overrides: Partial<RequestRecord>): RequestRecord {
 }
 
 describe("filterInbox", () => {
-  it("restricts visible requests to the guide base city", () => {
+  it("keeps specialization-matching requests visible outside the guide base city", () => {
     const items = [
-      request({ id: "elista", destination: "Элиста, центр" }),
-      request({ id: "karelia", destination: "Карелия, Рускеала" }),
+      request({ id: "elista", destination: "Элиста, центр", interests: ["nature"] }),
+      request({ id: "karelia", destination: "Карелия, Рускеала", interests: ["nature"] }),
     ];
 
     const filtered = filterInbox(items, {
@@ -70,13 +70,13 @@ describe("filterInbox", () => {
       offeredIds: new Set(),
       requestTypeFilter: "all",
       sortKey: "newest",
-      specializations: [],
+      specializations: ["nature"],
     });
 
-    expect(filtered.map((item) => item.id)).toEqual(["elista"]);
+    expect(filtered.map((item) => item.id).sort()).toEqual(["elista", "karelia"]);
   });
 
-  it("renders no requests when none match the guide base city", () => {
+  it("does not exclude requests solely because they are outside base city when specializations are unset", () => {
     const items = [
       request({ id: "elista", destination: "Элиста, центр" }),
       request({ id: "karelia", destination: "Карелия, Рускеала" }),
@@ -92,7 +92,7 @@ describe("filterInbox", () => {
       specializations: [],
     });
 
-    expect(filtered).toEqual([]);
+    expect(filtered.map((item) => item.id).sort()).toEqual(["elista", "karelia"]);
   });
 });
 
@@ -106,7 +106,7 @@ describe("getInboxTabCounts", () => {
     specializations: [] as string[],
   };
 
-  it("counts «Новые» only for unanswered requests in the guide base city", () => {
+  it("counts «Новые» for unanswered requests outside base city when they remain in inbox scope", () => {
     const items = [
       request({ id: "elista-a", destination: "Элиста, центр" }),
       request({ id: "elista-b", destination: "Элиста, музеи" }),
@@ -121,7 +121,7 @@ describe("getInboxTabCounts", () => {
     ).toBe(newCount);
   });
 
-  it("counts «Мои предложения» only for offers in the guide base city", () => {
+  it("counts «Мои предложения» for offers outside the guide base city", () => {
     const items = [
       request({ id: "elista-a", destination: "Элиста, центр" }),
       request({ id: "elista-b", destination: "Элиста, музеи" }),
@@ -130,10 +130,32 @@ describe("getInboxTabCounts", () => {
 
     const { myOffersCount } = getInboxTabCounts(items, scopeOptions);
 
-    expect(myOffersCount).toBe(1);
+    expect(myOffersCount).toBe(2);
     expect(
       filterInbox(items, { ...scopeOptions, filter: "my-offers" }).length,
     ).toBe(myOffersCount);
+  });
+
+  it("aligns «Новые» count with visible specialization-matching items outside base city", () => {
+    const items = [
+      request({ id: "elista-a", destination: "Элиста, центр", interests: ["nature"] }),
+      request({ id: "karelia-new", destination: "Карелия, Рускеала", interests: ["nature"] }),
+      request({ id: "elista-b", destination: "Элиста, музеи", interests: ["nature"] }),
+    ];
+    const options = {
+      ...scopeOptions,
+      offeredIds: new Set(["elista-b"]),
+      specializations: ["nature"],
+    };
+
+    const { newCount } = getInboxTabCounts(items, options);
+
+    expect(newCount).toBe(2);
+    expect(filterInbox(items, { ...options, filter: "new" }).map((item) => item.id).sort()).toEqual([
+      "elista-a",
+      "karelia-new",
+    ]);
+    expect(filterInbox(items, { ...options, filter: "new" }).length).toBe(newCount);
   });
 });
 


### PR DESCRIPTION
Fixes guide inbox visibility for open requests that match a guide specialization but have a different destination city.

Validation: bun run check; full test suite (288 files, 1,754 tests).

Task: s6s8/provodnik.app-Tasks#43