### PR TITLE
fix(guide): correct booking totals and traveler alerts

### DIFF
--- a/src/components/shared/site-header.test.tsx
+++ b/src/components/shared/site-header.test.tsx
@@ -3,12 +3,17 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 
 let mockPathname = "/trips";
 let mockUnreadCount = 0;
-const { useUnreadCountMock, linkPrefetchByHref } = vi.hoisted(() => ({
+const { useUnreadCountMock, linkPrefetchByHref, notificationBellMock } = vi.hoisted(() => ({
   useUnreadCountMock: vi.fn(() => ({
     unreadCount: 0,
     refetch: vi.fn(),
   })),
   linkPrefetchByHref: [] as Array<{ href: string; prefetch?: boolean | null }>,
+  notificationBellMock: vi.fn(({ userId }: { userId: string }) => (
+    <button type="button" aria-label="Уведомления" data-user-id={userId}>
+      Bell
+    </button>
+  )),
 }));
 
 vi.mock("next/link", () => ({
@@ -38,6 +43,10 @@ vi.mock("next/navigation", () => ({
 
 vi.mock("@/features/messaging/hooks/use-unread-count", () => ({
   useUnreadCount: useUnreadCountMock,
+}));
+
+vi.mock("@/features/notifications/components/NotificationBell", () => ({
+  NotificationBell: notificationBellMock,
 }));
 
 import { SiteHeader } from "./site-header";
@@ -346,5 +355,56 @@ describe("SiteHeader mobile menu", () => {
     expect(
       screen.getByText("Навигация по разделам Проводника."),
     ).toBeInTheDocument();
+  });
+});
+
+describe("SiteHeader traveler notification bell", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    notificationBellMock.mockClear();
+    mockPathname = "/trips";
+    useUnreadCountMock.mockImplementation(() => ({
+      unreadCount: 0,
+      refetch: vi.fn(),
+    }));
+  });
+
+  it("renders NotificationBell for authenticated travelers when notifications are enabled", () => {
+    render(
+      <SiteHeader
+        isAuthenticated
+        role="traveler"
+        email="traveler@example.com"
+        userId="traveler-user-1"
+        notificationsEnabled
+      />,
+    );
+
+    expect(screen.getByRole("button", { name: "Уведомления" })).toBeInTheDocument();
+    expect(notificationBellMock.mock.calls[0]?.[0]).toMatchObject({
+      userId: "traveler-user-1",
+    });
+  });
+
+  it("does not render NotificationBell when notifications are disabled", () => {
+    render(
+      <SiteHeader
+        isAuthenticated
+        role="traveler"
+        email="traveler@example.com"
+        userId="traveler-user-1"
+        notificationsEnabled={false}
+      />,
+    );
+
+    expect(screen.queryByRole("button", { name: "Уведомления" })).toBeNull();
+    expect(notificationBellMock).not.toHaveBeenCalled();
+  });
+
+  it("does not render NotificationBell for guests even when notifications are enabled", () => {
+    render(<SiteHeader isAuthenticated={false} notificationsEnabled />);
+
+    expect(screen.queryByRole("button", { name: "Уведомления" })).toBeNull();
+    expect(notificationBellMock).not.toHaveBeenCalled();
   });
 });

--- a/src/features/guide/components/bookings/guide-bookings-screen.test.tsx
+++ b/src/features/guide/components/bookings/guide-bookings-screen.test.tsx
@@ -46,4 +46,58 @@ describe("GuideBookingsScreen", () => {
     expect(screen.getByRole("button", { name: "Повторить загрузку" })).toBeInTheDocument();
     expect(screen.queryByText("Пока нет бронирований")).toBeNull();
   });
+
+  it("sums only active and completed bookings in excursion total", async () => {
+    getGuideBookingsMock.mockResolvedValue({
+      data: [
+        {
+          id: "b-completed",
+          title: "Экскурсия 1",
+          destination: "Казань",
+          dateLabel: "1 янв",
+          priceRub: 10_000,
+          status: "completed",
+        },
+        {
+          id: "b-active",
+          title: "Экскурсия 2",
+          destination: "Самара",
+          dateLabel: "2 янв",
+          priceRub: 5_000,
+          status: "confirmed",
+        },
+        {
+          id: "b-cancelled",
+          title: "Экскурсия 3",
+          destination: "Уфа",
+          dateLabel: "3 янв",
+          priceRub: 20_000,
+          status: "cancelled",
+        },
+        {
+          id: "b-no-show",
+          title: "Экскурсия 4",
+          destination: "Пермь",
+          dateLabel: "4 янв",
+          priceRub: 30_000,
+          status: "no_show",
+        },
+      ],
+      error: null,
+    });
+
+    render(<GuideBookingsScreen />);
+
+    await waitFor(() => {
+      expect(screen.getByText("Итоги по бронированиям")).toBeInTheDocument();
+    });
+
+    expect(screen.getByText(/15\s000\s*₽/)).toBeInTheDocument();
+    expect(screen.getByText("Уфа")).toBeInTheDocument();
+    expect(screen.getByText("Пермь")).toBeInTheDocument();
+
+    const cancelledLabel = screen.getByText("Отменено");
+    const cancelledValue = cancelledLabel.parentElement?.querySelectorAll("p")[1];
+    expect(cancelledValue).toHaveTextContent("2");
+  });
 });

--- a/src/features/guide/components/bookings/guide-bookings-screen.tsx
+++ b/src/features/guide/components/bookings/guide-bookings-screen.tsx
@@ -76,16 +76,16 @@ export function GuideBookingsScreen() {
     let totalEarningsRub = 0;
 
     for (const booking of bookings) {
-      totalEarningsRub += booking.priceRub;
-
       if (
         booking.status === "awaiting_confirmation" ||
         booking.status === "confirmed" ||
         booking.status === "in_progress"
       ) {
         activeCount += 1;
+        totalEarningsRub += booking.priceRub;
       } else if (booking.status === "completed") {
         completedCount += 1;
+        totalEarningsRub += booking.priceRub;
       } else if (booking.status === "cancelled" || booking.status === "no_show") {
         cancelledCount += 1;
       }

--- a/src/features/notifications/components/NotificationBell.test.tsx
+++ b/src/features/notifications/components/NotificationBell.test.tsx
@@ -43,18 +43,27 @@ vi.mock("@/lib/env", () => ({
   hasSupabaseEnv: () => true,
 }));
 
-import { NotificationBell } from "./NotificationBell";
+import { NotificationBell, isUnreadNotification } from "./NotificationBell";
 
 const unreadNotification = {
   id: "notification-1",
   user_id: "user-123",
   event_type: "new_offer",
+  kind: "new_offer",
   payload: null,
   channel: "inbox",
   status: "sent",
   created_at: "2026-05-31T06:00:00.000Z",
   read_at: null,
 };
+
+function makeUnreadOfferNotification(id: string) {
+  return {
+    ...unreadNotification,
+    id,
+    title: `Новое предложение от гида ${id}`,
+  };
+}
 
 async function renderNotificationBell(userId = "user-123") {
   const view = render(<NotificationBell userId={userId} />);
@@ -221,5 +230,54 @@ describe("NotificationBell", () => {
       expect(screen.queryByText("Новое предложение от гида")).not.toBeInTheDocument();
     });
     expect(screen.getByText("Нет новых уведомлений")).toBeInTheDocument();
+  });
+
+  it.each([
+    { ids: ["notification-1"], expected: "1" },
+    { ids: ["notification-1", "notification-2"], expected: "2" },
+    {
+      ids: ["notification-1", "notification-2", "notification-3"],
+      expected: "3",
+    },
+  ])(
+    "shows a destructive badge count of $expected for distinct unread new_offer rows",
+    async ({ ids, expected }) => {
+      mockLimit.mockResolvedValueOnce({
+        data: ids.map((id) => makeUnreadOfferNotification(id)),
+        error: null,
+      });
+
+      await renderNotificationBell();
+
+      const badge = document.querySelector(".bg-destructive");
+      expect(badge).not.toBeNull();
+      expect(badge).toHaveTextContent(expected);
+    },
+  );
+
+  it("does not increase the badge when the same notification id is inserted twice over realtime", async () => {
+    await renderNotificationBell();
+    const changeHandler = (mockOn as Mock).mock.calls[0][2] as (payload: {
+      new: typeof unreadNotification & { title: string };
+    }) => void;
+
+    const row = {
+      ...makeUnreadOfferNotification("notification-dup"),
+      title: "Новое предложение от гида",
+    };
+
+    await act(async () => {
+      changeHandler({ new: row });
+      changeHandler({ new: row });
+    });
+
+    const badge = document.querySelector(".bg-destructive");
+    expect(badge).toHaveTextContent("1");
+  });
+});
+
+describe("isUnreadNotification", () => {
+  it("treats sent inbox rows with null read_at as unread", () => {
+    expect(isUnreadNotification({ status: "sent", read_at: null })).toBe(true);
   });
 });

--- a/src/features/notifications/components/NotificationBell.tsx
+++ b/src/features/notifications/components/NotificationBell.tsx
@@ -17,13 +17,6 @@ import { NotificationItem } from "./NotificationItem";
 
 /** In-app delivery channel in DB (`notifications.channel` CHECK). */
 const IN_APP_NOTIFICATION_CHANNEL = "inbox" as const;
-const ACTION_KINDS = new Set([
-  "new_offer",
-  "offer_expiring",
-  "booking_created",
-  "review_requested",
-  "dispute_opened",
-]);
 
 export function isUnreadNotification(notification: { status: string | null; read_at: string | null }) {
   return notification.status !== "read" || notification.read_at === null;
@@ -120,17 +113,7 @@ export function NotificationBell({ userId }: NotificationBellProps) {
   }, [userId]);
 
   const count = notifications.length;
-  const actionCount = notifications.filter((n) =>
-    ACTION_KINDS.has(n.kind ?? n.event_type ?? ""),
-  ).length;
-  const badgeLabel =
-    actionCount > 9
-      ? "9+"
-      : actionCount > 0
-        ? String(actionCount)
-        : count > 9
-          ? "9+"
-          : String(count);
+  const badgeLabel = count > 9 ? "9+" : String(count);
 
   return (
     <Popover open={open} onOpenChange={setOpen}>

--- a/src/lib/flags.test.ts
+++ b/src/lib/flags.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect } from "vitest";
 import { flags, isEnabled, type FlagName } from "./flags";
 
 describe("flags registry", () => {
-  it("exposes every registered sub-flag disabled by default", () => {
+  it("exposes every registered sub-flag with the intended default contract", () => {
     const subs: FlagName[] = [
       "FEATURE_TR_TOURS",
       "FEATURE_TR_NOTIFICATIONS",
@@ -13,10 +13,14 @@ describe("flags registry", () => {
       "FEATURE_TR_DISPUTES",
       "FEATURE_PUBLIC_CATALOG",
     ];
+    const defaultOn: FlagName[] = [
+      "FEATURE_TR_NOTIFICATIONS",
+      "FEATURE_PUBLIC_CATALOG",
+    ];
     expect(subs).toEqual(Object.keys(flags));
     for (const k of subs) {
       expect(k in flags).toBe(true);
-      if (k === "FEATURE_PUBLIC_CATALOG") {
+      if (defaultOn.includes(k)) {
         expect(isEnabled(k)).toBe(true);
       } else {
         expect(isEnabled(k)).toBe(false);

--- a/src/lib/flags.ts
+++ b/src/lib/flags.ts
@@ -4,7 +4,9 @@ const envFlag = z.enum(["0", "1"]).catch("0");
 
 const flagsSchema = z.object({
   FEATURE_TR_TOURS: envFlag,
-  FEATURE_TR_NOTIFICATIONS: envFlag,
+  // Traveler notification center (bell + /account/notifications). Default on in production;
+  // set FEATURE_TR_NOTIFICATIONS=0 only when the surface must stay hidden.
+  FEATURE_TR_NOTIFICATIONS: z.enum(["0", "1"]).catch("1"),
   FEATURE_TR_PAYMENT: envFlag,
   FEATURE_TR_FAVORITES: envFlag,
   FEATURE_TR_PARTNER: envFlag,


### PR DESCRIPTION
## Summary
- exclude cancelled and no-show bookings from guide earnings totals
- show unread traveler alerts in the header by default

## Verification
- bun run test:run src/features/guide/components/bookings/guide-bookings-screen.test.tsx src/features/notifications/components/NotificationBell.test.tsx src/components/shared/site-header.test.tsx
- bun run check